### PR TITLE
MM-21415: make LoadTester API goroutine-safe

### DIFF
--- a/loadtest/errors.go
+++ b/loadtest/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrAlreadyRunning  = errors.New("LoadTester is already running")
 	ErrNoUsersLeft     = errors.New("No active users left")
 	ErrMaxUsersReached = errors.New("Max active users limit reached")
+	ErrStopping        = errors.New("LoadTester is stopping")
 )

--- a/loadtest/errors.go
+++ b/loadtest/errors.go
@@ -7,8 +7,6 @@ import (
 var (
 	ErrNotRunning      = errors.New("LoadTester is not running")
 	ErrNotStopped      = errors.New("LoadTester has not stopped")
-	ErrNotStopping     = errors.New("LoadTester is not stopping")
-	ErrNotStarting     = errors.New("LoadTester is not starting")
 	ErrNoUsersLeft     = errors.New("No active users left")
 	ErrMaxUsersReached = errors.New("Max active users limit reached")
 )

--- a/loadtest/errors.go
+++ b/loadtest/errors.go
@@ -6,8 +6,9 @@ import (
 
 var (
 	ErrNotRunning      = errors.New("LoadTester is not running")
-	ErrAlreadyRunning  = errors.New("LoadTester is already running")
+	ErrNotStopped      = errors.New("LoadTester has not stopped")
+	ErrNotStopping     = errors.New("LoadTester is not stopping")
+	ErrNotStarting     = errors.New("LoadTester is not starting")
 	ErrNoUsersLeft     = errors.New("No active users left")
 	ErrMaxUsersReached = errors.New("Max active users limit reached")
-	ErrStopping        = errors.New("LoadTester is stopping")
 )

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -54,7 +54,9 @@ func TestAddUser(t *testing.T) {
 	err := lt.AddUser()
 	require.Equal(t, ErrNotRunning, err)
 
+	lt.startedMut.Lock()
 	lt.started = true
+	lt.startedMut.Unlock()
 
 	ltConfig.UsersConfiguration.MaxActiveUsers = 0
 	err = lt.AddUser()


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add appropriate mutexes necessary to guard internal state
for racy access.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21415
