### PR TITLE
MM-21900: fix panic in userentity.postsMapToSlice

### DIFF
--- a/loadtest/user/userentity/utils.go
+++ b/loadtest/user/userentity/utils.go
@@ -3,7 +3,7 @@ package userentity
 import "github.com/mattermost/mattermost-server/v5/model"
 
 func postsMapToSlice(postsMap map[string]*model.Post) []*model.Post {
-	posts := make([]*model.Post, 0, len(postsMap))
+	posts := make([]*model.Post, len(postsMap))
 	i := 0
 	for _, v := range postsMap {
 		posts[i] = v

--- a/loadtest/user/userentity/utils_test.go
+++ b/loadtest/user/userentity/utils_test.go
@@ -1,0 +1,23 @@
+package userentity
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostsMapToSlice(t *testing.T) {
+	postsMap := make(map[string]*model.Post)
+
+	id1 := model.NewId()
+	id2 := model.NewId()
+	postsMap[id1] = &model.Post{Id: id1}
+	postsMap[id2] = &model.Post{Id: id2}
+
+	assert.Len(t, postsMapToSlice(postsMap), 2)
+
+	postsMap = map[string]*model.Post{}
+	assert.Len(t, postsMapToSlice(postsMap), 0)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
If we are setting 0 len with x cap, we should use append call.
If we are setting x len, we should use indices.

We were mixing the two. Fixed it now to set x len.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-21900