### PR TITLE
Fix indefinite wait in websocket reconnect

### DIFF
--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -83,12 +83,7 @@ func (ue *UserEntity) Disconnect() error {
 	// exits, which causes unnecessary delay.
 	close(ue.wsClosing)
 
-	// We wait to get the response with a timeout, because
-	// the loop may be sleeping on a reconnect cycle.
-	select {
-	case <-ue.wsClosed:
-	case <-time.After(minWebsocketReconnectDuration * 2):
-	}
+	<-ue.wsClosed
 
 	close(ue.wsErrorChan)
 	ue.connected = false


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
There may be a case where the server is down and the websocket
keeps on trying to reconnect. In that case, if the user tries
to disconnect, the closing signal will never reach the channel.

So we used to just wait with a timeout and return. This would
leave the goroutine dangling.

A better way is to select on 2 channels, and return whenever
we get the closing signal.
