### PR TITLE
[MM-21287] Refactor UserController/User

### DIFF
--- a/example/loadtest.go
+++ b/example/loadtest.go
@@ -11,12 +11,10 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/example/samplestore"
 	"github.com/mattermost/mattermost-load-test-ng/example/sampleuser"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
 type SampleLoadTester struct {
-	users       []user.User
 	controllers []control.UserController
 	wg          sync.WaitGroup
 	serverURL   string
@@ -24,9 +22,8 @@ type SampleLoadTester struct {
 
 func (lt *SampleLoadTester) initControllers(numUsers int) {
 	for i := 0; i < numUsers; i++ {
-		lt.users[i] = sampleuser.New(samplestore.New(), i, lt.serverURL)
-		lt.controllers[i] = &samplecontroller.SampleController{}
-		lt.controllers[i].Init(lt.users[i])
+		su := sampleuser.New(samplestore.New(), lt.serverURL)
+		lt.controllers[i] = samplecontroller.New(i, su)
 	}
 }
 
@@ -52,13 +49,13 @@ func (lt *SampleLoadTester) handleStatus(status <-chan control.UserStatus) {
 			lt.wg.Done()
 		}
 		if us.Code == control.USER_STATUS_ERROR {
-			mlog.Info(us.Err.Error(), mlog.Int("user_id", us.User.Id()))
+			mlog.Info(us.Err.Error(), mlog.Int("controller_id", us.ControllerId))
 			continue
 		} else if us.Code == control.USER_STATUS_FAILED {
 			mlog.Error(us.Err.Error())
 			continue
 		}
-		mlog.Info(us.Info, mlog.Int("user_id", us.User.Id()))
+		mlog.Info(us.Info, mlog.Int("controller_id", us.ControllerId))
 	}
 }
 
