### PR TITLE
[MM-21647] First implementation for the load-test agent coordinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ sessions.db
 
 # ignore local config
 config/config.json
+config/coordinator.json
 
 /terraformenv
 .idea

--- a/api/server.go
+++ b/api/server.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package api
 
 import (
@@ -6,7 +9,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
@@ -36,7 +38,7 @@ func writeResponse(w http.ResponseWriter, status int, response *Response) {
 }
 
 func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
-	var config config.LoadTestConfig
+	var config loadtest.LoadTestConfig
 	err := json.NewDecoder(r.Body).Decode(&config)
 	if err != nil {
 		writeResponse(w, http.StatusBadRequest, &Response{

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
 	"github.com/gavv/httpexpect"
 	"github.com/stretchr/testify/require"
@@ -31,7 +31,7 @@ func TestAPI(t *testing.T) {
 		Status(http.StatusNotFound)
 
 	sampleConfigBytes, _ := ioutil.ReadFile("../config/config.default.json")
-	var sampleConfig config.LoadTestConfig
+	var sampleConfig loadtest.LoadTestConfig
 	_ = json.Unmarshal(sampleConfigBytes, &sampleConfig)
 	sampleConfig.ConnectionConfiguration.ServerURL = "http://fakesitetotallydoesntexist.com"
 	sampleConfig.UsersConfiguration.MaxActiveUsers = 100

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -29,7 +28,8 @@ func RunCoordinatorCmdF(cmd *cobra.Command, args []string) error {
 	}
 	c, err := coordinator.New(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create coordinator \n%w", err)
+		mlog.Error("failed to create coordinator", mlog.Err(err))
+		return err
 	}
 	return c.Run()
 }

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
+	"github.com/spf13/cobra"
+)
+
+func RunCoordinatorCmdF(cmd *cobra.Command, args []string) error {
+	cfg, err := coordinator.GetConfig()
+	if err != nil {
+		return err
+	}
+	ltConfig, err := loadtest.GetConfig()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < len(cfg.ClusterConfig.Agents); i++ {
+		cfg.ClusterConfig.Agents[i].LoadTestConfig = *ltConfig
+	}
+	c, err := coordinator.New(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create coordinator \n%w", err)
+	}
+	return c.Run()
+}
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:     "coordinator",
+		RunE:    RunCoordinatorCmdF,
+		PreRunE: initConfig,
+	}
+	rootCmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
+	rootCmd.PersistentFlags().StringP("ltconfig", "l", "", "path to the load-test configuration file to use")
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func initConfig(cmd *cobra.Command, args []string) error {
+	configFilePath, _ := cmd.Flags().GetString("config")
+	if err := coordinator.ReadConfig(configFilePath); err != nil {
+		return err
+	}
+	return initLoadTestConfig(cmd, args)
+}
+
+func initLoadTestConfig(cmd *cobra.Command, args []string) error {
+	configFilePath, _ := cmd.Flags().GetString("ltconfig")
+	if err := loadtest.ReadConfig(configFilePath); err != nil {
+		return err
+	}
+
+	cfg, err := loadtest.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	// Initalize logging
+	log := mlog.NewLogger(&mlog.LoggerConfiguration{
+		EnableConsole: cfg.LogSettings.EnableConsole,
+		ConsoleJson:   cfg.LogSettings.ConsoleJson,
+		ConsoleLevel:  strings.ToLower(cfg.LogSettings.ConsoleLevel),
+		EnableFile:    cfg.LogSettings.EnableFile,
+		FileJson:      cfg.LogSettings.FileJson,
+		FileLevel:     strings.ToLower(cfg.LogSettings.FileLevel),
+		FileLocation:  cfg.LogSettings.FileLocation,
+	})
+
+	// Redirect default golang logger to this logger
+	mlog.RedirectStdLog(log)
+
+	// Use this app logger as the global logger
+	mlog.InitGlobalLogger(log)
+
+	return nil
+}

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -11,12 +11,10 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/spf13/cobra"
-
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
 )
 
 func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
-	config, err := config.GetConfig()
+	config, err := loadtest.GetConfig()
 	if err != nil {
 		return err
 	}
@@ -54,7 +52,7 @@ func MakeLoadTestCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "loadtest",
 		RunE:   RunLoadTestCmdF,
-		PreRun: config.SetupLoadTest,
+		PreRun: SetupLoadTest,
 	}
 	cmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
 	return cmd

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
 	"os"
 
 	"github.com/mattermost/mattermost-load-test-ng/example"
