### PR TITLE
[MM-21896] Implement performance monitor and complete feedback loop

### DIFF
--- a/cmd/metricswatcher/config/config.go
+++ b/cmd/metricswatcher/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -17,21 +18,8 @@ import (
 
 type MetricsWatcherConfiguration struct {
 	LogSettings             logger.LoggerSettings
-	PrometheusConfiguration PrometheusConfiguration
-	Queries                 []PrometheusQuery
-}
-
-type PrometheusConfiguration struct {
-	PrometheusURL                 string
-	MetricsUpdateIntervalInMS     int
-	HealthcheckUpdateIntervalInMS int
-}
-
-type PrometheusQuery struct {
-	Description string
-	Query       string
-	Threshold   float64
-	Alert       bool
+	PrometheusConfiguration prometheus.Configuration
+	Queries                 []prometheus.Query
 }
 
 func SetupMetricsCheck(cmd *cobra.Command, args []string) {

--- a/cmd/metricswatcher/metrics.go
+++ b/cmd/metricswatcher/metrics.go
@@ -5,13 +5,13 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/cmd/metricswatcher/config"
-	"github.com/mattermost/mattermost-load-test-ng/cmd/metricswatcher/prometheushelper"
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
-func checkMetrics(errChan chan error, configuration *config.MetricsWatcherConfiguration) {
-	prometheusHelper, err := prometheushelper.NewPrometheusHelper(configuration.PrometheusConfiguration.PrometheusURL)
+func checkMetrics(errChan chan error, config *config.MetricsWatcherConfiguration) {
+	helper, err := prometheus.NewHelper(config.PrometheusConfiguration.PrometheusURL)
 
 	if err != nil {
 		errChan <- err
@@ -19,15 +19,15 @@ func checkMetrics(errChan chan error, configuration *config.MetricsWatcherConfig
 	}
 
 	for {
-		checkQueries(prometheusHelper, configuration.Queries)
+		checkQueries(helper, config.Queries)
 
-		time.Sleep(time.Duration(configuration.PrometheusConfiguration.MetricsUpdateIntervalInMS) * time.Millisecond)
+		time.Sleep(time.Duration(config.PrometheusConfiguration.MetricsUpdateIntervalInMS) * time.Millisecond)
 	}
 }
 
-func checkQueries(prometheus *prometheushelper.PrometheusHelper, queries []config.PrometheusQuery) {
+func checkQueries(helper *prometheus.Helper, queries []prometheus.Query) {
 	for _, query := range queries {
-		value, err := prometheus.VectorFirst(query.Query)
+		value, err := helper.VectorFirst(query.Query)
 
 		if err != nil {
 			mlog.Error("Error while querying Prometheus:", mlog.String("query_description", query.Description), mlog.Err(err))

--- a/config/coordinator.default.json
+++ b/config/coordinator.default.json
@@ -11,5 +11,17 @@
       }
     ],
     "MaxActiveUsers": 100
+  },
+  "MonitorConfig": {
+    "PrometheusURL": "http://localhost:9090",
+    "UpdateInterval": 2000,
+    "Queries":  [
+        {
+            "Description": "Request duration",
+            "Query": "rate(mattermost_http_request_duration_seconds_sum[1m])/rate(mattermost_http_request_duration_seconds_count[1m])",
+            "Threshold": 0.2,
+            "Alert": true
+        }
+    ]
   }
 }

--- a/config/coordinator.default.json
+++ b/config/coordinator.default.json
@@ -14,7 +14,7 @@
   },
   "MonitorConfig": {
     "PrometheusURL": "http://localhost:9090",
-    "UpdateInterval": 2000,
+    "UpdateIntervalMs": 2000,
     "Queries":  [
         {
             "Description": "Request duration",

--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -93,7 +93,20 @@ func (c *LoadAgentCluster) IncrementUsers(n int) error {
 // DecrementUsers decrements the total number of active users in the load-test
 // custer by the provided amount.
 func (c *LoadAgentCluster) DecrementUsers(n int) error {
-	return fmt.Errorf("cluster: not implemented")
+	if len(c.agents) == 0 {
+		return nil
+	}
+	// TODO: Make this smarter. Implement an algorithm to make sure users are
+	// distributed evenly across the agents regardless of the input value and number of
+	// agents available.
+	dec := int(n / len(c.agents))
+	for i, agent := range c.agents {
+		mlog.Info("cluster: removing users from agent", mlog.Int("num_users", dec), mlog.String("agent_id", c.config.Agents[i].Id))
+		if err := agent.RemoveUsers(dec); err != nil {
+			return fmt.Errorf("cluster: failed to remove users from agent: %w", err)
+		}
+	}
+	return nil
 }
 
 // Status returns the current status of the LoadAgentCluster.

--- a/coordinator/config.go
+++ b/coordinator/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -17,6 +18,8 @@ import (
 type CoordinatorConfig struct {
 	// ClusterConfig defines the load-test agent cluster configuration.
 	ClusterConfig cluster.LoadAgentClusterConfig
+	// MonitorConfig holds the performance monitor configuration.
+	MonitorConfig performance.MonitorConfig
 }
 
 var v = viper.New()

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -49,10 +49,10 @@ func (c *Coordinator) Run() error {
 	// to the speed at which metrics are changing.
 
 	// The value of users to be incremented at each iteration.
-	// It should be proportional to the maximum number of users expected to test.
+	// TODO: It should be proportional to the maximum number of users expected to test.
 	const incValue = 8
 	// The value of users to be decremented at each iteration.
-	// It should be proportional to the maximum number of users expected to test.
+	// TODO: It should be proportional to the maximum number of users expected to test.
 	const decValue = 8
 	// The timespan to wait after a performance degradation alert before
 	// incrementing or decrementing users again.
@@ -75,7 +75,7 @@ func (c *Coordinator) Run() error {
 		status := c.cluster.Status()
 		mlog.Debug("coordinator: cluster status:", mlog.Int("active_users", status.ActiveUsers), mlog.Int64("errors", status.NumErrors))
 
-		// supportedUsers should be estimated in a more clever way in the future.
+		// TODO: supportedUsers should be estimated in a more clever way in the future.
 		// For now we say that the supported number of users is the number of active users that ran
 		// for the defined timespan without causing any performance degradation alert.
 		if !lastAlertTime.IsZero() && !perfStatus.Alert && hasPassed(lastAlertTime, restTime) && hasPassed(lastActionTime, restTime) {

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
@@ -20,7 +21,7 @@ import (
 type Coordinator struct {
 	config  *CoordinatorConfig
 	cluster *cluster.LoadAgentCluster
-	// monitor *Monitor
+	monitor *performance.Monitor
 }
 
 // Run starts a cluster of load-test agents.

--- a/coordinator/performance/config.go
+++ b/coordinator/performance/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package performance
 
 import (
@@ -6,17 +9,21 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
 )
 
+// MonitorConfig holds the necessary information to create a Monitor.
 type MonitorConfig struct {
-	PrometheusURL  string
-	UpdateInterval int
-	Queries        []prometheus.Query
+	// The URL of the Prometheus server to query.
+	PrometheusURL string
+	// The time interval in milliseconds to wait before querying again.
+	UpdateIntervalMs int
+	// The slice of queries to run.
+	Queries []prometheus.Query
 }
 
 func (c MonitorConfig) IsValid() (bool, error) {
 	if c.PrometheusURL == "" {
 		return false, fmt.Errorf("PrometheusURL cannot be empty")
 	}
-	if c.UpdateInterval < 1000 {
+	if c.UpdateIntervalMs < 1000 {
 		return false, fmt.Errorf("UpdateInterval cannot be less than 1000")
 	}
 	if len(c.Queries) == 0 {

--- a/coordinator/performance/config.go
+++ b/coordinator/performance/config.go
@@ -1,0 +1,26 @@
+package performance
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
+)
+
+type MonitorConfig struct {
+	PrometheusURL  string
+	UpdateInterval int
+	Queries        []prometheus.Query
+}
+
+func (c MonitorConfig) IsValid() (bool, error) {
+	if c.PrometheusURL == "" {
+		return false, fmt.Errorf("PrometheusURL cannot be empty")
+	}
+	if c.UpdateInterval < 1000 {
+		return false, fmt.Errorf("UpdateInterval cannot be less than 1000")
+	}
+	if len(c.Queries) == 0 {
+		return false, fmt.Errorf("Queries cannot be empty")
+	}
+	return true, nil
+}

--- a/coordinator/performance/monitor.go
+++ b/coordinator/performance/monitor.go
@@ -1,0 +1,4 @@
+package performance
+
+type Monitor struct {
+}

--- a/coordinator/performance/monitor.go
+++ b/coordinator/performance/monitor.go
@@ -1,4 +1,79 @@
 package performance
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
+)
+
 type Monitor struct {
+	config     MonitorConfig
+	helper     *prometheus.Helper
+	stopChan   chan struct{}
+	statusChan chan Status
+}
+
+func NewMonitor(config MonitorConfig) (*Monitor, error) {
+	if ok, err := config.IsValid(); !ok {
+		return nil, err
+	}
+	helper, err := prometheus.NewHelper(config.PrometheusURL)
+	if err != nil {
+		return nil, fmt.Errorf("performance: failed to create prometheus.Helper: %w", err)
+	}
+	return &Monitor{
+		config:     config,
+		helper:     helper,
+		stopChan:   make(chan struct{}),
+		statusChan: make(chan Status),
+	}, nil
+}
+
+func (m *Monitor) Run() (<-chan Status, error) {
+	go func() {
+		mlog.Info("monitor: started")
+		for {
+			m.statusChan <- m.runQueries()
+			select {
+			case <-m.stopChan:
+				mlog.Info("monitor: shutting down")
+				return
+			case <-time.After(time.Duration(m.config.UpdateInterval) * time.Millisecond):
+			}
+		}
+	}()
+	return m.statusChan, nil
+}
+
+func (m *Monitor) Stop() {
+	close(m.stopChan)
+}
+
+func (m *Monitor) runQueries() Status {
+	var status Status
+	for _, query := range m.config.Queries {
+		value, err := m.helper.VectorFirst(query.Query)
+		if err != nil {
+			mlog.Error("monitor: error while querying Prometheus:", mlog.String("query_description", query.Description), mlog.Err(err))
+			continue
+		}
+		mlog.Debug("monitor: ran query",
+			mlog.String("query_description", query.Description),
+			mlog.String("query_returned_value", fmt.Sprintf("%2.8f", value)),
+			mlog.String("query_threshold", fmt.Sprintf("%2.8f", query.Threshold)),
+		)
+		if query.Alert && value >= query.Threshold {
+			mlog.Warn("monitor: returned value is above the threshold",
+				mlog.String("query_description", query.Description),
+				mlog.String("query_returned_value", fmt.Sprintf("%2.8f", value)),
+				mlog.String("query_threshold", fmt.Sprintf("%2.8f", query.Threshold)),
+			)
+			status = Status{Alert: true}
+			break
+		}
+	}
+	return status
 }

--- a/coordinator/performance/prometheus/api.go
+++ b/coordinator/performance/prometheus/api.go
@@ -1,4 +1,4 @@
-package prometheushelper
+package prometheus
 
 import (
 	"context"
@@ -8,10 +8,10 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// prometheusAPI is a subset of Prometheus API interface.
+// API is a subset of Prometheus API interface.
 // https://github.com/prometheus/client_golang/blob/803ef2a759d7caaaa0de58e3815f1be4c8b5a42a/api/prometheus/v1/api.go#L218-L251
 // This subset allows us to implement in our tests only the functions we use,
 // while allowing compatibility with Prometheus API interface.
-type prometheusAPI interface {
+type API interface {
 	Query(ctx context.Context, query string, ts time.Time) (model.Value, apiv1.Warnings, error)
 }

--- a/coordinator/performance/prometheus/config.go
+++ b/coordinator/performance/prometheus/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package prometheus
 
 type Configuration struct {

--- a/coordinator/performance/prometheus/config.go
+++ b/coordinator/performance/prometheus/config.go
@@ -1,0 +1,14 @@
+package prometheus
+
+type Configuration struct {
+	PrometheusURL                 string
+	MetricsUpdateIntervalInMS     int
+	HealthcheckUpdateIntervalInMS int
+}
+
+type Query struct {
+	Description string
+	Query       string
+	Threshold   float64
+	Alert       bool
+}

--- a/coordinator/performance/prometheus/helper.go
+++ b/coordinator/performance/prometheus/helper.go
@@ -1,4 +1,4 @@
-package prometheushelper
+package prometheus
 
 import (
 	"context"
@@ -12,13 +12,13 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-type PrometheusHelper struct {
-	API prometheusAPI
+type Helper struct {
+	api API
 }
 
-// NewPrometheusHelper creates a helper with the standard Prometheus client
+// NewHelper creates a helper with the standard Prometheus client
 // and API inside it, encapsulating all Prometheus dependencies.
-func NewPrometheusHelper(prometheusURL string) (*PrometheusHelper, error) {
+func NewHelper(prometheusURL string) (*Helper, error) {
 	config := prometheus.Config{Address: prometheusURL}
 	client, err := prometheus.NewClient(config)
 
@@ -27,16 +27,16 @@ func NewPrometheusHelper(prometheusURL string) (*PrometheusHelper, error) {
 	}
 
 	api := apiv1.NewAPI(client)
-	prometheusHelper := &PrometheusHelper{api}
+	helper := &Helper{api}
 
-	return prometheusHelper, nil
+	return helper, nil
 }
 
-func (p PrometheusHelper) VectorFirst(query string) (float64, error) {
+func (p *Helper) VectorFirst(query string) (float64, error) {
 	context := context.Background()
 	ts := time.Now()
 
-	value, _, err := p.API.Query(context, query, ts)
+	value, _, err := p.api.Query(context, query, ts)
 
 	if err != nil {
 		return 0, err
@@ -45,7 +45,7 @@ func (p PrometheusHelper) VectorFirst(query string) (float64, error) {
 	return p.extractNumericValueFromFirstElement(value)
 }
 
-func (p PrometheusHelper) extractNumericValueFromFirstElement(value model.Value) (float64, error) {
+func (p *Helper) extractNumericValueFromFirstElement(value model.Value) (float64, error) {
 	if value.Type() != model.ValVector {
 		return 0, fmt.Errorf("Expected a vector, got a %s", value.Type().String())
 	}

--- a/coordinator/performance/prometheus/helper.go
+++ b/coordinator/performance/prometheus/helper.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package prometheus
 
 import (

--- a/coordinator/performance/prometheus/helper_test.go
+++ b/coordinator/performance/prometheus/helper_test.go
@@ -1,4 +1,4 @@
-package prometheushelper
+package prometheus
 
 import (
 	"context"
@@ -30,8 +30,8 @@ func Test_VectorFirst_ReturnsFloatValue(t *testing.T) {
 		value: model.Vector(vector),
 	}
 
-	prometheus := PrometheusHelper{api}
-	actualValue, err := prometheus.VectorFirst("some PromQL query")
+	helper := Helper{api}
+	actualValue, err := helper.VectorFirst("some PromQL query")
 
 	assert.Nil(t, err)
 	assert.Equal(t, expectedValue, actualValue)
@@ -42,8 +42,8 @@ func Test_VectorFirst_FailsIfItsNotAVector(t *testing.T) {
 		value: &model.String{Value: "oh no!"},
 	}
 
-	prometheus := PrometheusHelper{api}
-	actualValue, err := prometheus.VectorFirst("some PromQL query")
+	helper := Helper{api}
+	actualValue, err := helper.VectorFirst("some PromQL query")
 
 	assert.Equal(t, "Expected a vector, got a string", err.Error())
 	assert.Equal(t, float64(0), actualValue)

--- a/coordinator/performance/prometheus/sample_test.go
+++ b/coordinator/performance/prometheus/sample_test.go
@@ -1,4 +1,4 @@
-package prometheushelper
+package prometheus
 
 import (
 	"context"

--- a/coordinator/performance/status.go
+++ b/coordinator/performance/status.go
@@ -1,5 +1,11 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package performance
 
+// Status is a structure containing information on the performance status
+// of the target instance.
 type Status struct {
+	// A boolean value indicating if performance degradation occurred.
 	Alert bool
 }

--- a/coordinator/performance/status.go
+++ b/coordinator/performance/status.go
@@ -1,0 +1,5 @@
+package performance
+
+type Status struct {
+	Alert bool
+}

--- a/coordinator/utils.go
+++ b/coordinator/utils.go
@@ -1,0 +1,19 @@
+package coordinator
+
+import (
+	"time"
+)
+
+// hasPassed returns true if the provided duration has passed since the
+// provided time. Returns false otherwise.
+func hasPassed(t time.Time, d time.Duration) bool {
+	return time.Now().After(t.Add(d))
+}
+
+// min finds the minimum between the provided int values.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/coordinator/utils.go
+++ b/coordinator/utils.go
@@ -1,11 +1,14 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package coordinator
 
 import (
 	"time"
 )
 
-// hasPassed returns true if the provided duration has passed since the
-// provided time. Returns false otherwise.
+// hasPassed reports whether the provided duration
+// added with the given time is before the current time or not.
 func hasPassed(t time.Time, d time.Duration) bool {
 	return time.Now().After(t.Add(d))
 }

--- a/coordinator/utils_test.go
+++ b/coordinator/utils_test.go
@@ -1,0 +1,25 @@
+package coordinator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasPassed(t *testing.T) {
+	tm := time.Now()
+	require.False(t, hasPassed(tm, 1*time.Second))
+	time.Sleep(1 * time.Second)
+	require.True(t, hasPassed(tm, 500*time.Millisecond))
+	require.False(t, hasPassed(tm, 2*time.Second))
+}
+
+func TestMin(t *testing.T) {
+	require.Equal(t, 0, min(0, 1))
+	require.Equal(t, 0, min(1, 0))
+	require.Equal(t, 0, min(0, 0))
+	require.Equal(t, 1, min(1, 1))
+	require.Equal(t, 50, min(80, 50))
+	require.Equal(t, 30, min(100, 30))
+}

--- a/coordinator/utils_test.go
+++ b/coordinator/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package coordinator
 
 import (

--- a/loadtest/user/userentity/utils_test.go
+++ b/loadtest/user/userentity/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package userentity
 
 import (


### PR DESCRIPTION
#### Summary

PR implements the missing performance monitoring component by extracting some very useful code from the `metricswatcher` tool.
It also adds an initial implementation for the feedback loop that will regulate the number of concurrently active users to run.

This is all **very** experimental still. The idea is that we want to try and keep the loop as simple as possible (hard thing to do).  
I've left various comments throughout the code to explain some decisions and oversimplifications I took.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21896