### PR TITLE
[MM-22439] - Fix channel initialization and avoid removing valuable info from the user name while updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This populates a Mattermost instance with some teams and channels.
 
 - `go run ./cmd/loadtest`
 
-This runs for 60 minutes and stops.
+This runs for 60 seconds and stops.
 
 #### Start a load test agent
 

--- a/cmd/loadtest/init.go
+++ b/cmd/loadtest/init.go
@@ -47,9 +47,10 @@ func createChannels(admin *userentity.UserEntity, numChannels int) error {
 		}
 
 		id, err := admin.CreateChannel(&model.Channel{
-			Name:   model.NewId(),
-			TeamId: team.Id,
-			Type:   channelTypes[rand.Intn(len(channelTypes))],
+			Name:        model.NewId(),
+			DisplayName: fmt.Sprintf("ch-%d", i),
+			TeamId:      team.Id,
+			Type:        channelTypes[rand.Intn(len(channelTypes))],
 		})
 		if err != nil {
 			return err

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
@@ -409,8 +408,8 @@ func (c *SimpleController) searchUsers() control.UserStatus {
 
 func (c *SimpleController) updateProfile() control.UserStatus {
 	userId := c.user.Store().Id()
-	name := strings.TrimSuffix(c.user.Store().Username(), "-new")
-	userName := fmt.Sprintf("%s-new", name)
+
+	userName := randomizeUserName(c.user.Store().Username())
 	nickName := fmt.Sprintf("testNickName%d", c.id)
 	firstName := fmt.Sprintf("firstName%d", c.id)
 	lastName := fmt.Sprintf("lastName%d", c.id)

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
@@ -408,7 +409,8 @@ func (c *SimpleController) searchUsers() control.UserStatus {
 
 func (c *SimpleController) updateProfile() control.UserStatus {
 	userId := c.user.Store().Id()
-	userName := fmt.Sprintf("userName%d", c.id)
+	name := strings.TrimSuffix(c.user.Store().Username(), "-new")
+	userName := fmt.Sprintf("%s-new", name)
 	nickName := fmt.Sprintf("testNickName%d", c.id)
 	firstName := fmt.Sprintf("firstName%d", c.id)
 	lastName := fmt.Sprintf("lastName%d", c.id)

--- a/loadtest/control/simplecontroller/utils.go
+++ b/loadtest/control/simplecontroller/utils.go
@@ -15,10 +15,11 @@ const (
 	letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
 
-var (
-	re  = regexp.MustCompile(`-[[:alpha:]]+`)
-	src = rand.NewSource(time.Now().UnixNano())
-)
+var re = regexp.MustCompile(`-[[:alpha:]]+`)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func getErrOrigin() string {
 	var origin string

--- a/loadtest/control/simplecontroller/utils.go
+++ b/loadtest/control/simplecontroller/utils.go
@@ -2,12 +2,23 @@ package simplecontroller
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
+	"time"
 )
 
-const pkgPath = "github.com/mattermost/mattermost-load-test-ng/loadtest/control/"
+const (
+	pkgPath = "github.com/mattermost/mattermost-load-test-ng/loadtest/control/"
+	letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+var (
+	re  = regexp.MustCompile(`-[[:alpha:]]+`)
+	src = rand.NewSource(time.Now().UnixNano())
+)
 
 func getErrOrigin() string {
 	var origin string
@@ -19,4 +30,14 @@ func getErrOrigin() string {
 		}
 	}
 	return origin
+}
+
+// assuming the incoming name has a pattern of {{agent-id}}-{{user-name}}-{{user-number}}
+func randomizeUserName(name string) string {
+	parts := re.FindAllString(name, -1)
+	if len(parts) > 0 {
+		random := letters[rand.Intn(len(letters))]
+		name = strings.Replace(name, parts[len(parts)-1], "-user"+string(random), 1)
+	}
+	return name
 }

--- a/loadtest/control/simplecontroller/utils_test.go
+++ b/loadtest/control/simplecontroller/utils_test.go
@@ -1,0 +1,16 @@
+package simplecontroller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomizeUserName(t *testing.T) {
+
+	name := randomizeUserName("test-agent-1-user-4")
+	assert.Contains(t, name, "test-agent-1-user")
+
+	name = randomizeUserName("lt1-user4")
+	assert.Contains(t, name, "lt1-user")
+}

--- a/loadtest/control/simplecontroller/utils_test.go
+++ b/loadtest/control/simplecontroller/utils_test.go
@@ -1,6 +1,8 @@
 package simplecontroller
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +11,11 @@ import (
 func TestRandomizeUserName(t *testing.T) {
 
 	name := randomizeUserName("test-agent-1-user-4")
-	assert.Contains(t, name, "test-agent-1-user")
+	assert.Regexp(t, regexp.MustCompile(`user[[:alpha:]]+-4`), name)
 
 	name = randomizeUserName("lt1-user4")
-	assert.Contains(t, name, "lt1-user")
+	assert.True(t, strings.HasPrefix(name, "lt1-user"))
+
+	name = randomizeUserName("testuser")
+	assert.Equal(t, name, "testuser")
 }


### PR DESCRIPTION
#### Summary
This PR adds following:

- Initialize channels with a display name
- Avoid removing valuable info from the user name while updating

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22439