@@ -25,7 +24,7 @@ func main() {
 			Use:    "example",
 			Short:  "Run example implementation",
 			RunE:   RunExampleCmdF,
-			PreRun: config.SetupLoadTest,
+			PreRun: SetupLoadTest,
 		},
 		MakeInitCommand(),
 		MakeServerCommand(),

--- a/cmd/loadtest/server.go
+++ b/cmd/loadtest/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
 	"net/http"
 
 	"github.com/mattermost/mattermost-load-test-ng/api"
@@ -22,7 +21,7 @@ func MakeServerCommand() *cobra.Command {
 		Use:    "server",
 		Short:  "Start API agent",
 		RunE:   RunServerCmdF,
-		PreRun: config.SetupLoadTest,
+		PreRun: SetupLoadTest,
 	}
 	cmd.PersistentFlags().IntP("port", "p", 4000, "Port to listen on")
 

--- a/config/coordinator.default.json
+++ b/config/coordinator.default.json
@@ -1,0 +1,15 @@
+{
+  "ClusterConfig": {
+    "Agents": [
+      {
+        "Id": "lt0",
+        "ApiURL": "http://localhost:4000"
+      },
+      {
+        "Id": "lt1",
+        "ApiURL": "http://localhost:4001"
+      }
+    ],
+    "MaxActiveUsers": 100
+  }
+}

--- a/coordinator/agent/agent.go
+++ b/coordinator/agent/agent.go
@@ -61,10 +61,7 @@ func (a *LoadAgent) AddUsers(n int) error {
 	if err != nil {
 		return err
 	}
-	if err := a.apiRequest(req); err != nil {
-		return err
-	}
-	return nil
+	return a.apiRequest(req)
 }
 
 func (a *LoadAgent) RemoveUsers(n int) error {
@@ -73,10 +70,7 @@ func (a *LoadAgent) RemoveUsers(n int) error {
 	if err != nil {
 		return err
 	}
-	if err := a.apiRequest(req); err != nil {
-		return err
-	}
-	return nil
+	return a.apiRequest(req)
 }
 
 func (a *LoadAgent) Start() error {
@@ -96,8 +90,6 @@ func (a *LoadAgent) Start() error {
 		return err
 	}
 
-	fmt.Printf("agent: agent %s created\n", a.config.Id)
-
 	url = fmt.Sprintf("%s/loadagent/%s/run", a.config.ApiURL, a.config.Id)
 	req, err = http.NewRequest("POST", url, nil)
 	if err != nil {
@@ -106,6 +98,8 @@ func (a *LoadAgent) Start() error {
 	if err := a.apiRequest(req); err != nil {
 		return err
 	}
+
+	fmt.Printf("agent: agent %s created\n", a.config.Id)
 
 	return nil
 }

--- a/coordinator/agent/agent.go
+++ b/coordinator/agent/agent.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/api"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
 // LoadAgent is the object acting as a client to the load-test agent
@@ -99,7 +101,7 @@ func (a *LoadAgent) Start() error {
 		return err
 	}
 
-	fmt.Printf("agent: agent %s created\n", a.config.Id)
+	mlog.Info("agent: agent created", mlog.String("agent_id", a.config.Id))
 
 	return nil
 }
@@ -113,7 +115,9 @@ func (a *LoadAgent) Stop() error {
 	if err := a.apiRequest(req); err != nil {
 		return err
 	}
-	fmt.Printf("agent: agent %s destroyed\n", a.config.Id)
+
+	mlog.Info("agent: agent destroyed", mlog.String("agent_id", a.config.Id))
+
 	return nil
 }
 

--- a/coordinator/agent/agent.go
+++ b/coordinator/agent/agent.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mattermost/mattermost-load-test-ng/api"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+)
+
+// LoadAgent is the object acting as a client to the load-test agent
+// HTTP API.
+type LoadAgent struct {
+	config LoadAgentConfig
+	status loadtest.Status
+	client *http.Client
+}
+
+// New creates and initializes a new LoadAgent for the given config.
+// An error is returned if the initialization fails.
+func New(config LoadAgentConfig) (*LoadAgent, error) {
+	if ok, err := config.IsValid(); !ok {
+		return nil, err
+	}
+	return &LoadAgent{
+		config: config,
+		status: loadtest.Status{},
+		client: &http.Client{},
+	}, nil
+}
+
+func (a *LoadAgent) apiRequest(req *http.Request) error {
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("agent: bad response status code %d", resp.StatusCode)
+	}
+	res := &api.Response{}
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	if err != nil {
+		return err
+	}
+	if res.Error != "" {
+		return fmt.Errorf("agent: api request error: %s", res.Error)
+	}
+	a.status = res.Status
+	return nil
+}
+
+func (a *LoadAgent) AddUsers(n int) error {
+	url := fmt.Sprintf("%s/loadagent/%s/addusers?amount=%d", a.config.ApiURL, a.config.Id, n)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return err
+	}
+	if err := a.apiRequest(req); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *LoadAgent) RemoveUsers(n int) error {
+	url := fmt.Sprintf("%s/loadagent/%s/removeusers?amount=%d", a.config.ApiURL, a.config.Id, n)
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return err
+	}
+	if err := a.apiRequest(req); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *LoadAgent) Start() error {
+	a.config.LoadTestConfig.UsersConfiguration.InitialActiveUsers = 0
+	configData, err := json.Marshal(a.config.LoadTestConfig)
+	if err != nil {
+		return err
+	}
+
+	// TODO: unify the API requests, making the following code less verbose/repetitive.
+	url := fmt.Sprintf("%s/loadagent/create?id=%s", a.config.ApiURL, a.config.Id)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(configData))
+	if err != nil {
+		return err
+	}
+	if err := a.apiRequest(req); err != nil {
+		return err
+	}
+
+	fmt.Printf("agent: agent %s created\n", a.config.Id)
+
+	url = fmt.Sprintf("%s/loadagent/%s/run", a.config.ApiURL, a.config.Id)
+	req, err = http.NewRequest("POST", url, nil)
+	if err != nil {
+		return err
+	}
+	if err := a.apiRequest(req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *LoadAgent) Stop() error {
+	url := fmt.Sprintf("%s/loadagent/%s", a.config.ApiURL, a.config.Id)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+	if err := a.apiRequest(req); err != nil {
+		return err
+	}
+	fmt.Printf("agent: agent %s destroyed\n", a.config.Id)
+	return nil
+}
+
+func (a *LoadAgent) Status() loadtest.Status {
+	return a.status
+}

