### PR TITLE
MM-21505: implement LoadTester.Status

### DIFF
--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -43,22 +43,7 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	mlog.Info("loadtest started")
-	time.Sleep(15 * time.Second)
-
-	go func() {
-		err := lt.AddUser()
-		if err != nil {
-			mlog.Error(err.Error())
-		}
-	}()
-	time.Sleep(5 * time.Second)
-	go func() {
-		err := lt.RemoveUser()
-		if err != nil {
-			mlog.Error(err.Error())
-		}
-	}()
-	time.Sleep(15 * time.Second)
+	time.Sleep(60 * time.Second)
 
 	err = lt.Stop()
 	mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -42,9 +42,23 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
 	mlog.Info("loadtest started")
-	time.Sleep(60 * time.Second)
+	time.Sleep(15 * time.Second)
+
+	go func() {
+		err := lt.AddUser()
+		if err != nil {
+			mlog.Error(err.Error())
+		}
+	}()
+	time.Sleep(5 * time.Second)
+	go func() {
+		err := lt.RemoveUser()
+		if err != nil {
+			mlog.Error(err.Error())
+		}
+	}()
+	time.Sleep(15 * time.Second)
 
 	err = lt.Stop()
 	mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -162,10 +162,10 @@ func TestStatus(t *testing.T) {
 	assert.Equal(t, 1, st.NumUsersAdded)
 	assert.Equal(t, 1, st.NumUsersRemoved)
 
-	// Start again, and verify that start time does not change.
+	// Start again, and verify that start time got reset.
 	err = lt.Run()
 	require.NoError(t, err)
 	st = lt.Status()
-	assert.True(t, startTime.Equal(st.StartTime))
+	assert.True(t, startTime.Before(st.StartTime))
 	assert.Equal(t, StateRunning, st.State)
 }

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,7 +55,7 @@ func TestAddUser(t *testing.T) {
 	err := lt.AddUser()
 	require.Equal(t, ErrNotRunning, err)
 
-	lt.state = StateRunning
+	lt.status.State = StateRunning
 
 	ltConfig.UsersConfiguration.MaxActiveUsers = 0
 	err = lt.AddUser()
@@ -77,7 +78,7 @@ func TestRemoveUser(t *testing.T) {
 	err := lt.RemoveUser()
 	require.Equal(t, ErrNotRunning, err)
 
-	lt.state = StateRunning
+	lt.status.State = StateRunning
 
 	err = lt.RemoveUser()
 	require.Equal(t, ErrNoUsersLeft, err)
@@ -94,7 +95,7 @@ func TestRun(t *testing.T) {
 	lt := New(&ltConfig, newController)
 	err := lt.Run()
 	require.NoError(t, err)
-	require.Equal(t, lt.state, StateRunning)
+	require.Equal(t, lt.status.State, StateRunning)
 	require.Len(t, lt.controllers, ltConfig.UsersConfiguration.InitialActiveUsers)
 
 	err = lt.Run()
@@ -111,7 +112,7 @@ func TestStop(t *testing.T) {
 
 	err = lt.Run()
 	require.NoError(t, err)
-	lt.state = StateRunning
+	lt.status.State = StateRunning
 
 	numUsers := 8
 	for i := 0; i < numUsers; i++ {
@@ -120,6 +121,51 @@ func TestStop(t *testing.T) {
 	}
 	err = lt.Stop()
 	require.NoError(t, err)
-	require.Equal(t, lt.state, StateStopped)
+	require.Equal(t, lt.status.State, StateStopped)
 	require.Empty(t, lt.controllers)
+}
+
+func TestStatus(t *testing.T) {
+	lt := New(&ltConfig, newController)
+	require.NotNil(t, lt)
+
+	err := lt.Run()
+	require.NoError(t, err)
+	st := lt.Status()
+	startTime := st.StartTime
+	assert.Equal(t, StateRunning, st.State)
+	assert.Equal(t, 0, st.NumUsers)
+	assert.Equal(t, 0, st.NumUsersAdded)
+	assert.Equal(t, 0, st.NumUsersRemoved)
+
+	err = lt.AddUser()
+	require.NoError(t, err)
+	st = lt.Status()
+	assert.Equal(t, StateRunning, st.State)
+	assert.Equal(t, 1, st.NumUsers)
+	assert.Equal(t, 1, st.NumUsersAdded)
+	assert.Equal(t, 0, st.NumUsersRemoved)
+
+	err = lt.RemoveUser()
+	require.NoError(t, err)
+	st = lt.Status()
+	assert.Equal(t, StateRunning, st.State)
+	assert.Equal(t, 0, st.NumUsers)
+	assert.Equal(t, 1, st.NumUsersAdded)
+	assert.Equal(t, 1, st.NumUsersRemoved)
+
+	err = lt.Stop()
+	require.NoError(t, err)
+	st = lt.Status()
+	assert.Equal(t, StateStopped, st.State)
+	assert.Equal(t, 0, st.NumUsers)
+	assert.Equal(t, 1, st.NumUsersAdded)
+	assert.Equal(t, 1, st.NumUsersRemoved)
+
+	// Start again, and verify that start time does not change.
+	err = lt.Run()
+	require.NoError(t, err)
+	st = lt.Status()
+	assert.True(t, startTime.Equal(st.StartTime))
+	assert.Equal(t, StateRunning, st.State)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We add various counters and state variables to the struct
and expose them through a method.

This will help us get more information about the running load test
and store the data to be analyzed later.

While at it, we also add a AddUser/RemoveUser call in main.go
to help test race conditions. I had to do this every time manually
and thought it would be good to just keep it there.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21505
