### PR TITLE
[MM-21842] Improve and cleanup load-test agent API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/gavv/httpexpect v2.0.0+incompatible
-	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/gorilla/mux v1.7.3
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
-github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -175,6 +175,7 @@ func (lt *LoadTester) Status() Status {
 // function is also given to enable the creation of UserController values from within the
 // loadtest package.
 func New(config *config.LoadTestConfig, nc NewController) *LoadTester {
+	// TODO: add config validation
 	if config == nil || nc == nil {
 		return nil
 	}


### PR DESCRIPTION
#### Summary

This PR makes some minor modifications to the API that will be needed for the upcoming load agent coordinator implementation.

The most important bits:

- Switch to `/addusers` and `/removeusers` endpoints.
- Add a GET `/loadagent/{id}` endpoint.
- Make `api.APIResponse` fully JSON serializable and rename it to `api.Response`.
- Make returned messages and function names consistent.
- Make `/loadagent/create` require an `id` instead of generating one. This is particularly important so we can have better control on what we run and make everything predictable. Using `UUIDs` was not wrong but just an overkill for the current use case. I feel it's better for now to leave the `coordinator` decide how to name/identify the agents in the cluster.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21842