--- a/coordinator/agent/config.go
+++ b/coordinator/agent/config.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package agent
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+)
+
+// LoadAgentConfig holds information about the load-test agent instance.
+type LoadAgentConfig struct {
+	// A sring that identifies the load-test agent instance.
+	Id string
+	// The API URL used to control the specified load-test instance.
+	ApiURL string
+	// The configuration for the load-test to run.
+	LoadTestConfig loadtest.LoadTestConfig
+}
+
+// IsValid checks whether a LoadAgentConfig is valid or not.
+// Returns an error if the validtation fails.
+func (c LoadAgentConfig) IsValid() (bool, error) {
+	if c.Id == "" {
+		return false, fmt.Errorf("Id should not be empty")
+	}
+	if c.ApiURL == "" {
+		return false, fmt.Errorf("ApiURL should not be empty")
+	}
+	return c.LoadTestConfig.IsValid()
+}

--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
+)
+
+// LoadAgentCluster is the object holding information about all the load-test
+// agents available in the cluster.
+type LoadAgentCluster struct {
+	config LoadAgentClusterConfig
+	agents []*agent.LoadAgent
+}
+
+// New creates and initializes a new LoadAgentCluster for the given config.
+// An error is returned if the initialization fails.
+func New(config LoadAgentClusterConfig) (*LoadAgentCluster, error) {
+	if ok, err := config.IsValid(); !ok {
+		return nil, err
+	}
+	agents := make([]*agent.LoadAgent, len(config.Agents))
+	for i := 0; i < len(agents); i++ {
+		agent, err := agent.New(config.Agents[i])
+		if err != nil {
+			return nil, fmt.Errorf("cluster: failed to create agent \n%w", err)
+		}
+		agents[i] = agent
+	}
+	return &LoadAgentCluster{
+		agents: agents,
+		config: config,
+	}, nil
+}
+
+// Run starts all the load-test agents available in the cluster.
+func (c *LoadAgentCluster) Run() error {
+	for _, agent := range c.agents {
+		err := agent.Start()
+		if err != nil {
+			return fmt.Errorf("cluster: failed to start agent.\n%w", err)
+		}
+	}
+	return nil
+}
+
+// Stop stops all the load-test agents available in the cluster.
+func (c *LoadAgentCluster) Stop() error {
+	for _, agent := range c.agents {
+		err := agent.Stop()
+		if err != nil {
+			return fmt.Errorf("cluster: failed to stop agent.\n%w", err)
+		}
+	}
+	return nil
+}
+
+// IncrementUsers increments the total number of active users in the load-test
+// custer by the provided amount.
+func (c *LoadAgentCluster) IncrementUsers(n int) error {
+	if len(c.agents) == 0 {
+		return nil
+	}
+	// TODO: Make this smarter. Implement an algorithm to make sure users are
+	// distributed evenly across the agents regardless of the input value and number of
+	// agents available.
+	inc := int(n / len(c.agents))
+	for i, agent := range c.agents {
+		fmt.Printf("cluster: adding %d users to %s\n", inc, c.config.Agents[i].Id)
+		if err := agent.AddUsers(inc); err != nil {
+			return fmt.Errorf("cluster: failed to add users to agent.\n%w", err)
+		}
+	}
+	return nil
+}
+
+// DecrementUsers decrements the total number of active users in the load-test
+// custer by the provided amount.
+func (c *LoadAgentCluster) DecrementUsers(n int) error {
+	return fmt.Errorf("cluster: not implemented")
+}
+
+// Status returns the current status of the LoadAgentCluster.
+func (c *LoadAgentCluster) Status() Status {
+	var status Status
+	for _, agent := range c.agents {
+		st := agent.Status()
+		status.ActiveUsers += st.NumUsers
+		status.NumErrors += st.NumErrors
+	}
+	return status
+}

