### PR TITLE
MM-21559: React to websocket events

### DIFF
--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -52,6 +52,13 @@ func (u *SampleUser) Disconnect() error {
 	return nil
 }
 
+func (u *SampleUser) Events() <-chan *model.WebSocketEvent {
+	return nil
+}
+
+func (u *SampleUser) Cleanup() {
+}
+
 func (u *SampleUser) CreatePost(post *model.Post) (string, error) {
 	return "", nil
 }

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -184,6 +184,30 @@ func (c *SimpleController) createPost() control.UserStatus {
 	return c.newInfoStatus(fmt.Sprintf("post created, id %v", postId))
 }
 
+func (c *SimpleController) sendDirectMessage(userID string) control.UserStatus {
+	channelId := model.GetDMNameFromIds(userID, c.user.Store().Id())
+	ok, err := c.user.Store().Channel(channelId)
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+	// We check if a direct channel has been made between the users,
+	// and send the message only if it exists.
+	if ok == nil {
+		return c.newInfoStatus("skipping sending direct message")
+	}
+
+	postId, err := c.user.CreatePost(&model.Post{
+		Message:   "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+		ChannelId: channelId,
+		CreateAt:  time.Now().Unix() * 1000,
+	})
+	if err != nil {
+		return c.newErrorStatus(err)
+	}
+
+	return c.newInfoStatus(fmt.Sprintf("direct post created, id %v", postId))
+}
+
 func (c *SimpleController) addReaction() control.UserStatus {
 	// get posts from UserStore that have been created in the last minute
 	posts, err := c.user.Store().PostsSince(time.Now().Add(-1*time.Minute).Unix() * 1000)
@@ -301,7 +325,7 @@ func (c *SimpleController) createDirectChannel() control.UserStatus {
 		return c.newErrorStatus(err)
 	}
 
-	return c.newInfoStatus(fmt.Sprintf("direct channel  for user %v created, id %v", user.Id, channelId))
+	return c.newInfoStatus(fmt.Sprintf("direct channel for user %v created, id %v", user.Id, channelId))
 }
 
 func (c *SimpleController) viewChannel() control.UserStatus {

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/mattermost/mattermost-server/v5/model"
+
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 )
@@ -44,6 +46,30 @@ func (c *SimpleController) Run() {
 		c.sendFailStatus("controller was not initialized")
 		return
 	}
+
+	// Start listening for websocket events.
+	go func() {
+		for ev := range c.user.Events() {
+			switch ev.EventType() {
+			case model.WEBSOCKET_EVENT_USER_UPDATED:
+				// probably do something interesting ?
+			case model.WEBSOCKET_EVENT_STATUS_CHANGE:
+				// Send a message if the user has come online.
+				data := ev.Data // TODO: upgrade the server dependency and move to GetData call
+				status, ok := data["status"].(string)
+				if !ok || status != "online" {
+					continue
+				}
+				userID, ok := data["user_id"].(string)
+				if !ok {
+					continue
+				}
+				c.status <- c.sendDirectMessage(userID)
+			default:
+				// add other handlers as necessary.
+			}
+		}
+	}()
 
 	actions := []UserAction{
 		{

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -21,9 +21,11 @@ type UserStore interface {
 
 	// TODO: Move all getters to this interface
 
-	// Config return the server configuration settings.
+	// Config returns the server configuration settings.
 	Config() model.Config
-	// Channels return the channels for a team.
+	// Channel returns the channel for a given channelId.
+	Channel(channelId string) (*model.Channel, error)
+	// Channels returns the channels for a team.
 	Channels(teamId string) ([]model.Channel, error)
 	// ChannelMember returns the ChannelMember for the given channelId and userId.
 	ChannelMember(channelId, userId string) (model.ChannelMember, error)
@@ -31,13 +33,13 @@ type UserStore interface {
 	ChannelPosts(channelId string) ([]*model.Post, error)
 	// ChannelPostsSorted returns all posts for given channelId, sorted by CreateAt
 	ChannelPostsSorted(channelId string, asc bool) ([]*model.Post, error)
-	// Teams return the teams a user belong to.
+	// Teams returns the teams a user belong to.
 	Teams() ([]model.Team, error)
 	// TeamMember returns the TeamMember for the given teamId and userId.
 	TeamMember(teamdId, userId string) (model.TeamMember, error)
-	// Preferences return the preferences of the user.
+	// Preferences returns the preferences of the user.
 	Preferences() (model.Preferences, error)
-	// Roles return the roles of the user.
+	// Roles returns the roles of the user.
 	Roles() ([]model.Role, error)
 
 	// PostsSince returns posts created after a specified timestamp in milliseconds.
@@ -95,7 +97,6 @@ type MutableUserStore interface {
 	// channels
 	SetChannel(channel *model.Channel) error
 	SetChannels(channels []*model.Channel) error
-	Channel(channelId string) (*model.Channel, error)
 	// SetChannelMembers stores the given channel members in the store.
 	SetChannelMembers(channelMembers *model.ChannelMembers) error
 	ChannelMembers(channelId string) (*model.ChannelMembers, error)

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -13,9 +13,16 @@ import (
 type User interface {
 	Store() store.UserStore
 
+	// Cleanup is a one time method used to close any open resources
+	// that the user might have kept open throughout its lifetime.
+	Cleanup()
+
 	// connection
 	Connect() <-chan error
 	Disconnect() error
+	// Events returns the WebSocket event chan for the controller
+	// to listen and react to events.
+	Events() <-chan *model.WebSocketEvent
 	SignUp(email, username, password string) error
 	Login() error
 	Logout() (bool, error)

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -48,13 +48,12 @@ func (ue *UserEntity) listen(errChan chan error) {
 					chanClosed = true
 					break
 				}
-				_ = ev // TODO: handle event
-			case resp, ok := <-client.ResponseChannel:
+				ue.wsEventChan <- ev
+			case _, ok := <-client.ResponseChannel:
 				if !ok {
 					chanClosed = true
 					break
 				}
-				_ = resp // TODO: handle response
 			case <-ue.wsClosing:
 				client.Close()
 				// Explicit disconnect. Return.


### PR DESCRIPTION
- Handle USER_UPDATED and STATUS_CHANGED events.
- When a user status becomes online, send a direct message to the user
if we already have a direct channel created with that user.
- Ignore the WebSocket response channel for now because there aren't
any interesting things to do.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

