### PR TITLE
[MM-20879] Implement userentity.CreateTeam()

### DIFF
--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -165,3 +165,7 @@ func (u *SampleUser) GetPreferences() error {
 func (u *SampleUser) CreateUser(user *model.User) (string, error) {
 	return "", nil
 }
+
+func (u *SampleUser) CreateTeam(team *model.Team) (string, error) {
+	return "", nil
+}

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -37,4 +37,5 @@ type User interface {
 	GetChannelStats(channelId string) error
 
 	// teams
+	CreateTeam(team *model.Team) (string, error)
 }

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -202,3 +202,12 @@ func (ue *UserEntity) GetChannelStats(channelId string) error {
 
 	return nil
 }
+
+func (ue *UserEntity) CreateTeam(team *model.Team) (string, error) {
+	team, resp := ue.client.CreateTeam(team)
+	if resp.Error != nil {
+		return "", resp.Error
+	}
+
+	return team.Id, nil
+}


### PR DESCRIPTION
#### Summary

Implements userentity.CreateTeam().
The function is a simple wrapper to the underlying API call. It will be mainly used during initial data generation by a sysadmin.

#### Ticket

https://mattermost.atlassian.net/browse/MM-20879