--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -58,6 +58,17 @@ func (c *LoadAgentCluster) Stop() error {
 	return nil
 }
 
+// Shutdown stops all the load-test agents available in the cluster.
+// It differs from Stop() as it won't return early in case of an error.
+// It makes sure agent.Stop() is called once for every agent in the cluster.
+func (c *LoadAgentCluster) Shutdown() {
+	for _, agent := range c.agents {
+		if err := agent.Stop(); err != nil {
+			fmt.Printf("cluster: failed to stop agent.\n %s\n", err.Error())
+		}
+	}
+}
+
 // IncrementUsers increments the total number of active users in the load-test
 // custer by the provided amount.
 func (c *LoadAgentCluster) IncrementUsers(n int) error {

--- a/coordinator/cluster/config.go
+++ b/coordinator/cluster/config.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
+)
+
+// LoadAgentClusterConfig holds information regarding the cluster of load-test
+// agents.
+type LoadAgentClusterConfig struct {
+	// Agents is a list of the load-test agents API endpoints to be used during
+	// the load-test. It's length defines the number of load-test instances
+	// used during a load-test.
+	Agents []agent.LoadAgentConfig
+	// MaxActiveUsers defines the upper limit of concurrently active users to run across
+	// the whole cluster.
+	MaxActiveUsers int
+}
+
+// IsValid checks whether a LoadAgentClusterConfig is valid or not.
+// Returns an error if the validtation fails.
+func (c LoadAgentClusterConfig) IsValid() (bool, error) {
+	if len(c.Agents) == 0 {
+		return false, fmt.Errorf("no agents configured. At least one agent should be provided.")
+	}
+	if c.MaxActiveUsers == 0 {
+		return false, fmt.Errorf("MaxActiveUsers should be greated than 0.")
+	}
+	return true, nil
+}

--- a/coordinator/cluster/status.go
+++ b/coordinator/cluster/status.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package cluster
+
+type Status struct {
+	ActiveUsers int
+	NumErrors   int64
+}

