### PR TITLE
MM-21367: Fix panic when Disconnect gets called consecutively

### DIFF
--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -17,7 +17,6 @@ type UserEntity struct {
 	id          int
 	store       store.MutableUserStore
 	client      *model.Client4
-	wsClient    *model.WebSocketClient
 	wsClosing   chan struct{}
 	wsClosed    chan struct{}
 	wsErrorChan chan error
@@ -94,7 +93,7 @@ func (ue *UserEntity) Disconnect() error {
 	// the loop may be sleeping on a reconnect cycle.
 	select {
 	case <-ue.wsClosed:
-	case <-time.After(minWebsocketReconnectDuration):
+	case <-time.After(minWebsocketReconnectDuration * 2):
 	}
 
 	close(ue.wsErrorChan)

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -23,6 +23,7 @@ type UserEntity struct {
 	wsClosing   chan struct{}
 	wsClosed    chan struct{}
 	wsErrorChan chan error
+	connected   bool
 	config      Config
 }
 
@@ -59,14 +60,14 @@ func New(store store.MutableUserStore, id int, config Config) *UserEntity {
 	}
 	ue.client.HttpClient = &http.Client{Transport: transport}
 	ue.store = store
-	ue.wsClosing = make(chan struct{})
-	ue.wsClosed = make(chan struct{})
-	ue.wsErrorChan = make(chan error, 1)
 	return &ue
 }
 
 // Connect creates a websocket connection to the server and starts listening for messages.
 func (ue *UserEntity) Connect() <-chan error {
+	ue.wsClosing = make(chan struct{})
+	ue.wsClosed = make(chan struct{})
+	ue.wsErrorChan = make(chan error, 1)
 	if ue.client.AuthToken == "" {
 		ue.wsErrorChan <- errors.New("user is not authenticated")
 		return ue.wsErrorChan
@@ -78,13 +79,14 @@ func (ue *UserEntity) Connect() <-chan error {
 	}
 
 	go ue.listen(ue.wsErrorChan)
+	ue.connected = true
 	return ue.wsErrorChan
 }
 
 // Disconnect closes the websocket connection.
 func (ue *UserEntity) Disconnect() error {
 	cli := ue.getWsClient()
-	if cli == nil {
+	if cli == nil || !ue.connected {
 		return errors.New("user is not connected")
 	}
 	// We exit the listener loop first, and then close the connection.
@@ -103,6 +105,7 @@ func (ue *UserEntity) Disconnect() error {
 
 	cli.Close()
 	cli = nil
+	ue.connected = false
 	return nil
 }
 

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -31,9 +31,7 @@ func (ue *UserEntity) listen(errChan chan error) {
 			// Reconnect again.
 			continue
 		}
-		ue.wsClientMut.Lock()
 		ue.wsClient = client
-		ue.wsClientMut.Unlock()
 
 		ue.wsClient.Listen()
 		chanClosed := false
@@ -52,6 +50,7 @@ func (ue *UserEntity) listen(errChan chan error) {
 				}
 				_ = resp // TODO: handle response
 			case <-ue.wsClosing:
+				ue.wsClient.Close()
 				// Explicit disconnect. Return.
 				close(ue.wsClosed)
 				return

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -31,26 +31,25 @@ func (ue *UserEntity) listen(errChan chan error) {
 			// Reconnect again.
 			continue
 		}
-		ue.wsClient = client
 
-		ue.wsClient.Listen()
+		client.Listen()
 		chanClosed := false
 		for {
 			select {
-			case ev, ok := <-ue.wsClient.EventChannel:
+			case ev, ok := <-client.EventChannel:
 				if !ok {
 					chanClosed = true
 					break
 				}
 				_ = ev // TODO: handle event
-			case resp, ok := <-ue.wsClient.ResponseChannel:
+			case resp, ok := <-client.ResponseChannel:
 				if !ok {
 					chanClosed = true
 					break
 				}
 				_ = resp // TODO: handle response
 			case <-ue.wsClosing:
-				ue.wsClient.Close()
+				client.Close()
 				// Explicit disconnect. Return.
 				close(ue.wsClosed)
 				return
@@ -60,8 +59,8 @@ func (ue *UserEntity) listen(errChan chan error) {
 			}
 		}
 
-		if ue.wsClient.ListenError != nil {
-			errChan <- fmt.Errorf("websocket listen error: %w", ue.wsClient.ListenError)
+		if client.ListenError != nil {
+			errChan <- fmt.Errorf("websocket listen error: %w", client.ListenError)
 		}
 		connectionFailCount++
 		time.Sleep(getWaitTime(connectionFailCount))


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The issue was that when the controller loop runs for the 2nd time,
the user does not login again, and the API throws "user already signed up error".
This means user.Connect does not get called. Now when it goes forward,
it calls Disconnect again during logout, essentially calling disconnect 2 times
consecutively.

This creates a panic because we call `close(ue.wsClosing)` twice consecutively.

We fix 2 bugs here:

1. We reset the channels in Connect.
2. We add a state check to indicate whether the user is disconnected/connected.
And depending on that, bail out early from the disconnect function.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21367
