### PR TITLE
[MM-20298] Add --config|-c flag to read the config from a file

### DIFF
--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -14,33 +14,36 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func RunLoadTest(cmd *cobra.Command, args []string) error {
+func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	return loadtest.Run()
 }
 
-func RunExample(cmd *cobra.Command, args []string) error {
+func RunExampleCmdF(cmd *cobra.Command, args []string) error {
 	return example.Run()
 }
 
 func main() {
-	cobra.OnInitialize(initConfig)
-
-	var rootCmd = &cobra.Command{Use: "loadtest", RunE: RunLoadTest}
+	rootCmd := &cobra.Command{
+		Use:    "loadtest",
+		RunE:   RunLoadTestCmdF,
+		PreRun: initializeRootCmdF,
+	}
+	rootCmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
 
 	commands := make([]*cobra.Command, 1)
-
 	commands[0] = &cobra.Command{
 		Use:   "example",
 		Short: "Run example implementation",
-		RunE:  RunExample,
+		RunE:  RunExampleCmdF,
 	}
 
 	rootCmd.AddCommand(commands...)
 	rootCmd.Execute()
 }
 
-func initConfig() {
-	if err := config.ReadConfig(); err != nil {
+func initializeRootCmdF(cmd *cobra.Command, args []string) {
+	configFilePath, _ := cmd.Flags().GetString("config")
+	if err := config.ReadConfig(configFilePath); err != nil {
 		mlog.Error("Failed to initialize config", mlog.Err(err))
 		os.Exit(1)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ type LoggerSettings struct {
 	FileLocation  string
 }
 
-func ReadConfig() error {
+func ReadConfig(configFilePath string) error {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("./config/")
@@ -53,6 +53,10 @@ func ReadConfig() error {
 	viper.SetDefault("ConnectionConfiguration.MaxIdleConns", 100)
 	viper.SetDefault("ConnectionConfiguration.MaxIdleConnsPerHost", 128)
 	viper.SetDefault("ConnectionConfiguration.IdleConnTimeoutMilliseconds", 90000)
+
+	if configFilePath != "" {
+		viper.SetConfigFile(configFilePath)
+	}
 
 	if err := viper.ReadInConfig(); err != nil {
 		return errors.Wrap(err, "unable to read configuration file")


### PR DESCRIPTION
#### Summary
Adds a global `--config|-c` flag and loads the configuration from a file if it is set.

#### Ticket link
https://mattermost.atlassian.net/browse/MM-20298