### PR TITLE
[MM-21850] Let LoadTester API user define basic user's information

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -64,6 +64,9 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		ueConfig := userentity.Config{
 			ServerURL:    config.ConnectionConfiguration.ServerURL,
 			WebSocketURL: config.ConnectionConfiguration.WebSocketURL,
+			Username:     fmt.Sprintf("%s-user%d", u.String(), id),
+			Email:        fmt.Sprintf("%s-user%d@example.com", u.String(), id),
+			Password:     "testPass123$",
 		}
 		ue := userentity.New(memstore.New(), ueConfig)
 		return simplecontroller.New(id, ue, status)

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/config"
@@ -23,6 +24,9 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		ueConfig := userentity.Config{
 			ServerURL:    config.ConnectionConfiguration.ServerURL,
 			WebSocketURL: config.ConnectionConfiguration.WebSocketURL,
+			Username:     fmt.Sprintf("testuser-%d", id),
+			Email:        fmt.Sprintf("testuser-%d@example.com", id),
+			Password:     "testPass123$",
 		}
 		ue := userentity.New(memstore.New(), ueConfig)
 		return simplecontroller.New(id, ue, status)

--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -37,6 +37,27 @@ func (s *SampleStore) Id() string {
 	return s.user.Id
 }
 
+func (s *SampleStore) Username() string {
+	if s.user == nil {
+		return ""
+	}
+	return s.user.Username
+}
+
+func (s *SampleStore) Email() string {
+	if s.user == nil {
+		return ""
+	}
+	return s.user.Email
+}
+
+func (s *SampleStore) Password() string {
+	if s.user == nil {
+		return ""
+	}
+	return s.user.Password
+}
+
 func (s *SampleStore) Config() model.Config {
 	return *s.config
 }

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -23,16 +23,16 @@ func (c *SimpleController) signUp() control.UserStatus {
 		return c.newInfoStatus("user already signed up")
 	}
 
-	email := fmt.Sprintf("testuser%d@example.com", c.id)
-	username := fmt.Sprintf("testuser%d", c.id)
-	password := "testPass123$"
+	email := c.user.Store().Email()
+	username := c.user.Store().Username()
+	password := c.user.Store().Password()
 
 	err := c.user.SignUp(email, username, password)
 	if err != nil {
 		return c.newErrorStatus(err)
 	}
 
-	return c.newInfoStatus("signed up")
+	return c.newInfoStatus(fmt.Sprintf("signed up as %s", username))
 }
 
 func (c *SimpleController) login() control.UserStatus {

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -48,6 +48,27 @@ func (s *MemStore) Id() string {
 	return s.user.Id
 }
 
+func (s *MemStore) Username() string {
+	if s.user == nil {
+		return ""
+	}
+	return s.user.Username
+}
+
+func (s *MemStore) Email() string {
+	if s.user == nil {
+		return ""
+	}
+	return s.user.Email
+}
+
+func (s *MemStore) Password() string {
+	if s.user == nil {
+		return ""
+	}
+	return s.user.Password
+}
+
 func (s *MemStore) Config() model.Config {
 	return *s.config
 }

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -12,6 +12,13 @@ import (
 type UserStore interface {
 	// Id of the user.
 	Id() string
+	// Username of the user.
+	Username() string
+	// Email of the user.
+	Email() string
+	// Password of the user.
+	Password() string
+
 	// TODO: Move all getters to this interface
 
 	// Config return the server configuration settings.

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -34,6 +34,9 @@ func (th *TestHelper) CreateUser() *UserEntity {
 	u := New(s, Config{
 		th.config.ConnectionConfiguration.ServerURL,
 		th.config.ConnectionConfiguration.WebSocketURL,
+		"testuser",
+		"testuser@example.com",
+		"testpassword",
 	})
 	require.NotNil(th.tb, u)
 	return u

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -31,6 +31,12 @@ type Config struct {
 	ServerURL string
 	// The URL of the mattermost WebSocket server.
 	WebSocketURL string
+	// The username to be used by the entity.
+	Username string
+	// The email to be used by the entity.
+	Email string
+	// The password to be used by the entity.
+	Password string
 }
 
 // Store returns the underlying store of the user.
@@ -57,6 +63,14 @@ func New(store store.MutableUserStore, config Config) *UserEntity {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 	ue.client.HttpClient = &http.Client{Transport: transport}
+	err := store.SetUser(&model.User{
+		Username: config.Username,
+		Email:    config.Email,
+		Password: config.Password,
+	})
+	if err != nil {
+		return nil
+	}
 	ue.store = store
 	return &ue
 }

--- a/loadtest/user/userentity/user_test.go
+++ b/loadtest/user/userentity/user_test.go
@@ -11,9 +11,9 @@ func TestGetUserFromStore(t *testing.T) {
 	th := Setup(t).Init()
 
 	user, err := th.User.getUserFromStore()
-	require.Nil(t, user)
-	require.Error(t, err)
-	require.EqualError(t, err, "user was not initialized")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.Empty(t, user.Id)
 
 	err = th.User.store.SetUser(&model.User{
 		Id: "someid",


### PR DESCRIPTION
#### Summary

Right now the required information to signup a user (username, email and password) are hardcoded in the `SimpleController` implementation. This PR makes those fields configurable from the upper layer (the user of the `LoadTester` API).   
This will be particularly useful to the upcoming coordinator implementation as it will help making sure we have complete control over users and guarantee uniqueness among the whole load agent cluster.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21850
