### PR TITLE
Implements GetUserStatus in the user entity

### DIFF
--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -160,6 +160,10 @@ func (u *SampleUser) AutocompleteChannelsForTeam(teamId, name string) error {
 	return nil
 }
 
+func (ue *SampleUser) GetUserStatus() error {
+	return nil
+}
+
 func (u *SampleUser) GetUsersStatusesByIds(userIds []string) error {
 	return nil
 }

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -27,6 +27,7 @@ type User interface {
 	PatchUser(userId string, patch *model.UserPatch) error
 	GetUsersByIds(userIds []string) ([]string, error)
 	GetUsersByUsernames(usernames []string) ([]string, error)
+	GetUserStatus() error
 	GetUsersStatusesByIds(userIds []string) error
 	SetProfileImage(data []byte) error
 	GetProfileImage() error

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -477,6 +477,20 @@ func (ue *UserEntity) GetUsersByUsernames(usernames []string) ([]string, error) 
 	return newUserIds, nil
 }
 
+func (ue *UserEntity) GetUserStatus() error {
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return err
+	}
+
+	_, resp := ue.client.GetUserStatus(user.Id, "")
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return nil
+}
+
 func (ue *UserEntity) GetUsersStatusesByIds(userIds []string) error {
 	_, resp := ue.client.GetUsersStatusesByIds(userIds)
 	return resp.Error


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR adds the `GetStatus` method to the user entity. Get just use this method to test load in that endpoint mainly because the status info is passed through the websocket

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21275