--- a/coordinator/config.go
+++ b/coordinator/config.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package coordinator
+
+import (
+	"strings"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+)
+
+// CoordinatorConfig holds the necessary information to drive a cluster of
+// load-test agents performing a load-test on a target instance.
+type CoordinatorConfig struct {
+	// ClusterConfig defines the load-test agent cluster configuration.
+	ClusterConfig cluster.LoadAgentClusterConfig
+}
+
+var v = viper.New()
+
+func ReadConfig(configFilePath string) error {
+	v.SetConfigName("coordinator")
+	v.AddConfigPath(".")
+	v.AddConfigPath("./config/")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.AutomaticEnv()
+
+	if configFilePath != "" {
+		v.SetConfigFile(configFilePath)
+	}
+
+	if err := v.ReadInConfig(); err != nil {
+		return errors.Wrap(err, "unable to read configuration file")
+	}
+
+	return nil
+}
+
+func GetConfig() (*CoordinatorConfig, error) {
+	var cfg *CoordinatorConfig
+
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// IsValid checks whether a CoordinatorConfig is valid or not.
+// Returns an error if the validtation fails.
+func (c *CoordinatorConfig) IsValid() (bool, error) {
+	return true, nil
+}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -29,7 +29,9 @@ func (c *Coordinator) Run() error {
 	signal.Notify(interruptChannel, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	if err := c.cluster.Run(); err != nil {
-		return fmt.Errorf("coordinator: running cluster failed \n%w", err)
+		fmt.Printf("coordinator: running cluster failed \n%s\n", err.Error())
+		c.cluster.Shutdown()
+		return err
 	}
 
 	for {
@@ -53,7 +55,8 @@ func (c *Coordinator) Run() error {
 		select {
 		case <-interruptChannel:
 			fmt.Printf("coordinator: shutting down\n")
-			return c.cluster.Stop()
+			c.cluster.Shutdown()
+			return nil
 		case <-time.After(1 * time.Second):
 		}
 

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package coordinator
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
+)
+
+// Coordinator is the object used to coordinate a cluster of
+// load-test agents.
+type Coordinator struct {
+	config  *CoordinatorConfig
+	cluster *cluster.LoadAgentCluster
+	// monitor *Monitor
+}
+
+// Run starts a cluster of load-test agents.
+func (c *Coordinator) Run() error {
+	fmt.Printf("coordinator: ready to drive a cluster of %d load-test agents\n", len(c.config.ClusterConfig.Agents))
+
+	interruptChannel := make(chan os.Signal, 1)
+	signal.Notify(interruptChannel, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	if err := c.cluster.Run(); err != nil {
+		return fmt.Errorf("coordinator: running cluster failed \n%w", err)
+	}
+
+	for {
+		status := c.cluster.Status()
+		fmt.Printf("coordinator: cluster status: %d active users, %d errors\n", status.ActiveUsers, status.NumErrors)
+
+		if status.ActiveUsers < c.config.ClusterConfig.MaxActiveUsers {
+			// TODO: make the choice of this value a bit smarter.
+			inc := 10
+			diff := c.config.ClusterConfig.MaxActiveUsers - status.ActiveUsers
+			if diff < inc {
+				inc = diff
+			}
+			fmt.Printf("coordinator: incrementing active users by %d\n", inc)
+			err := c.cluster.IncrementUsers(inc)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+		}
+
+		select {
+		case <-interruptChannel:
+			fmt.Printf("coordinator: shutting down\n")
+			return c.cluster.Stop()
+		case <-time.After(1 * time.Second):
+		}
+
+		// TODO: implement performance monitoring and act on them to complete feedback loop.
+	}
+}
+
+// New creates and initializes a new Coordinator for the given config.
+// An error is returned if the initialization fails.
+func New(config *CoordinatorConfig) (*Coordinator, error) {
+	if config == nil {
+		return nil, fmt.Errorf("coordinator: config should not be nil")
+	}
+	if ok, err := config.IsValid(); !ok {
+		return nil, err
+	}
+	cluster, err := cluster.New(config.ClusterConfig)
+	if err != nil {
+		return nil, fmt.Errorf("coordinator: failed to create cluster \n%w", err)
+	}
+	return &Coordinator{
+		config:  config,
+		cluster: cluster,
+	}, nil
+}

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -1,18 +1,15 @@
 // Copyright (c) 2019 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information
 
-package config
+package loadtest
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
@@ -52,24 +49,6 @@ type LoggerSettings struct {
 	FileJson      bool
 	FileLevel     string
 	FileLocation  string
-}
-
-func SetupLoadTest(cmd *cobra.Command, args []string) {
-	configFilePath, _ := cmd.Flags().GetString("config")
-
-	if err := ReadConfig(configFilePath); err != nil {
-		mlog.Error("Failed to initialize config", mlog.Err(err))
-		os.Exit(1)
-	}
-
-	cfg, err := GetConfig()
-
-	if err != nil {
-		mlog.Error("Failed to get logging config:", mlog.Err(err))
-		os.Exit(1)
-	}
-
-	logger.Init(&cfg.LogSettings)
 }
 
 func ReadConfig(configFilePath string) error {

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -271,7 +271,7 @@ func (c *SimpleController) searchUsers() control.UserStatus {
 
 func (c *SimpleController) updateProfile() control.UserStatus {
 	userId := c.user.Store().Id()
-	userName := fmt.Sprintf("testuserNew%d", c.id)
+	userName := fmt.Sprintf("%s-new", c.user.Store().Username())
 	nickName := fmt.Sprintf("testNickName%d", c.id)
 	firstName := fmt.Sprintf("firstName%d", c.id)
 	lastName := fmt.Sprintf("lastName%d", c.id)

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
@@ -17,7 +16,7 @@ import (
 type LoadTester struct {
 	mut           sync.RWMutex
 	controllers   []control.UserController
-	config        *config.LoadTestConfig
+	config        *LoadTestConfig
 	wg            sync.WaitGroup
 	statusChan    chan control.UserStatus
 	status        Status
@@ -173,7 +172,7 @@ func (lt *LoadTester) Status() Status {
 // New creates and initializes a new LoadTester with given config. A factory
 // function is also given to enable the creation of UserController values from within the
 // loadtest package.
-func New(config *config.LoadTestConfig, nc NewController) *LoadTester {
+func New(config *LoadTestConfig, nc NewController) *LoadTester {
 	// TODO: add config validation
 	if config == nil || nc == nil {
 		return nil

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -6,7 +6,6 @@ package loadtest
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
@@ -17,12 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var ltConfig = config.LoadTestConfig{
-	ConnectionConfiguration: config.ConnectionConfiguration{
+var ltConfig = LoadTestConfig{
+	ConnectionConfiguration: ConnectionConfiguration{
 		ServerURL:    "http://localhost:8065",
 		WebSocketURL: "ws://localhost:8065",
 	},
-	UsersConfiguration: config.UsersConfiguration{
+	UsersConfiguration: UsersConfiguration{
 		MaxActiveUsers:     8,
 		InitialActiveUsers: 0,
 	},

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -3,7 +3,7 @@ package userentity
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-load-test-ng/cmd/loadtest/config"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 
 	"github.com/stretchr/testify/require"
@@ -11,14 +11,14 @@ import (
 
 type TestHelper struct {
 	User   *UserEntity
-	config *config.LoadTestConfig
+	config *loadtest.LoadTestConfig
 	tb     testing.TB
 }
 
 func Setup(tb testing.TB) *TestHelper {
 	var th TestHelper
 	th.tb = tb
-	config, err := config.GetConfig()
+	config, err := loadtest.GetConfig()
 	require.Nil(th.tb, err)
 	require.NotNil(th.tb, config)
 	th.config = config


### PR DESCRIPTION
#### Summary

This PR proposes the first draft implementation for the load-test agent coordinator. This is a separate command that will help in running a load-test across a cluster of load-test agents. It will be the main tool used when running load-tests for production. 

The implementation is made by three main components/packages:

- `coordinator` (the highest level component that handles a cluster of load-test agents and reacts to performance degradation events).
- `cluster` (the layer in charge of incrementing/decrementing the number of concurrently active users across all the available agents and provide aggregated status reports).
- `agent` (a component that acts as a simple HTTP API client that interfaces with the load-test API that we recently implemented.)

I apologize in advance for the complete lack of tests and for some missing documentation. I've had to take a couple of shortcuts within the code and left a few TODOs to try and keep the PR as short as possible and also move development under the time constraints that we are facing (really want to get to a MVP demo next week).

#### Ticket

https://mattermost.atlassian.net/browse/MM-21647