### PR TITLE
MM-22701: Fix race in reading statusChan

### DIFF
--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -19,7 +19,6 @@ type LoadTester struct {
 	config        *Config
 	wg            sync.WaitGroup
 	statusChan    chan control.UserStatus
-	quitChan      chan struct{}
 	status        Status
 	newController NewController
 }
@@ -32,24 +31,23 @@ type LoadTester struct {
 type NewController func(int, chan<- control.UserStatus) control.UserController
 
 func (lt *LoadTester) handleStatus() {
-	for {
-		select {
-		case <-lt.quitChan:
-			return
-		case st := <-lt.statusChan:
-			if st.Code == control.USER_STATUS_STOPPED || st.Code == control.USER_STATUS_FAILED {
-				lt.wg.Done()
-			}
-			if st.Code == control.USER_STATUS_ERROR {
-				mlog.Info(st.Err.Error(), mlog.Int("controller_id", st.ControllerId), mlog.String("origin", st.Err.Origin))
-				atomic.AddInt64(&lt.status.NumErrors, 1)
-				continue
-			} else if st.Code == control.USER_STATUS_FAILED {
-				mlog.Error(st.Err.Error())
-				continue
-			}
-			mlog.Info(st.Info, mlog.Int("controller_id", st.ControllerId))
+	var statusChan chan control.UserStatus
+	lt.mut.RLock()
+	statusChan = lt.statusChan
+	lt.mut.RUnlock()
+	for st := range statusChan {
+		if st.Code == control.USER_STATUS_STOPPED || st.Code == control.USER_STATUS_FAILED {
+			lt.wg.Done()
 		}
+		if st.Code == control.USER_STATUS_ERROR {
+			mlog.Info(st.Err.Error(), mlog.Int("controller_id", st.ControllerId), mlog.String("origin", st.Err.Origin))
+			atomic.AddInt64(&lt.status.NumErrors, 1)
+			continue
+		} else if st.Code == control.USER_STATUS_FAILED {
+			mlog.Error(st.Err.Error())
+			continue
+		}
+		mlog.Info(st.Info, mlog.Int("controller_id", st.ControllerId))
 	}
 }
 
@@ -152,7 +150,6 @@ func (lt *LoadTester) Stop() error {
 	}
 	lt.wg.Wait()
 	close(lt.statusChan)
-	lt.quitChan <- struct{}{}
 	lt.status.NumUsers = 0
 	lt.status.State = Stopped
 	return nil
@@ -188,7 +185,6 @@ func New(config *Config, nc NewController) *LoadTester {
 	return &LoadTester{
 		config:        config,
 		statusChan:    make(chan control.UserStatus, config.UsersConfiguration.MaxActiveUsers),
-		quitChan:      make(chan struct{}),
 		newController: nc,
 		status:        Status{},
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
While stopping a LoadTester, we just stopped reading from the channel
without ensuring the goroutine exited. This cause a race condition
when re-starting an existing loadtester.

We fix this by sending a quit signal which would actually exit
from the goroutine and ensure the channel read is no longer in memory.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22701
