### PR TITLE
[MM-20702] Implement basic init command, add joinTeam action

### DIFF
--- a/cmd/loadtest/init.go
+++ b/cmd/loadtest/init.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost-load-test-ng/config"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/spf13/cobra"
+)
+
+func createTeams(admin *userentity.UserEntity, numTeams int) error {
+	team := &model.Team{
+		AllowOpenInvite: true,
+		Type:            "O",
+	}
+	for i := 0; i < numTeams; i++ {
+		team.Name = fmt.Sprintf("team%d", i)
+		team.DisplayName = team.Name
+		id, err := admin.CreateTeam(team)
+		if err != nil {
+			return err
+		}
+		mlog.Info("team created", mlog.String("team_id", id))
+	}
+	return nil
+}
+
+func RunInitCmdF(cmd *cobra.Command, args []string) error {
+	mlog.Info("init started")
+
+	config, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	numTeams := config.InstanceConfiguration.NumTeams
+
+	ueConfig := userentity.Config{
+		ServerURL:    config.ConnectionConfiguration.ServerURL,
+		WebSocketURL: config.ConnectionConfiguration.WebSocketURL,
+	}
+	store := memstore.New()
+	err = store.SetUser(&model.User{
+		Email:    config.ConnectionConfiguration.AdminEmail,
+		Password: config.ConnectionConfiguration.AdminPassword,
+	})
+	if err != nil {
+		return err
+	}
+
+	admin := userentity.New(store, ueConfig)
+
+	start := time.Now()
+
+	if err = admin.Login(); err != nil {
+		return err
+	}
+
+	if err = createTeams(admin, numTeams); err != nil {
+		return err
+	}
+
+	if _, err = admin.Logout(); err != nil {
+		return err
+	}
+
+	mlog.Info("done", mlog.String("elapsed", time.Since(start).String()))
+
+	return nil
+}

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -65,11 +65,17 @@ func main() {
 	}
 	rootCmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
 
-	commands := make([]*cobra.Command, 1)
+	commands := make([]*cobra.Command, 2)
 	commands[0] = &cobra.Command{
 		Use:    "example",
 		Short:  "Run example implementation",
 		RunE:   RunExampleCmdF,
+		PreRun: initLogger,
+	}
+	commands[1] = &cobra.Command{
+		Use:    "init",
+		Short:  "Initialize instance",
+		RunE:   RunInitCmdF,
 		PreRun: initLogger,
 	}
 

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -4,9 +4,14 @@
         "WebSocketURL": "ws://localhost:8065",
         "DriverName": "mysql",
         "DataSource": "mmuser:mostest@tcp(localhost:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=20s&writeTimeout=20s&timeout=20s",
+        "AdminEmail": "sysadmin@sample.mattermost.com",
+        "AdminPassword": "Sys@dmin-sample1",
         "MaxIdleConns": 100,
         "MaxIdleConnsPerHost": 128,
         "IdleConnTimeoutMilliseconds": 90000
