### PR TITLE
MM-21676: Fix panic on closed channel

### DIFF
--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -141,6 +141,7 @@ func (lt *LoadTester) Run() error {
 	lt.status.NumUsersAdded = 0
 	lt.status.NumErrors = 0
 	lt.status.StartTime = time.Now()
+	lt.statusChan = make(chan control.UserStatus, lt.config.UsersConfiguration.MaxActiveUsers)
 	go lt.handleStatus()
 	for i := 0; i < lt.config.UsersConfiguration.InitialActiveUsers; i++ {
 		if err := lt.addUser(); err != nil {

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -105,6 +105,21 @@ func TestRun(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRerun(t *testing.T) {
+	lt := New(&ltConfig, newController)
+	err := lt.Run()
+	require.NoError(t, err)
+
+	err = lt.Stop()
+	require.NoError(t, err)
+
+	err = lt.Run()
+	require.NoError(t, err)
+
+	err = lt.Stop()
+	require.NoError(t, err)
+}
+
 func TestStop(t *testing.T) {
 	lt := New(&ltConfig, newController)
 	err := lt.Stop()


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Re-initialize the status channel when starting a run.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21676
