### PR TITLE
MM-22101: reduce login/logout frequency

### DIFF
--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -15,8 +15,9 @@ import (
 )
 
 type UserAction struct {
-	run       func() control.UserStatus
-	waitAfter time.Duration
+	run          func() control.UserStatus
+	waitAfter    time.Duration
+	runFrequency int
 }
 
 func (c *SimpleController) signUp() control.UserStatus {

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -190,7 +190,7 @@ func (c *SimpleController) Run() {
 	c.status <- c.signUp()
 	c.status <- c.login()
 
-	cycleCount := 0 // keeps a track of how many times the entire cycle of actions have been completed.
+	cycleCount := 1 // keeps a track of how many times the entire cycle of actions have been completed.
 	for {
 		for i := 0; i < len(actions); i++ {
 			if cycleCount%actions[i].runFrequency == 0 {

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -73,65 +73,80 @@ func (c *SimpleController) Run() {
 
 	actions := []UserAction{
 		{
-			run:       c.signUp,
-			waitAfter: 1000,
+			run:          c.signUp,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
 			run: func() control.UserStatus {
 				return c.reload(false)
 			},
+			runFrequency: 1,
 		},
 		{
-			run:       c.joinTeam,
-			waitAfter: 1000,
+			run:          c.joinTeam,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.joinChannel,
-			waitAfter: 1000,
+			run:          c.joinChannel,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.addReaction,
-			waitAfter: 1000,
+			run:          c.addReaction,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.removeReaction,
-			waitAfter: 1000,
+			run:          c.removeReaction,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.searchPosts,
-			waitAfter: 1000,
+			run:          c.searchPosts,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.searchChannels,
-			waitAfter: 1000,
+			run:          c.searchChannels,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.searchUsers,
-			waitAfter: 1000,
+			run:          c.searchUsers,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.viewUser,
-			waitAfter: 1000,
+			run:          c.viewUser,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.createPost,
-			waitAfter: 1000,
+			run:          c.createPost,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.updateProfile,
-			waitAfter: 1000,
+			run:          c.updateProfile,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.updateProfileImage,
-			waitAfter: 1000,
+			run:          c.updateProfileImage,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.createGroupChannel,
-			waitAfter: 1000,
+			run:          c.createGroupChannel,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.createDirectChannel,
-			waitAfter: 1000,
+			run:          c.createDirectChannel,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		// {
 		// 	run:       c.createPublicChannel,
@@ -142,16 +157,19 @@ func (c *SimpleController) Run() {
 		// 	waitAfter: 1000,
 		// },
 		{
-			run:       c.viewChannel,
-			waitAfter: 1000,
+			run:          c.viewChannel,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.scrollChannel,
-			waitAfter: 1000,
+			run:          c.scrollChannel,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
-			run:       c.leaveChannel,
-			waitAfter: 1000,
+			run:          c.leaveChannel,
+			waitAfter:    1000,
+			runFrequency: 1,
 		},
 		{
 			run:          c.logout,
@@ -175,8 +193,7 @@ func (c *SimpleController) Run() {
 	cycleCount := 0 // keeps a track of how many times the entire cycle of actions have been completed.
 	for {
 		for i := 0; i < len(actions); i++ {
-			if actions[i].runFrequency == 0 ||
-				cycleCount%actions[i].runFrequency == 0 {
+			if cycleCount%actions[i].runFrequency == 0 {
 				// run the action if runFrequency is not set, or else it's set and it's a multiple
 				// of the cycle count.
 				c.status <- actions[i].run()


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- During load testing, it was found that doing login/logout on every iteration has a huge CPU cost and essentially takes up the entire CPU profile. Keeping this logic would prevent us from looking into what bottlenecks do we have in the system because all of the time would be spent on hashing the user passwords.

Hence we reduce the frequency to allow other actions to be executed more frequently and allow us to look into what other parts can be optimized.
- Reordered login to be after logout in the loop
so that the frquency of logout/login can be reduced without
leaving the user in a logged out state.
- Doing logout/login once every 20 iterations of the loop.
- Doing signup and login in an initial phase before starting the loop
so that the user is in a logged in state when the loop starts.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22101
