### PR TITLE
Fix circleci schema violation. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,5 @@
 version: 2.1
 
-executors:
-  default:
-    docker:
-      - image: circleci/golang:1.13
-
 aliases:
 - &restore_cache
   restore_cache:
@@ -47,8 +42,8 @@ commands:
 
 jobs:
   test:
-    executor:
-      name: default
+    docker:
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - install-golangci-lint


### PR DESCRIPTION
The created named circleCI executor is causing schema violations. Not using a named schema executor seems to fix it. 

