### PR TITLE
[MM-20868] Improve error handling in userentity package

### DIFF
--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -160,11 +160,6 @@ func (ue *UserEntity) GetChannelUnread(channelId string) (*model.ChannelUnread, 
 }
 
 func (ue *UserEntity) GetChannelMembers(channelId string, page, perPage int) error {
-	user, err := ue.getUserFromStore()
-	if err != nil {
-		return nil, err
-	}
-
 	channelMembers, resp := ue.client.GetChannelMembers(channelId, page, perPage, "")
 	if resp.Error != nil {
 		return resp.Error
@@ -174,14 +169,10 @@ func (ue *UserEntity) GetChannelMembers(channelId string, page, perPage int) err
 }
 
 func (ue *UserEntity) GetChannelStats(channelId string) error {
-	user, err := ue.getUserFromStore()
-	if err != nil {
-		return nil, err
-	}
 	_, resp := ue.client.GetChannelStats(channelId, "")
 	if resp.Error != nil {
-		return nil, resp.Error
+		return resp.Error
 	}
 
-	return channelUnreadResponse, nil
+	return nil
 }

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -4,8 +4,6 @@
 package userentity
 
 import (
-	"errors"
-
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -27,27 +25,26 @@ func (ue *UserEntity) SignUp(email, username, password string) error {
 }
 
 func (ue *UserEntity) Login() error {
-	user, err := ue.store.User()
-
-	if user == nil || err != nil {
-		return errors.New("user was not initialized")
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return err
 	}
 
 	_, resp := ue.client.Login(user.Email, user.Password)
+	if resp.Error != nil {
+		return resp.Error
+	}
 
-	return resp.Error
+	return nil
 }
 
 func (ue *UserEntity) Logout() (bool, error) {
-	user, err := ue.store.User()
-
-	if user == nil || err != nil {
-		return false, errors.New("user was not initialized")
+	ok, resp := ue.client.Logout()
+	if resp.Error != nil {
+		return false, resp.Error
 	}
 
-	ok, resp := ue.client.Logout()
-
-	return ok, resp.Error
+	return ok, nil
 }
 
 func (ue *UserEntity) GetMe() (string, error) {
@@ -64,9 +61,9 @@ func (ue *UserEntity) GetMe() (string, error) {
 }
 
 func (ue *UserEntity) CreatePost(post *model.Post) (string, error) {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return "", errors.New("user was not initialized")
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return "", err
 	}
 
 	post.PendingPostId = model.NewId()
@@ -83,83 +80,108 @@ func (ue *UserEntity) CreatePost(post *model.Post) (string, error) {
 }
 
 func (ue *UserEntity) CreateChannel(channel *model.Channel) (string, error) {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return "", errors.New("user was not initialized")
+	_, err := ue.getUserFromStore()
+	if err != nil {
+		return "", err
 	}
 
 	channel, resp := ue.client.CreateChannel(channel)
 	if resp.Error != nil {
 		return "", resp.Error
 	}
+
 	err = ue.store.SetChannel(channel)
-	return channel.Id, err
+	if err != nil {
+		return "", err
+	}
+
+	return channel.Id, nil
 }
 
 func (ue *UserEntity) CreateGroupChannel(memberIds []string) (string, error) {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return "", errors.New("user was not initialized")
-	}
 	channel, resp := ue.client.CreateGroupChannel(memberIds)
 	if resp.Error != nil {
 		return "", resp.Error
 	}
-	err = ue.store.SetChannel(channel)
-	return channel.Id, err
+
+	err := ue.store.SetChannel(channel)
+	if err != nil {
+		return "", err
+	}
+
+	return channel.Id, nil
 }
 
 func (ue *UserEntity) CreateDirectChannel(otherUserId string) (string, error) {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return "", errors.New("user was not initialized")
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return "", err
 	}
+
 	channel, resp := ue.client.CreateDirectChannel(user.Id, otherUserId)
 	if resp.Error != nil {
 		return "", resp.Error
 	}
+
 	err = ue.store.SetChannel(channel)
-	return channel.Id, err
+	if err != nil {
+		return "", err
+	}
+
+	return channel.Id, nil
 }
 
 func (ue *UserEntity) ViewChannel(view *model.ChannelView) (*model.ChannelViewResponse, error) {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return nil, errors.New("user was not initialized")
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return nil, err
 	}
+
 	channelViewResponse, resp := ue.client.ViewChannel(user.Id, view)
-	return channelViewResponse, resp.Error
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return channelViewResponse, nil
 }
 
 func (ue *UserEntity) GetChannelUnread(channelId string) (*model.ChannelUnread, error) {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return nil, errors.New("user was not initialized")
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return nil, err
 	}
+
 	channelUnreadResponse, resp := ue.client.GetChannelUnread(channelId, user.Id)
-	return channelUnreadResponse, resp.Error
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return channelUnreadResponse, nil
 }
 
 func (ue *UserEntity) GetChannelMembers(channelId string, page, perPage int) error {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return errors.New("user was not initialized")
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return nil, err
 	}
+
 	channelMembers, resp := ue.client.GetChannelMembers(channelId, page, perPage, "")
 	if resp.Error != nil {
 		return resp.Error
 	}
+
 	return ue.store.SetChannelMembers(channelId, channelMembers)
 }
 
 func (ue *UserEntity) GetChannelStats(channelId string) error {
-	user, err := ue.store.User()
-	if user == nil || err != nil {
-		return errors.New("user was not initialized")
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return nil, err
 	}
 	_, resp := ue.client.GetChannelStats(channelId, "")
 	if resp.Error != nil {
-		return resp.Error
+		return nil, resp.Error
 	}
-	return err
+
+	return channelUnreadResponse, nil
 }

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/config"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 	"github.com/stretchr/testify/require"
 )
 
 type TestHelper struct {
-	User   user.User
+	User   *UserEntity
 	config *config.LoadTestConfig
 	tb     testing.TB
 }
@@ -30,7 +29,7 @@ func (th *TestHelper) Init() *TestHelper {
 	return th
 }
 
-func (th *TestHelper) CreateUser() user.User {
+func (th *TestHelper) CreateUser() *UserEntity {
 	s := memstore.New()
 	u := New(s, 1, Config{
 		th.config.ConnectionConfiguration.ServerURL,

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -82,3 +82,17 @@ func (ue *UserEntity) Disconnect() error {
 	ue.wsClient = nil
 	return nil
 }
+
+func (ue *UserEntity) getUserFromStore() (*model.User, error) {
+	user, err := ue.store.User()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if user == nil {
+		return nil, errors.New("user was not initialized")
+	}
+
+	return user, nil
+}

--- a/loadtest/user/userentity/user_test.go
+++ b/loadtest/user/userentity/user_test.go
@@ -1,0 +1,25 @@
+package userentity
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserFromStore(t *testing.T) {
+	th := Setup(t).Init()
+
+	user, err := th.User.getUserFromStore()
+	require.Nil(t, user)
+	require.Error(t, err)
+	require.EqualError(t, err, "user was not initialized")
+
+	th.User.store.SetUser(&model.User{
+		Id: "someid",
+	})
+	user, err = th.User.getUserFromStore()
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.Equal(t, "someid", user.Id)
+}


### PR DESCRIPTION
#### Summary

PR fixes a couple of problems with error handling in the `userentity` package and adds a method to mitigate some code duplication.
It also fixes a panic (thanks @ethervoid) triggered by returning `resp.Error` directly.

#### Ticket

https://mattermost.atlassian.net/browse/MM-20868