### PR TITLE
MM-21897: Fix failing actions in simpleController

### DIFF
--- a/cmd/loadtest/init.go
+++ b/cmd/loadtest/init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"time"
 
@@ -28,6 +29,32 @@ func createTeams(admin *userentity.UserEntity, numTeams int) error {
 			return err
 		}
 		mlog.Info("team created", mlog.String("team_id", id))
+		err = admin.GetTeam(id)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createChannels(admin *userentity.UserEntity, numChannels int) error {
+	channelTypes := []string{"O", "P"}
+
+	for i := 0; i < numChannels; i++ {
+		team, err := admin.Store().RandomTeam()
+		if err != nil {
+			return err
+		}
+
+		id, err := admin.CreateChannel(&model.Channel{
+			Name:   model.NewId(),
+			TeamId: team.Id,
+			Type:   channelTypes[rand.Intn(len(channelTypes))],
+		})
+		if err != nil {
+			return err
+		}
+		mlog.Info("channel created", mlog.String("channel_id", id))
 	}
 	return nil
 }
@@ -64,6 +91,10 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if err = createTeams(admin, numTeams); err != nil {
+		return err
+	}
+
+	if err = createChannels(admin, 10); err != nil {
 		return err
 	}
 

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -186,7 +186,7 @@ func (c *SimpleController) createPost() control.UserStatus {
 
 func (c *SimpleController) addReaction() control.UserStatus {
 	// get posts from UserStore that have been created in the last minute
-	posts, err := c.user.Store().PostsSince(time.Now().Unix()*1000 - 60000)
+	posts, err := c.user.Store().PostsSince(time.Now().Add(-1*time.Minute).Unix() * 1000)
 	if err != nil {
 		return c.newErrorStatus(err)
 	}
@@ -209,7 +209,7 @@ func (c *SimpleController) addReaction() control.UserStatus {
 
 func (c *SimpleController) removeReaction() control.UserStatus {
 	// get posts from UserStore that have been created in the last minute
-	posts, err := c.user.Store().PostsSince(time.Now().Unix()*1000 - 60000)
+	posts, err := c.user.Store().PostsSince(time.Now().Add(-1*time.Minute).Unix() * 1000)
 	if err != nil {
 		return c.newErrorStatus(err)
 	}

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -45,6 +45,18 @@ func (c *SimpleController) login() control.UserStatus {
 
 	c.connect()
 
+	// Populate teams and channels.
+	teamIds, err := c.user.GetAllTeams(0, 100)
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+	for _, teamId := range teamIds {
+		err := c.user.GetChannelsForTeam(teamId)
+		if err != nil {
+			return c.newErrorStatus(err)
+		}
+	}
+
 	return c.newInfoStatus("logged in")
 }
 
@@ -162,6 +174,7 @@ func (c *SimpleController) createPost() control.UserStatus {
 	postId, err := c.user.CreatePost(&model.Post{
 		Message:   "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 		ChannelId: channel.Id,
+		CreateAt:  time.Now().Unix() * 1000,
 	})
 
 	if err != nil {
@@ -173,7 +186,7 @@ func (c *SimpleController) createPost() control.UserStatus {
 
 func (c *SimpleController) addReaction() control.UserStatus {
 	// get posts from UserStore that have been created in the last minute
-	posts, err := c.user.Store().PostsSince(time.Now().Unix()*1000 + 60000)
+	posts, err := c.user.Store().PostsSince(time.Now().Unix()*1000 - 60000)
 	if err != nil {
 		return c.newErrorStatus(err)
 	}
@@ -196,7 +209,7 @@ func (c *SimpleController) addReaction() control.UserStatus {
 
 func (c *SimpleController) removeReaction() control.UserStatus {
 	// get posts from UserStore that have been created in the last minute
-	posts, err := c.user.Store().PostsSince(time.Now().Unix()*1000 + 60000)
+	posts, err := c.user.Store().PostsSince(time.Now().Unix()*1000 - 60000)
 	if err != nil {
 		return c.newErrorStatus(err)
 	}
@@ -238,43 +251,43 @@ func (c *SimpleController) createGroupChannel() control.UserStatus {
 	return c.newInfoStatus(fmt.Sprintf("group channel created, id %v with users %+v", channelId, userIds))
 }
 
-func (c *SimpleController) createPublicChannel() control.UserStatus {
-	team, err := c.user.Store().RandomTeam()
-	if err != nil {
-		return c.newErrorStatus(err)
-	}
+// func (c *SimpleController) createPublicChannel() control.UserStatus {
+// 	team, err := c.user.Store().RandomTeam()
+// 	if err != nil {
+// 		return c.newErrorStatus(err)
+// 	}
 
-	channelId, err := c.user.CreateChannel(&model.Channel{
-		Name:   model.NewId(),
-		TeamId: team.Id,
-		Type:   "O",
-	})
+// 	channelId, err := c.user.CreateChannel(&model.Channel{
+// 		Name:   model.NewId(),
+// 		TeamId: team.Id,
+// 		Type:   "O",
+// 	})
 
-	if err != nil {
-		return c.newErrorStatus(err)
-	}
+// 	if err != nil {
+// 		return c.newErrorStatus(err)
+// 	}
 
-	return c.newInfoStatus(fmt.Sprintf("public channel created, id %v", channelId))
-}
+// 	return c.newInfoStatus(fmt.Sprintf("public channel created, id %v", channelId))
+// }
 
-func (c *SimpleController) createPrivateChannel() control.UserStatus {
-	team, err := c.user.Store().RandomTeam()
-	if err != nil {
-		return c.newErrorStatus(err)
-	}
+// func (c *SimpleController) createPrivateChannel() control.UserStatus {
+// 	team, err := c.user.Store().RandomTeam()
+// 	if err != nil {
+// 		return c.newErrorStatus(err)
+// 	}
 
-	channelId, err := c.user.CreateChannel(&model.Channel{
-		Name:   model.NewId(),
-		TeamId: team.Id,
-		Type:   "P",
-	})
+// 	channelId, err := c.user.CreateChannel(&model.Channel{
+// 		Name:   model.NewId(),
+// 		TeamId: team.Id,
+// 		Type:   "P",
+// 	})
 
-	if err != nil {
-		return c.newErrorStatus(err)
-	}
+// 	if err != nil {
+// 		return c.newErrorStatus(err)
+// 	}
 
-	return c.newInfoStatus(fmt.Sprintf("private channel created, id %v", channelId))
-}
+// 	return c.newInfoStatus(fmt.Sprintf("private channel created, id %v", channelId))
+// }
 
 func (c *SimpleController) createDirectChannel() control.UserStatus {
 	user, err := c.user.Store().RandomUser()
@@ -402,15 +415,12 @@ func (c *SimpleController) updateProfileImage() control.UserStatus {
 }
 
 func (c *SimpleController) searchChannels() control.UserStatus {
-	teams, err := c.user.Store().Teams()
+	team, err := c.user.Store().RandomTeam()
 	if err != nil {
 		return c.newErrorStatus(err)
 	}
-	if len(teams) == 0 {
-		return c.newInfoStatus("no teams to search for channels")
-	}
 
-	channels, err := c.user.SearchChannels(teams[0].Id, &model.ChannelSearch{
+	channels, err := c.user.SearchChannels(team.Id, &model.ChannelSearch{
 		Term: "test",
 	})
 	if err != nil {
@@ -421,15 +431,12 @@ func (c *SimpleController) searchChannels() control.UserStatus {
 }
 
 func (c *SimpleController) searchPosts() control.UserStatus {
-	teams, err := c.user.Store().Teams()
+	team, err := c.user.Store().RandomTeam()
 	if err != nil {
 		return c.newErrorStatus(err)
 	}
-	if len(teams) == 0 {
-		return c.newInfoStatus("no teams to search for posts")
-	}
 
-	list, err := c.user.SearchPosts(teams[0].Id, "test search", false)
+	list, err := c.user.SearchPosts(team.Id, "test search", false)
 	if err != nil {
 		return c.newErrorStatus(err)
 	}
@@ -584,6 +591,34 @@ func (c *SimpleController) reload(full bool) control.UserStatus {
 	}
 
 	return c.newInfoStatus("page reloaded")
+}
+
+func (c *SimpleController) viewUser() control.UserStatus {
+	team, err := c.user.Store().RandomTeam()
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+	channel, err := c.user.Store().RandomChannel(team.Id)
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+
+	err = c.user.GetChannelMembers(channel.Id, 0, 100)
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+
+	member, err := c.user.Store().RandomChannelMember(channel.Id)
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+
+	// GetUsersByIds for that userid
+	_, err = c.user.GetUsersByIds([]string{member.UserId})
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+	return c.newInfoStatus(fmt.Sprintf("viewed user %s", member.UserId))
 }
 
 func (c *SimpleController) connect() {

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -88,6 +88,10 @@ func (c *SimpleController) Run() {
 			waitAfter: 1000,
 		},
 		{
+			run:       c.viewUser,
+			waitAfter: 1000,
+		},
+		{
 			run:       c.createPost,
 			waitAfter: 1000,
 		},
@@ -107,14 +111,14 @@ func (c *SimpleController) Run() {
 			run:       c.createDirectChannel,
 			waitAfter: 1000,
 		},
-		{
-			run:       c.createPublicChannel,
-			waitAfter: 1000,
-		},
-		{
-			run:       c.createPrivateChannel,
-			waitAfter: 1000,
-		},
+		// {
+		// 	run:       c.createPublicChannel,
+		// 	waitAfter: 1000,
+		// },
+		// {
+		// 	run:       c.createPrivateChannel,
+		// 	waitAfter: 1000,
+		// },
 		{
 			run:       c.viewChannel,
 			waitAfter: 1000,

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -17,7 +17,6 @@ func (ue *UserEntity) SignUp(email, username, password string) error {
 	}
 
 	newUser, resp := ue.client.CreateUser(&user)
-
 	if resp.Error != nil {
 		return resp.Error
 	}
@@ -32,9 +31,15 @@ func (ue *UserEntity) Login() error {
 		return err
 	}
 
-	_, resp := ue.client.Login(user.Email, user.Password)
+	loggedUser, resp := ue.client.Login(user.Email, user.Password)
 	if resp.Error != nil {
 		return resp.Error
+	}
+
+	// We need to set user again because the user ID does not get set
+	// if a user is already signed up.
+	if err := ue.store.SetUser(loggedUser); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Create channels during the init phase.
- Populate teams and channels after login.
- Set the createAt time during creating a post, and fix the time search range
while searching for posts.
- Choose a channel randomly instead of the first channel.
- Added a viewUser action which populates the users in the store.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21897
