### PR TITLE
[MM-20851] Implement userentity.GetChannelMember()

### DIFF
--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -4,22 +4,22 @@
 package samplestore
 
 import (
+	"errors"
+
 	"github.com/mattermost/mattermost-server/model"
 )
 
 type SampleStore struct {
-	user           *model.User
-	preferences    model.Preferences
-	posts          map[string]*model.Post
-	channels       map[string]*model.Channel
-	channelMembers map[string]*model.ChannelMembers
+	user        *model.User
+	preferences model.Preferences
+	posts       map[string]*model.Post
+	channels    map[string]*model.Channel
 }
 
 func New() *SampleStore {
 	return &SampleStore{
-		posts:          map[string]*model.Post{},
-		channels:       map[string]*model.Channel{},
-		channelMembers: map[string]*model.ChannelMembers{},
+		posts:    map[string]*model.Post{},
+		channels: map[string]*model.Channel{},
 	}
 }
 
@@ -73,6 +73,17 @@ func (s *SampleStore) SetChannel(channel *model.Channel) error {
 }
 
 func (s *SampleStore) SetChannelMembers(channelId string, channelMembers *model.ChannelMembers) error {
-	s.channelMembers[channelId] = channelMembers
-	return nil
+	return errors.New("not implemented")
+}
+
+func (s *SampleStore) ChannelMembers(channelId string) (*model.ChannelMembers, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *SampleStore) SetChannelMember(channelId string, channelMember *model.ChannelMember) error {
+	return errors.New("not implemented")
+}
+
+func (s *SampleStore) ChannelMember(channelId, userId string) (*model.ChannelMember, error) {
+	return nil, errors.New("not implemented")
 }

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -86,6 +86,10 @@ func (u *SampleUser) GetChannelMembers(channelId string, page, perPage int) erro
 	return nil
 }
 
+func (u *SampleUser) GetChannelMember(channelId, userId string) error {
+	return nil
+}
+
 func (u *SampleUser) GetChannelStats(channelId string) error {
 	return nil
 }

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -72,3 +72,39 @@ func TestId(t *testing.T) {
 		require.Equal(t, expected, id)
 	})
 }
+
+func TestChannelMembers(t *testing.T) {
+	s := New()
+
+	t.Run("SetChannelMembers", func(t *testing.T) {
+		channelId := model.NewId()
+		userId := model.NewId()
+		expected := model.ChannelMembers{
+			model.ChannelMember{
+				ChannelId: channelId,
+				UserId:    userId,
+			},
+		}
+		s.SetChannelMembers(channelId, &expected)
+		members, err := s.ChannelMembers(channelId)
+		require.NoError(t, err)
+		require.Equal(t, &expected, members)
+	})
+
+	t.Run("SetChannelMember", func(t *testing.T) {
+		channelId := model.NewId()
+		userId := model.NewId()
+		member, err := s.ChannelMember(channelId, userId)
+		require.NoError(t, err)
+		require.Nil(t, member)
+		expected := model.ChannelMember{
+			ChannelId: channelId,
+			UserId:    userId,
+		}
+		err = s.SetChannelMember(channelId, &expected)
+		require.NoError(t, err)
+		member, err = s.ChannelMember(channelId, userId)
+		require.NoError(t, err)
+		require.Equal(t, &expected, member)
+	})
+}

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -22,4 +22,7 @@ type MutableUserStore interface {
 	User() (*model.User, error)
 	Channel(channelId string) (*model.Channel, error)
 	SetChannelMembers(channelId string, channelMembers *model.ChannelMembers) error
+	ChannelMembers(channelId string) (*model.ChannelMembers, error)
+	SetChannelMember(channelId string, channelMember *model.ChannelMember) error
+	ChannelMember(channelId, userId string) (*model.ChannelMember, error)
 }

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -34,6 +34,7 @@ type User interface {
 	ViewChannel(view *model.ChannelView) (*model.ChannelViewResponse, error)
 	GetChannelUnread(channelId string) (*model.ChannelUnread, error)
 	GetChannelMembers(channelId string, page, perPage int) error
+	GetChannelMember(channelId string, userId string) error
 	GetChannelStats(channelId string) error
 
 	// teams

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -194,6 +194,15 @@ func (ue *UserEntity) GetChannelMembers(channelId string, page, perPage int) err
 	return ue.store.SetChannelMembers(channelId, channelMembers)
 }
 
+func (ue *UserEntity) GetChannelMember(channelId, userId string) error {
+	cm, resp := ue.client.GetChannelMember(channelId, userId, "")
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return ue.store.SetChannelMember(channelId, cm)
+}
+
 func (ue *UserEntity) GetChannelStats(channelId string) error {
 	_, resp := ue.client.GetChannelStats(channelId, "")
 	if resp.Error != nil {


### PR DESCRIPTION
#### Summary

PR implements `userentity.GetChannelMember()`.
It also re-implements how we store `ChannelMembers` data and provides related getters/setters.

#### Ticket

https://mattermost.atlassian.net/browse/MM-20851
