### PR TITLE
[MM-21463] Add origin information to errors in SimpleController

### DIFF
--- a/example/samplecontroller/controller.go
+++ b/example/samplecontroller/controller.go
@@ -79,7 +79,7 @@ func (c *SampleController) Stop() {
 }
 
 func (c *SampleController) sendFailStatus(reason string) {
-	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Code: control.USER_STATUS_FAILED, Err: errors.New(reason)}
+	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Code: control.USER_STATUS_FAILED, Err: &control.ControlError{Err: errors.New(reason)}}
 }
 
 func (c *SampleController) sendStopStatus() {
@@ -97,7 +97,7 @@ func (c *SampleController) signUp() control.UserStatus {
 
 	err := c.user.SignUp(email, username, password)
 	if err != nil {
-		return control.UserStatus{ControllerId: c.id, User: c.user, Err: err, Code: control.USER_STATUS_ERROR}
+		return control.UserStatus{ControllerId: c.id, User: c.user, Err: &control.ControlError{Err: err}, Code: control.USER_STATUS_ERROR}
 	}
 
 	return control.UserStatus{ControllerId: c.id, User: c.user, Info: fmt.Sprintf("signed up: %s", c.user.Store().Id()), Code: control.USER_STATUS_INFO}
@@ -106,7 +106,7 @@ func (c *SampleController) signUp() control.UserStatus {
 func (c *SampleController) login() control.UserStatus {
 	err := c.user.Login()
 	if err != nil {
-		return control.UserStatus{ControllerId: c.id, User: c.user, Err: err, Code: control.USER_STATUS_ERROR}
+		return control.UserStatus{ControllerId: c.id, User: c.user, Err: &control.ControlError{Err: err}, Code: control.USER_STATUS_ERROR}
 	}
 
 	return control.UserStatus{ControllerId: c.id, User: c.user, Info: "logged in", Code: control.USER_STATUS_INFO}
@@ -115,11 +115,11 @@ func (c *SampleController) login() control.UserStatus {
 func (c *SampleController) logout() control.UserStatus {
 	ok, err := c.user.Logout()
 	if err != nil {
-		return control.UserStatus{ControllerId: c.id, User: c.user, Err: err, Code: control.USER_STATUS_ERROR}
+		return control.UserStatus{ControllerId: c.id, User: c.user, Err: &control.ControlError{Err: err}, Code: control.USER_STATUS_ERROR}
 	}
 
 	if !ok {
-		return control.UserStatus{ControllerId: c.id, User: c.user, Err: errors.New("User did not logout"), Code: control.USER_STATUS_ERROR}
+		return control.UserStatus{ControllerId: c.id, User: c.user, Err: &control.ControlError{Err: errors.New("User did not logout")}, Code: control.USER_STATUS_ERROR}
 	}
 
 	return control.UserStatus{ControllerId: c.id, User: c.user, Info: "logged out", Code: control.USER_STATUS_INFO}

--- a/loadtest/control/error.go
+++ b/loadtest/control/error.go
@@ -1,0 +1,14 @@
+package control
+
+// ControlError is custom error type used by a UserController.
+type ControlError struct {
+	// Err contains the error encountered while performing the action.
+	Err error
+	// Origin contains information about where the error originated in the
+	// controller.
+	Origin string
+}
+
+func (e *ControlError) Error() string {
+	return e.Err.Error()
+}

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -119,7 +119,7 @@ func (c *SimpleController) Stop() {
 }
 
 func (c *SimpleController) sendFailStatus(reason string) {
-	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Code: control.USER_STATUS_FAILED, Err: errors.New(reason)}
+	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Code: control.USER_STATUS_FAILED, Err: &control.ControlError{Err: errors.New(reason)}}
 }
 
 func (c *SimpleController) sendStopStatus() {

--- a/loadtest/control/simplecontroller/controller_test.go
+++ b/loadtest/control/simplecontroller/controller_test.go
@@ -1,6 +1,7 @@
 package simplecontroller
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
@@ -24,4 +25,13 @@ func TestSetRate(t *testing.T) {
 	err = c.SetRate(1.5)
 	require.Nil(t, err)
 	require.Equal(t, 1.5, c.rate)
+}
+
+func TestGetErrOrigin(t *testing.T) {
+	var origin string
+	test := func() {
+		origin = getErrOrigin()
+	}
+	test()
+	require.True(t, strings.HasPrefix(origin, "simplecontroller.TestGetErrOrigin"))
 }

--- a/loadtest/control/simplecontroller/status.go
+++ b/loadtest/control/simplecontroller/status.go
@@ -1,15 +1,8 @@
 package simplecontroller
 
 import (
-	"fmt"
-	"os"
-	"runtime"
-	"strings"
-
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 )
-
-const pkgPath string = "github.com/mattermost/mattermost-load-test-ng/loadtest/control/"
 
 func (c *SimpleController) newInfoStatus(info string) control.UserStatus {
 	return control.UserStatus{
@@ -22,14 +15,7 @@ func (c *SimpleController) newInfoStatus(info string) control.UserStatus {
 }
 
 func (c *SimpleController) newErrorStatus(err error) control.UserStatus {
-	var origin string
-	if pc, file, line, ok := runtime.Caller(1); ok {
-		if f := runtime.FuncForPC(pc); f != nil {
-			if wd, err := os.Getwd(); err == nil {
-				origin = fmt.Sprintf("%s %s:%d", strings.TrimPrefix(f.Name(), pkgPath), strings.TrimPrefix(file, wd+"/"), line)
-			}
-		}
-	}
+	origin := getErrOrigin()
 	return control.UserStatus{
 		ControllerId: c.id,
 		User:         c.user,

--- a/loadtest/control/simplecontroller/status.go
+++ b/loadtest/control/simplecontroller/status.go
@@ -21,7 +21,9 @@ func (c *SimpleController) newErrorStatus(err error) control.UserStatus {
 		User:         c.user,
 		Code:         control.USER_STATUS_ERROR,
 		Info:         "",
-		Err:          err,
-		ErrOrigin:    origin,
+		Err: &control.ControlError{
+			Err:    err,
+			Origin: origin,
+		},
 	}
 }

--- a/loadtest/control/simplecontroller/status.go
+++ b/loadtest/control/simplecontroller/status.go
@@ -1,8 +1,15 @@
 package simplecontroller
 
 import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 )
+
+const pkgPath string = "github.com/mattermost/mattermost-load-test-ng/loadtest/control/"
 
 func (c *SimpleController) newInfoStatus(info string) control.UserStatus {
 	return control.UserStatus{
@@ -15,11 +22,20 @@ func (c *SimpleController) newInfoStatus(info string) control.UserStatus {
 }
 
 func (c *SimpleController) newErrorStatus(err error) control.UserStatus {
+	var origin string
+	if pc, file, line, ok := runtime.Caller(1); ok {
+		if f := runtime.FuncForPC(pc); f != nil {
+			if wd, err := os.Getwd(); err == nil {
+				origin = fmt.Sprintf("%s %s:%d", strings.TrimPrefix(f.Name(), pkgPath), strings.TrimPrefix(file, wd+"/"), line)
+			}
+		}
+	}
 	return control.UserStatus{
 		ControllerId: c.id,
 		User:         c.user,
 		Code:         control.USER_STATUS_ERROR,
 		Info:         "",
 		Err:          err,
+		ErrOrigin:    origin,
 	}
 }

--- a/loadtest/control/simplecontroller/utils.go
+++ b/loadtest/control/simplecontroller/utils.go
@@ -1,0 +1,22 @@
+package simplecontroller
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+const pkgPath = "github.com/mattermost/mattermost-load-test-ng/loadtest/control/"
+
+func getErrOrigin() string {
+	var origin string
+	if pc, file, line, ok := runtime.Caller(2); ok {
+		if f := runtime.FuncForPC(pc); f != nil {
+			if wd, err := os.Getwd(); err == nil {
+				origin = fmt.Sprintf("%s %s:%d", strings.TrimPrefix(f.Name(), pkgPath), strings.TrimPrefix(file, wd+string(os.PathSeparator)), line)
+			}
+		}
+	}
+	return origin
+}

--- a/loadtest/control/status.go
+++ b/loadtest/control/status.go
@@ -30,4 +30,7 @@ type UserStatus struct {
 	Info string
 	// Err contains the error encountered while performing the action.
 	Err error
+	// ErrOrigin contains information about where the error originated in the
+	// controller.
+	ErrOrigin string
 }

--- a/loadtest/control/status.go
+++ b/loadtest/control/status.go
@@ -28,9 +28,6 @@ type UserStatus struct {
 	Code int
 	// Info contains any extra information attached with the status.
 	Info string
-	// Err contains the error encountered while performing the action.
-	Err error
-	// ErrOrigin contains information about where the error originated in the
-	// controller.
-	ErrOrigin string
+	// Custom error containing the error encountered and location information.
+	Err *ControlError
 }

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -47,7 +47,7 @@ func (lt *LoadTester) handleStatus() {
 			lt.wg.Done()
 		}
 		if st.Code == control.USER_STATUS_ERROR {
-			mlog.Info(st.Err.Error(), mlog.Int("controller_id", st.ControllerId), mlog.String("origin", st.ErrOrigin))
+			mlog.Info(st.Err.Error(), mlog.Int("controller_id", st.ControllerId), mlog.String("origin", st.Err.Origin))
 			continue
 		} else if st.Code == control.USER_STATUS_FAILED {
 			mlog.Error(st.Err.Error())

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -47,7 +47,7 @@ func (lt *LoadTester) handleStatus() {
 			lt.wg.Done()
 		}
 		if st.Code == control.USER_STATUS_ERROR {
-			mlog.Info(st.Err.Error(), mlog.Int("controller_id", st.ControllerId))
+			mlog.Info(st.Err.Error(), mlog.Int("controller_id", st.ControllerId), mlog.String("origin", st.ErrOrigin))
 			continue
 		} else if st.Code == control.USER_STATUS_FAILED {
 			mlog.Error(st.Err.Error())

--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	ErrEmptyMap   = errors.New("cannot select from an empty map")
-	ErrEmptySlice = errors.New("cannot select from an empty slice")
+	ErrEmptyMap   = errors.New("memstore: cannot select from an empty map")
+	ErrEmptySlice = errors.New("memstore: cannot select from an empty slice")
 )
 
 // RandomChannel returns a random channel for a user.
@@ -102,7 +102,7 @@ func (s *MemStore) RandomTeamMember(teamId string) (model.TeamMember, error) {
 func pickRandomKeyFromMap(m interface{}) (interface{}, error) {
 	val := reflect.ValueOf(m)
 	if val.Kind() != reflect.Map {
-		return nil, errors.New("not a map")
+		return nil, errors.New("memstore: not a map")
 	}
 	keys := val.MapKeys()
 	if len(keys) == 0 {

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -210,7 +210,7 @@ func TestPickRandomKeyFromMap(t *testing.T) {
 
 	t.Run("NotMap", func(t *testing.T) {
 		_, err := pickRandomKeyFromMap(1)
-		require.Equal(t, err.Error(), "not a map")
+		require.Equal(t, err.Error(), "memstore: not a map")
 	})
 
 	t.Run("EmptyMap", func(t *testing.T) {

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -62,7 +62,7 @@ func (s *MemStore) User() (*model.User, error) {
 
 func (s *MemStore) SetUser(user *model.User) error {
 	if user == nil {
-		return errors.New("user should not be nil")
+		return errors.New("memstore: user should not be nil")
 	}
 	restorePrivateData(s.user, user)
 	s.user = user
@@ -103,7 +103,7 @@ func (s *MemStore) ChannelPosts(channelId string) ([]*model.Post, error) {
 
 func (s *MemStore) SetPost(post *model.Post) error {
 	if post == nil {
-		return errors.New("post should not be nil")
+		return errors.New("memstore: post should not be nil")
 	}
 	s.posts[post.Id] = post
 	return nil
@@ -111,7 +111,7 @@ func (s *MemStore) SetPost(post *model.Post) error {
 
 func (s *MemStore) SetPosts(posts []*model.Post) error {
 	if len(posts) == 0 {
-		return errors.New("posts should not be nil or empty")
+		return errors.New("memstore: posts should not be nil or empty")
 	}
 
 	for _, post := range posts {
@@ -131,7 +131,7 @@ func (s *MemStore) Channel(channelId string) (*model.Channel, error) {
 
 func (s *MemStore) SetChannel(channel *model.Channel) error {
 	if channel == nil {
-		return errors.New("channel should not be nil")
+		return errors.New("memstore: channel should not be nil")
 	}
 	s.channels[channel.Id] = channel
 	return nil
@@ -150,7 +150,7 @@ func (s *MemStore) Channels(teamId string) ([]model.Channel, error) {
 
 func (s *MemStore) SetChannels(channels []*model.Channel) error {
 	if channels == nil {
-		return errors.New("channels shouldn't be nil")
+		return errors.New("memstore: channels shouldn't be nil")
 	}
 	for _, channel := range channels {
 		if err := s.SetChannel(channel); err != nil {
@@ -193,7 +193,7 @@ func (s *MemStore) SetTeams(teams []*model.Team) error {
 // SetChannelMembers stores the given channel members in the store.
 func (s *MemStore) SetChannelMembers(channelMembers *model.ChannelMembers) error {
 	if channelMembers == nil {
-		return errors.New("channelMembers should not be nil")
+		return errors.New("memstore: channelMembers should not be nil")
 	}
 
 	for _, member := range *channelMembers {
@@ -221,7 +221,7 @@ func (s *MemStore) ChannelMembers(channelId string) (*model.ChannelMembers, erro
 
 func (s *MemStore) SetChannelMember(channelId string, channelMember *model.ChannelMember) error {
 	if channelMember == nil {
-		return errors.New("channelMember should not be nil")
+		return errors.New("memstore: channelMember should not be nil")
 	}
 	if s.channelMembers[channelId] == nil {
 		s.channelMembers[channelId] = map[string]*model.ChannelMember{}
@@ -246,7 +246,7 @@ func (s *MemStore) RemoveTeamMember(teamId string, userId string) error {
 
 func (s *MemStore) SetTeamMember(teamId string, teamMember *model.TeamMember) error {
 	if teamMember == nil {
-		return errors.New("teamMember should not be nil")
+		return errors.New("memstore: teamMember should not be nil")
 	}
 	if s.teamMembers[teamId] == nil {
 		s.teamMembers[teamId] = map[string]*model.TeamMember{}

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -150,7 +150,7 @@ func (s *MemStore) Channels(teamId string) ([]model.Channel, error) {
 
 func (s *MemStore) SetChannels(channels []*model.Channel) error {
 	if channels == nil {
-		return errors.New("memstore: channels shouldn't be nil")
+		return errors.New("memstore: channels should not be nil")
 	}
 	for _, channel := range channels {
 		if err := s.SetChannel(channel); err != nil {


### PR DESCRIPTION
#### Summary

PR adds an `ErrOrigin` field in `UserStatus` with information on the location of errors coming from `SimpleController`.
I've also modified errors string coming from the store to help identify them better.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21463