+    },
+    "InstanceConfiguration": {
+      "NumTeams": 2
     },
     "UsersConfiguration": {
       "InitialActiveUsers": 4,

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 
 type LoadTestConfig struct {
 	ConnectionConfiguration ConnectionConfiguration
+	InstanceConfiguration   InstanceConfiguration
 	UsersConfiguration      UsersConfiguration
 	LogSettings             LoggerSettings
 }
@@ -21,9 +22,15 @@ type ConnectionConfiguration struct {
 	WebSocketURL                string
 	DriverName                  string
 	DataSource                  string
+	AdminEmail                  string
+	AdminPassword               string
 	MaxIdleConns                int
 	MaxIdleConnsPerHost         int
 	IdleConnTimeoutMilliseconds int
+}
+
+type InstanceConfiguration struct {
+	NumTeams int
 }
 
 type UsersConfiguration struct {

--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -236,8 +236,8 @@ func (s *SampleStore) RemoveTeamMember(teamId, userId string) error {
 	return errors.New("not implemented")
 }
 
-func (s *SampleStore) TeamMember(teamId, userId string) (*model.TeamMember, error) {
-	return nil, errors.New("not implemented")
+func (s *SampleStore) TeamMember(teamId, userId string) (model.TeamMember, error) {
+	return model.TeamMember{}, errors.New("not implemented")
 }
 
 func (s *SampleStore) SetTeamMembers(teamId string, teamMembers []*model.TeamMember) error {

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -380,3 +380,7 @@ func (ue *SampleUser) GetWebappPlugins() error {
 func (ue *SampleUser) GetClientLicense() error {
 	return nil
 }
+
+func (ue *SampleUser) IsSysAdmin() (bool, error) {
+	return false, nil
+}

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -66,6 +66,29 @@ func (c *SimpleController) logout() control.UserStatus {
 	return c.newInfoStatus("logged out")
 }
 
+func (c *SimpleController) joinTeam() control.UserStatus {
+	userStore := c.user.Store()
+	userId := userStore.Id()
+	teams, err := userStore.Teams()
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+	for _, team := range teams {
+		tm, err := userStore.TeamMember(team.Id, userId)
+		if err != nil {
+			return c.newErrorStatus(err)
+		}
+		if tm.UserId == "" {
+			err := c.user.AddTeamMember(team.Id, userId)
+			if err != nil {
+				return c.newErrorStatus(err)
+			}
+			return c.newInfoStatus(fmt.Sprintf("joined team %s", team.Id))
+		}
+	}
+	return c.newInfoStatus("no teams to join")
+}
+
 func (c *SimpleController) createPost() control.UserStatus {
 	postId, err := c.user.CreatePost(&model.Post{
 		Message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -174,9 +174,11 @@ func (c *SimpleController) reload(full bool) control.UserStatus {
 		}
 	}
 
-	err = c.user.GetConfig()
-	if err != nil {
-		return c.newErrorStatus(err)
+	if ok, err := c.user.IsSysAdmin(); ok && err != nil {
+		err = c.user.GetConfig()
+		if err != nil {
+			return c.newErrorStatus(err)
+		}
 	}
 
 	err = c.user.GetClientLicense()

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -58,6 +58,13 @@ func (c *SimpleController) Run() {
 			run: func() control.UserStatus {
 				return c.reload(false)
 			},
+		},
+		{
+			run:       c.joinTeam,
+			waitAfter: 1000,
+		},
+		{
+			run:       c.createPost,
 			waitAfter: 1000,
 		},
 		{

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
-// LoadTester is a structure holding all the state needed to run a load-test
+// LoadTester is a structure holding all the state needed to run a load-test.
 type LoadTester struct {
 	controllers   []control.UserController
 	config        *config.LoadTestConfig
@@ -45,7 +45,7 @@ func (lt *LoadTester) handleStatus() {
 	}
 }
 
-// AddUser increments by one the number of concurrently active users
+// AddUser increments by one the number of concurrently active users.
 func (lt *LoadTester) AddUser() error {
 	if !lt.started {
 		return ErrNotRunning
@@ -63,7 +63,7 @@ func (lt *LoadTester) AddUser() error {
 	return nil
 }
 
-// RemoveUser decrements by one the number of concurrently active users
+// RemoveUser decrements by one the number of concurrently active users.
 func (lt *LoadTester) RemoveUser() error {
 	if !lt.started {
 		return ErrNotRunning
@@ -80,7 +80,7 @@ func (lt *LoadTester) RemoveUser() error {
 	return nil
 }
 
-// Run starts the execution of a new load-test
+// Run starts the execution of a new load-test.
 func (lt *LoadTester) Run() error {
 	// NOTE: we are currently not guarding against access from multiple goroutines.
 	// TODO: Access to LoadTester should be made goroutine safe.
@@ -97,7 +97,7 @@ func (lt *LoadTester) Run() error {
 	return nil
 }
 
-// Stop terminates the current load-test
+// Stop terminates the current load-test.
 func (lt *LoadTester) Stop() error {
 	if !lt.started {
 		return ErrNotRunning

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -264,8 +264,12 @@ func (s *MemStore) SetTeamMembers(teamId string, teamMembers []*model.TeamMember
 	return nil
 }
 
-func (s *MemStore) TeamMember(teamId, userId string) (*model.TeamMember, error) {
-	return s.teamMembers[teamId][userId], nil
+func (s *MemStore) TeamMember(teamId, userId string) (model.TeamMember, error) {
+	var tm model.TeamMember
+	if s.teamMembers[teamId][userId] != nil {
+		tm = *s.teamMembers[teamId][userId]
+	}
+	return tm, nil
 }
 
 func (s *MemStore) SetEmojis(emoji []*model.Emoji) error {

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -291,7 +291,7 @@ func TestTeamMembers(t *testing.T) {
 		userId := model.NewId()
 		member, err := s.TeamMember(teamId, userId)
 		require.NoError(t, err)
-		require.Nil(t, member)
+		require.Empty(t, member.UserId)
 		expected := model.TeamMember{
 			TeamId: teamId,
 			UserId: userId,
@@ -302,7 +302,7 @@ func TestTeamMembers(t *testing.T) {
 		require.NoError(t, err)
 		member, err = s.TeamMember(teamId, userId)
 		require.NoError(t, err)
-		require.Equal(t, &expected, member)
+		require.Equal(t, expected, member)
 	})
 
 	t.Run("SetTeamMembers", func(t *testing.T) {
@@ -310,7 +310,7 @@ func TestTeamMembers(t *testing.T) {
 		userId := model.NewId()
 		member, err := s.TeamMember(teamId, userId)
 		require.NoError(t, err)
-		require.Nil(t, member)
+		require.Empty(t, member.UserId)
 		expected := model.TeamMember{
 			TeamId: teamId,
 			UserId: userId,
@@ -319,7 +319,7 @@ func TestTeamMembers(t *testing.T) {
 		require.NoError(t, err)
 		member, err = s.TeamMember(teamId, userId)
 		require.NoError(t, err)
-		require.Equal(t, &expected, member)
+		require.Equal(t, expected, member)
 	})
 }
 

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -20,6 +20,8 @@ type UserStore interface {
 	Channels(teamId string) ([]model.Channel, error)
 	// Teams return the teams a user belong to.
 	Teams() ([]model.Team, error)
+	// TeamMember returns the TeamMember for the given teamId and userId
+	TeamMember(teamdId, userId string) (model.TeamMember, error)
 	// Preferences return the preferences of the user.
 	Preferences() (model.Preferences, error)
 	// Roles return the roles of the user.
@@ -85,7 +87,6 @@ type MutableUserStore interface {
 	SetTeamMember(teamId string, teamMember *model.TeamMember) error
 	RemoveTeamMember(teamId, memberId string) error
 	SetTeamMembers(teamId string, teamMember []*model.TeamMember) error
-	TeamMember(teamdId, userId string) (*model.TeamMember, error)
 
 	// roles
 	// SetRoles stores the given roles.

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -14,13 +14,13 @@ type UserStore interface {
 	Id() string
 	// TODO: Move all getters to this interface
 
-	// Config return the server configuration settings
+	// Config return the server configuration settings.
 	Config() model.Config
 	// Channels return the channels for a team.
 	Channels(teamId string) ([]model.Channel, error)
 	// Teams return the teams a user belong to.
 	Teams() ([]model.Team, error)
-	// TeamMember returns the TeamMember for the given teamId and userId
+	// TeamMember returns the TeamMember for the given teamId and userId.
 	TeamMember(teamdId, userId string) (model.TeamMember, error)
 	// Preferences return the preferences of the user.
 	Preferences() (model.Preferences, error)

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -106,6 +106,6 @@ type User interface {
 	GetClientLicense() error
 
 	// utils
-	// IsSysAdmin will return true if the user is a SystemAdmin, false otherwise
+	// IsSysAdmin will return true if the user is a SystemAdmin, false otherwise.
 	IsSysAdmin() (bool, error)
 }

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -104,4 +104,8 @@ type User interface {
 	// license
 	// GetClientLicense returns the client license in the old format.
 	GetClientLicense() error
+
+	// utils
+	// IsSysAdmin will return true if the user is a SystemAdmin, false otherwise
+	IsSysAdmin() (bool, error)
 }

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -97,6 +97,15 @@ func (ue *UserEntity) Disconnect() error {
 	return nil
 }
 
+func (ue *UserEntity) IsSysAdmin() (bool, error) {
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return false, err
+	}
+
+	return user.IsInRole(model.SYSTEM_ADMIN_ROLE_ID), nil
+}
+
 func (ue *UserEntity) getUserFromStore() (*model.User, error) {
 	user, err := ue.store.User()
 

--- a/loadtest/user/userentity/user_test.go
+++ b/loadtest/user/userentity/user_test.go
@@ -24,3 +24,25 @@ func TestGetUserFromStore(t *testing.T) {
 	require.NotNil(t, user)
 	require.Equal(t, "someid", user.Id)
 }
+
+func TestIsSysAdmin(t *testing.T) {
+	th := Setup(t).Init()
+
+	err := th.User.store.SetUser(&model.User{
+		Id:    "someid",
+		Roles: "system_user",
+	})
+	require.NoError(t, err)
+
+	user, err := th.User.getUserFromStore()
+	require.NoError(t, err)
+
+	ok, err := th.User.IsSysAdmin()
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	user.Roles = "system_user system_admin"
+	ok, err = th.User.IsSysAdmin()
+	require.NoError(t, err)
+	require.True(t, ok)
+}


### PR DESCRIPTION
#### Summary

PR does add a `init` method used to insert minimal data in a MM instance needed for a load-test to run.  
Right now it simply creates a config specified number of open teams which should be enough to get us started.

PR also adds a `joinTeam` action to the `SimpleController` and a utility method `IsSysAdmin` to `UserEntity` which is needed to allow for different behaviours based on what role the user has.

#### Ticket

https://mattermost.atlassian.net/browse/MM-20702