### PR TITLE
[MM-20825] Move UserStatus out of user package

### DIFF
--- a/example/loadtest.go
+++ b/example/loadtest.go
@@ -30,7 +30,7 @@ func (lt *SampleLoadTester) initControllers(numUsers int) {
 	}
 }
 
-func (lt *SampleLoadTester) runControllers(status chan<- user.UserStatus) {
+func (lt *SampleLoadTester) runControllers(status chan<- control.UserStatus) {
 	lt.wg.Add(len(lt.controllers))
 	for i := 0; i < len(lt.controllers); i++ {
 		go func(controller control.UserController) {
@@ -46,15 +46,15 @@ func (lt *SampleLoadTester) stopControllers() {
 	lt.wg.Wait()
 }
 
-func (lt *SampleLoadTester) handleStatus(status <-chan user.UserStatus) {
+func (lt *SampleLoadTester) handleStatus(status <-chan control.UserStatus) {
 	for us := range status {
-		if us.Code == user.STATUS_STOPPED || us.Code == user.STATUS_FAILED {
+		if us.Code == control.USER_STATUS_STOPPED || us.Code == control.USER_STATUS_FAILED {
 			lt.wg.Done()
 		}
-		if us.Code == user.STATUS_ERROR {
+		if us.Code == control.USER_STATUS_ERROR {
 			mlog.Info(us.Err.Error(), mlog.Int("user_id", us.User.Id()))
 			continue
-		} else if us.Code == user.STATUS_FAILED {
+		} else if us.Code == control.USER_STATUS_FAILED {
 			mlog.Error(us.Err.Error())
 			continue
 		}
@@ -71,7 +71,7 @@ func Run() error {
 		serverURL:   "http://localhost:8065",
 	}
 
-	status := make(chan user.UserStatus, numUsers)
+	status := make(chan control.UserStatus, numUsers)
 
 	lt.initControllers(numUsers)
 

--- a/loadtest/control/controller.go
+++ b/loadtest/control/controller.go
@@ -9,7 +9,7 @@ import (
 
 type UserController interface {
 	Init(user user.User)
-	Run(status chan<- user.UserStatus)
+	Run(status chan<- UserStatus)
 	SetRate(rate float64) error
 	Stop()
 }

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -8,18 +8,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-server/model"
 )
 
 type UserAction struct {
-	run       func() user.UserStatus
+	run       func() control.UserStatus
 	waitAfter time.Duration
 }
 
-func (c *SimpleController) signUp() user.UserStatus {
+func (c *SimpleController) signUp() control.UserStatus {
 	if c.user.Store().Id() != "" {
-		return user.UserStatus{User: c.user, Info: "user already signed up"}
+		return c.newInfoStatus("user already signed up")
 	}
 
 	email := fmt.Sprintf("testuser%d@example.com", c.user.Id())
@@ -28,73 +28,73 @@ func (c *SimpleController) signUp() user.UserStatus {
 
 	err := c.user.SignUp(email, username, password)
 	if err != nil {
-		return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+		return c.newErrorStatus(err)
 	}
 
-	return user.UserStatus{User: c.user, Info: "signed up"}
+	return c.newInfoStatus("signed up")
 }
 
-func (c *SimpleController) login() user.UserStatus {
+func (c *SimpleController) login() control.UserStatus {
 	// return here if already logged in
 	err := c.user.Login()
 	if err != nil {
-		return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+		return c.newErrorStatus(err)
 	}
 
 	err = c.user.Connect()
 	if err != nil {
-		return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+		return c.newErrorStatus(err)
 	}
 
-	return user.UserStatus{User: c.user, Info: "logged in"}
+	return c.newInfoStatus("logged in")
 }
 
-func (c *SimpleController) logout() user.UserStatus {
+func (c *SimpleController) logout() control.UserStatus {
 	// return here if already logged out
 
 	err := c.user.Disconnect()
 	if err != nil {
-		return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+		return c.newErrorStatus(err)
 	}
 
 	ok, err := c.user.Logout()
 	if err != nil {
-		return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+		return c.newErrorStatus(err)
 	}
 
 	if !ok {
-		return user.UserStatus{User: c.user, Err: errors.New("User did not logout"), Code: user.STATUS_ERROR}
+		return c.newErrorStatus(errors.New("user did not logout"))
 	}
 
-	return user.UserStatus{User: c.user, Info: "logged out"}
+	return c.newInfoStatus("logged out")
 }
 
-func (c *SimpleController) createPost() user.UserStatus {
+func (c *SimpleController) createPost() control.UserStatus {
 	postId, err := c.user.CreatePost(&model.Post{
 		Message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 	})
 	if err != nil {
-		return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+		return c.newErrorStatus(err)
 	}
 
-	return user.UserStatus{User: c.user, Info: fmt.Sprintf("post created, id %v", postId)}
+	return c.newInfoStatus(fmt.Sprintf("post created, id %v", postId))
 }
 
-func (c *SimpleController) createGroupChannel() user.UserStatus {
+func (c *SimpleController) createGroupChannel() control.UserStatus {
 	channelId, err := c.user.CreateGroupChannel([]string{}) // TODO: populate memberIds parameter with other users
 	if err != nil {
-		return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+		return c.newErrorStatus(err)
 	}
 
-	return user.UserStatus{User: c.user, Info: fmt.Sprintf("group channel created, id %v", channelId)}
+	return c.newInfoStatus(fmt.Sprintf("group channel created, id %v", channelId))
 }
 
-func (c *SimpleController) viewChannel() user.UserStatus {
-	return user.UserStatus{User: c.user, Err: errors.New("not implemented"), Code: user.STATUS_ERROR}
+func (c *SimpleController) viewChannel() control.UserStatus {
+	return c.newErrorStatus(errors.New("not implemented"))
 	/*
 		channel, err := c.user.Store().Channel("") // TODO: fetch channel randomly?
 		if err != nil {
-			return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+			return control.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
 		}
 
 		channelViewResponse, err := c.user.ViewChannel(&model.ChannelView{
@@ -102,9 +102,9 @@ func (c *SimpleController) viewChannel() user.UserStatus {
 			PrevChannelId: "",
 		})
 		if err != nil {
-			return user.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
+			return control.UserStatus{User: c.user, Err: err, Code: user.STATUS_ERROR}
 		}
 
-		return user.UserStatus{User: c.user, Info: fmt.Sprintf("channel viewed. result: %v", channelViewResponse.ToJson())}
+		return control.UserStatus{User: c.user, Info: fmt.Sprintf("channel viewed. result: %v", channelViewResponse.ToJson())}
 	*/
 }

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 )
 
@@ -23,7 +24,7 @@ func (c *SimpleController) Init(user user.User) {
 	c.rate = 1.0
 }
 
-func (c *SimpleController) Run(status chan<- user.UserStatus) {
+func (c *SimpleController) Run(status chan<- control.UserStatus) {
 	if c.user == nil {
 		c.sendFailStatus(status, "controller was not initialized")
 		return
@@ -56,7 +57,7 @@ func (c *SimpleController) Run(status chan<- user.UserStatus) {
 		},
 	}
 
-	status <- user.UserStatus{User: c.user, Info: "user started", Code: user.STATUS_STARTED}
+	status <- control.UserStatus{User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
 
 	defer c.sendStopStatus(status)
 
@@ -72,8 +73,6 @@ func (c *SimpleController) Run(status chan<- user.UserStatus) {
 			case <-time.After(time.Millisecond * idleTime):
 			}
 		}
-
-		// status <- user.UserStatus{User: c.user, Info: "user loop done", Code: user.STATUS_DONE}
 	}
 }
 
@@ -89,10 +88,10 @@ func (c *SimpleController) Stop() {
 	close(c.stop)
 }
 
-func (c *SimpleController) sendFailStatus(status chan<- user.UserStatus, reason string) {
-	status <- user.UserStatus{User: c.user, Code: user.STATUS_FAILED, Err: errors.New(reason)}
+func (c *SimpleController) sendFailStatus(status chan<- control.UserStatus, reason string) {
+	status <- control.UserStatus{User: c.user, Code: control.USER_STATUS_FAILED, Err: errors.New(reason)}
 }
 
-func (c *SimpleController) sendStopStatus(status chan<- user.UserStatus) {
-	status <- user.UserStatus{User: c.user, Info: "user stopped", Code: user.STATUS_STOPPED}
+func (c *SimpleController) sendStopStatus(status chan<- control.UserStatus) {
+	status <- control.UserStatus{User: c.user, Info: "user stopped", Code: control.USER_STATUS_STOPPED}
 }

--- a/loadtest/control/simplecontroller/status.go
+++ b/loadtest/control/simplecontroller/status.go
@@ -1,0 +1,23 @@
+package simplecontroller
+
+import (
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
+)
+
+func (c *SimpleController) newInfoStatus(info string) control.UserStatus {
+	return control.UserStatus{
+		c.user,
+		control.USER_STATUS_INFO,
+		info,
+		nil,
+	}
+}
+
+func (c *SimpleController) newErrorStatus(err error) control.UserStatus {
+	return control.UserStatus{
+		c.user,
+		control.USER_STATUS_ERROR,
+		"",
+		err,
+	}
+}

--- a/loadtest/control/status.go
+++ b/loadtest/control/status.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package control
+
+import (
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
+)
+
+const (
+	USER_STATUS_UNKNOWN int = iota
+	USER_STATUS_STARTED
+	USER_STATUS_STOPPED
+	USER_STATUS_DONE
+	USER_STATUS_ERROR
+	USER_STATUS_FAILED
+	USER_STATUS_INFO
+)
+
+type UserStatus struct {
+	User user.User
+	Code int
+	Info string
+	Err  error
+}

--- a/loadtest/run.go
+++ b/loadtest/run.go
@@ -35,7 +35,7 @@ func (lt *LoadTester) initControllers(numUsers int) {
 	}
 }
 
-func (lt *LoadTester) runControllers(status chan<- user.UserStatus) {
+func (lt *LoadTester) runControllers(status chan<- control.UserStatus) {
 	lt.wg.Add(len(lt.controllers))
 	for i := 0; i < len(lt.controllers); i++ {
 		go func(controller control.UserController) {
@@ -51,15 +51,15 @@ func (lt *LoadTester) stopControllers() {
 	lt.wg.Wait()
 }
 
-func (lt *LoadTester) handleStatus(status <-chan user.UserStatus) {
+func (lt *LoadTester) handleStatus(status <-chan control.UserStatus) {
 	for us := range status {
-		if us.Code == user.STATUS_STOPPED || us.Code == user.STATUS_FAILED {
+		if us.Code == control.USER_STATUS_STOPPED || us.Code == control.USER_STATUS_FAILED {
 			lt.wg.Done()
 		}
-		if us.Code == user.STATUS_ERROR {
+		if us.Code == control.USER_STATUS_ERROR {
 			mlog.Info(us.Err.Error(), mlog.Int("user_id", us.User.Id()))
 			continue
-		} else if us.Code == user.STATUS_FAILED {
+		} else if us.Code == control.USER_STATUS_FAILED {
 			mlog.Error(us.Err.Error())
 			continue
 		}
@@ -84,7 +84,7 @@ func Run() error {
 
 	lt.initControllers(numUsers)
 
-	status := make(chan user.UserStatus, numUsers)
+	status := make(chan control.UserStatus, numUsers)
 
 	go lt.handleStatus(status)
 

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -8,15 +8,6 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-const (
-	STATUS_UNKNOWN int = iota
-	STATUS_STARTED
-	STATUS_STOPPED
-	STATUS_DONE
-	STATUS_ERROR
-	STATUS_FAILED
-)
-
 type User interface {
 	Id() int
 	Store() store.UserStore
@@ -38,11 +29,4 @@ type User interface {
 	GetChannelUnread(channelId string) (*model.ChannelUnread, error)
 
 	// teams
-}
-
-type UserStatus struct {
-	User User
-	Code int
-	Info string
-	Err  error
 }


### PR DESCRIPTION
#### Summary

PR moves `UserStatus` out of `user` package. Not sure why I added it there (maybe cause of the name) but it clearly belongs to the higher level of abstraction.  

Other changes included:

- Implemented some utilities methods for the `SimpleController` to create common statuses with ease (less typing :tada: ).
- Added missing `USER_STATUS_INFO` code.

#### Ticket

https://mattermost.atlassian.net/browse/MM-20825