@@ -66,7 +63,6 @@ func Run() error {
 	const numUsers = 4
 
 	lt := SampleLoadTester{
-		users:       make([]user.User, numUsers),
 		controllers: make([]control.UserController, numUsers),
 		serverURL:   "http://localhost:8065",
 	}

--- a/example/samplecontroller/controller.go
+++ b/example/samplecontroller/controller.go
@@ -26,10 +26,10 @@ type userAction struct {
 
 func New(id int, user user.User, status chan<- control.UserStatus) *SampleController {
 	return &SampleController{
-		id,
-		user,
-		make(chan struct{}),
-		status,
+		id:     id,
+		user:   user,
+		stop:   make(chan struct{}),
+		status: status,
 	}
 }
 

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -14,20 +14,15 @@ import (
 )
 
 type SampleUser struct {
-	id     int
 	store  store.MutableUserStore
 	client *model.Client4
-}
-
-func (u *SampleUser) Id() int {
-	return u.id
 }
 
 func (u *SampleUser) Store() store.UserStore {
 	return u.store
 }
 
-func New(store store.MutableUserStore, id int, serverURL string) *SampleUser {
+func New(store store.MutableUserStore, serverURL string) *SampleUser {
 	client := model.NewAPIv4Client(serverURL)
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -44,7 +39,6 @@ func New(store store.MutableUserStore, id int, serverURL string) *SampleUser {
 	}
 	client.HttpClient = &http.Client{Transport: transport}
 	return &SampleUser{
-		id:     id,
 		client: client,
 		store:  store,
 	}

--- a/loadtest/control/controller.go
+++ b/loadtest/control/controller.go
@@ -3,12 +3,7 @@
 
 package control
 
-import (
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
-)
-
 type UserController interface {
-	Init(user user.User)
 	Run(status chan<- UserStatus)
 	SetRate(rate float64) error
 	Stop()

--- a/loadtest/control/controller.go
+++ b/loadtest/control/controller.go
@@ -4,7 +4,7 @@
 package control
 
 type UserController interface {
-	Run(status chan<- UserStatus)
+	Run()
 	SetRate(rate float64) error
 	Stop()
 }

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -22,8 +22,8 @@ func (c *SimpleController) signUp() control.UserStatus {
 		return c.newInfoStatus("user already signed up")
 	}
 
-	email := fmt.Sprintf("testuser%d@example.com", c.user.Id())
-	username := fmt.Sprintf("testuser%d", c.user.Id())
+	email := fmt.Sprintf("testuser%d@example.com", c.id)
+	username := fmt.Sprintf("testuser%d", c.id)
 	password := "testPass123$"
 
 	err := c.user.SignUp(email, username, password)

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -13,6 +13,7 @@ import (
 )
 
 type SimpleController struct {
+	id     int
 	user   user.User
 	stop   chan struct{}
 	status chan<- control.UserStatus
@@ -23,6 +24,15 @@ func (c *SimpleController) Init(user user.User) {
 	c.user = user
 	c.stop = make(chan struct{})
 	c.rate = 1.0
+}
+
+func New(id int, user user.User) *SimpleController {
+	return &SimpleController{
+		id,
+		user,
+		make(chan struct{}),
+		1.0,
+	}
 }
 
 func (c *SimpleController) Run(status chan<- control.UserStatus) {
@@ -65,7 +75,7 @@ func (c *SimpleController) Run(status chan<- control.UserStatus) {
 		},
 	}
 
-	status <- control.UserStatus{User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
+	status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
 
 	defer c.sendStopStatus(status)
 
@@ -97,9 +107,9 @@ func (c *SimpleController) Stop() {
 }
 
 func (c *SimpleController) sendFailStatus(status chan<- control.UserStatus, reason string) {
-	status <- control.UserStatus{User: c.user, Code: control.USER_STATUS_FAILED, Err: errors.New(reason)}
+	status <- control.UserStatus{ControllerId: c.id, User: c.user, Code: control.USER_STATUS_FAILED, Err: errors.New(reason)}
 }
 
 func (c *SimpleController) sendStopStatus(status chan<- control.UserStatus) {
-	status <- control.UserStatus{User: c.user, Info: "user stopped", Code: control.USER_STATUS_STOPPED}
+	status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user stopped", Code: control.USER_STATUS_STOPPED}
 }

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -20,29 +20,21 @@ type SimpleController struct {
 	rate   float64
 }
 
-func (c *SimpleController) Init(user user.User) {
-	c.user = user
-	c.stop = make(chan struct{})
-	c.rate = 1.0
-}
-
-func New(id int, user user.User) *SimpleController {
+func New(id int, user user.User, status chan<- control.UserStatus) *SimpleController {
 	return &SimpleController{
-		id,
-		user,
-		make(chan struct{}),
-		1.0,
+		id:     id,
+		user:   user,
+		stop:   make(chan struct{}),
+		status: status,
+		rate:   1.0,
 	}
 }
 
-func (c *SimpleController) Run(status chan<- control.UserStatus) {
+func (c *SimpleController) Run() {
 	if c.user == nil {
-		c.sendFailStatus(status, "controller was not initialized")
+		c.sendFailStatus("controller was not initialized")
 		return
 	}
-	// TODO: This needs to be revamped. Status needs to be passed during
-	// initialization.
-	c.status = status
 
 	actions := []UserAction{
 		{
@@ -75,13 +67,13 @@ func (c *SimpleController) Run(status chan<- control.UserStatus) {
 		},
 	}
 
-	status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
+	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
 
-	defer c.sendStopStatus(status)
+	defer c.sendStopStatus()
 
 	for {
 		for i := 0; i < len(actions); i++ {
-			status <- actions[i].run()
+			c.status <- actions[i].run()
 
 			idleTime := time.Duration(math.Round(float64(actions[i].waitAfter) * c.rate))
 
@@ -106,10 +98,10 @@ func (c *SimpleController) Stop() {
 	close(c.stop)
 }
 
-func (c *SimpleController) sendFailStatus(status chan<- control.UserStatus, reason string) {
-	status <- control.UserStatus{ControllerId: c.id, User: c.user, Code: control.USER_STATUS_FAILED, Err: errors.New(reason)}
+func (c *SimpleController) sendFailStatus(reason string) {
+	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Code: control.USER_STATUS_FAILED, Err: errors.New(reason)}
 }
 
-func (c *SimpleController) sendStopStatus(status chan<- control.UserStatus) {
-	status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user stopped", Code: control.USER_STATUS_STOPPED}
+func (c *SimpleController) sendStopStatus() {
+	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user stopped", Code: control.USER_STATUS_STOPPED}
 }

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -20,6 +20,9 @@ type SimpleController struct {
 	rate   float64
 }
 
+// New creates and initializes a new SimpleController with given parameters.
+// An id is provided to identify the controller, a User is passed as the entity to be controlled and
+// a UserStatus channel is passed to communicate errors and information about the user's status.
 func New(id int, user user.User, status chan<- control.UserStatus) *SimpleController {
 	return &SimpleController{
 		id:     id,

--- a/loadtest/control/simplecontroller/controller_test.go
+++ b/loadtest/control/simplecontroller/controller_test.go
@@ -3,14 +3,14 @@ package simplecontroller
 import (
 	"testing"
 
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSetRate(t *testing.T) {
-	c := SimpleController{}
+	c := New(1, &userentity.UserEntity{}, make(chan control.UserStatus))
 
-	c.Init(&userentity.UserEntity{})
 	require.Equal(t, 1.0, c.rate)
 
 	err := c.SetRate(-1.0)

--- a/loadtest/control/simplecontroller/status.go
+++ b/loadtest/control/simplecontroller/status.go
@@ -6,18 +6,20 @@ import (
 
 func (c *SimpleController) newInfoStatus(info string) control.UserStatus {
 	return control.UserStatus{
-		User: c.user,
-		Code: control.USER_STATUS_INFO,
-		Info: info,
-		Err:  nil,
+		ControllerId: c.id,
+		User:         c.user,
+		Code:         control.USER_STATUS_INFO,
+		Info:         info,
+		Err:          nil,
 	}
 }
 
 func (c *SimpleController) newErrorStatus(err error) control.UserStatus {
 	return control.UserStatus{
-		User: c.user,
-		Code: control.USER_STATUS_ERROR,
-		Info: "",
-		Err:  err,
+		ControllerId: c.id,
+		User:         c.user,
+		Code:         control.USER_STATUS_ERROR,
+		Info:         "",
+		Err:          err,
 	}
 }

--- a/loadtest/control/status.go
+++ b/loadtest/control/status.go
@@ -18,8 +18,9 @@ const (
 )
 
 type UserStatus struct {
-	User user.User
-	Code int
-	Info string
-	Err  error
+	ControllerId int
+	User         user.User
+	Code         int
+	Info         string
+	Err          error
 }

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -9,7 +9,6 @@ import (
 )
 
 type User interface {
-	Id() int
 	Store() store.UserStore
 
 	// connection

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -31,7 +31,7 @@ func (th *TestHelper) Init() *TestHelper {
 
 func (th *TestHelper) CreateUser() *UserEntity {
 	s := memstore.New()
-	u := New(s, 1, Config{
+	u := New(s, Config{
 		th.config.ConnectionConfiguration.ServerURL,
 		th.config.ConnectionConfiguration.WebSocketURL,
 	})

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -14,7 +14,6 @@ import (
 )
 
 type UserEntity struct {
-	id          int
 	store       store.MutableUserStore
 	client      *model.Client4
 	wsClosing   chan struct{}
@@ -29,17 +28,12 @@ type Config struct {
 	WebSocketURL string
 }
 
-func (ue *UserEntity) Id() int {
-	return ue.id
-}
-
 func (ue *UserEntity) Store() store.UserStore {
 	return ue.store
 }
 
-func New(store store.MutableUserStore, id int, config Config) *UserEntity {
+func New(store store.MutableUserStore, config Config) *UserEntity {
 	ue := UserEntity{}
-	ue.id = id
 	ue.config = config
 	ue.client = model.NewAPIv4Client(ue.config.ServerURL)
 	transport := &http.Transport{


### PR DESCRIPTION
#### Summary

- Removed `UserController.Init()`. The implementations should now provide their factory functions.
- Removed status parameter from `UserController.Run()`. This will be now passed during controller creation.
- Removed `Id` from `UserEntity` and added it to the controller since it is used to identify the latter.
- Removed unnecessary slice of users in `LoadTester`.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21287

