### PR TITLE
[MM-22893] Make UserController type to be used configurable

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 
@@ -72,7 +73,15 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 			Password:     "testPass123$",
 		}
 		ue := userentity.New(memstore.New(), ueConfig)
-		return simplecontroller.New(id, ue, status)
+		switch config.UserControllerConfiguration.Type {
+		case loadtest.UserControllerSimple:
+			return simplecontroller.New(id, ue, status)
+		case loadtest.UserControllerSimulative:
+			return simulcontroller.New(id, ue, status)
+		default:
+			// This should never happen if we validated the config.
+			return nil
+		}
 	}
 
 	lt, err := loadtest.New(&config, newSimpleController)

--- a/api/server.go
+++ b/api/server.go
@@ -79,8 +79,7 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		case loadtest.UserControllerSimulative:
 			return simulcontroller.New(id, ue, status)
 		default:
-			// This should never happen if we validated the config.
-			return nil
+			panic("controller type must be valid")
 		}
 	}
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -46,8 +46,7 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		case loadtest.UserControllerSimulative:
 			return simulcontroller.New(id, ue, status)
 		default:
-			// This should never happen if we validated the config.
-			return nil
+			panic("controller type must be valid")
 		}
 	}
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -22,7 +23,15 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	newSimpleController := func(id int, status chan<- control.UserStatus) control.UserController {
+	if ok, err := config.IsValid(); !ok {
+		return err
+	}
+
+	controllerType := config.UserControllerConfiguration.Type
+
+	mlog.Info(fmt.Sprintf("will run load-test with UserController of type %s", controllerType))
+
+	newControllerFn := func(id int, status chan<- control.UserStatus) control.UserController {
 		ueConfig := userentity.Config{
 			ServerURL:    config.ConnectionConfiguration.ServerURL,
 			WebSocketURL: config.ConnectionConfiguration.WebSocketURL,
@@ -31,10 +40,18 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 			Password:     "testPass123$",
 		}
 		ue := userentity.New(memstore.New(), ueConfig)
-		return simplecontroller.New(id, ue, status)
+		switch controllerType {
+		case loadtest.UserControllerSimple:
+			return simplecontroller.New(id, ue, status)
+		case loadtest.UserControllerSimulative:
+			return simulcontroller.New(id, ue, status)
+		default:
+			// This should never happen if we validated the config.
+			return nil
+		}
 	}
 
-	lt, err := loadtest.New(config, newSimpleController)
+	lt, err := loadtest.New(config, newControllerFn)
 	if err != nil {
 		return fmt.Errorf("error while initializing loadtest: %w", err)
 	}

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -8,6 +8,10 @@
         "MaxIdleConnsPerHost": 128,
         "IdleConnTimeoutMilliseconds": 90000
     },
+    "UserControllerConfiguration": {
+      "Type": "simple",
+      "Rate": 1.0
+    },
     "InstanceConfiguration": {
         "NumTeams": 2
     },

--- a/coordinator/cluster/utils_test.go
+++ b/coordinator/cluster/utils_test.go
@@ -22,6 +22,10 @@ func createMockAgents(t *testing.T) []*agent.LoadAgent {
 				AdminEmail:    "user@example.com",
 				AdminPassword: "str0ngPassword##",
 			},
+			UserControllerConfiguration: loadtest.UserControllerConfiguration{
+				Type: "simple",
+				Rate: 1.0,
+			},
 			UsersConfiguration: loadtest.UsersConfiguration{
 				MaxActiveUsers:     8,
 				InitialActiveUsers: 0,

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -40,17 +40,17 @@ func (cc *ConnectionConfiguration) IsValid() (bool, error) {
 	return true, nil
 }
 
-// UserControllerType describes the type of a UserController.
-type UserControllerType string
+// userControllerType describes the type of a UserController.
+type userControllerType string
 
 // Available UserController implementations.
 const (
-	UserControllerSimple     UserControllerType = "simple"
+	UserControllerSimple     userControllerType = "simple"
 	UserControllerSimulative                    = "simulative"
 )
 
 // IsValid reports whether a given UserControllerType is valid or not.
-func (t UserControllerType) IsValid() (bool, error) {
+func (t userControllerType) IsValid() (bool, error) {
 	switch t {
 	case UserControllerSimple:
 		return true, nil
@@ -68,9 +68,9 @@ func (t UserControllerType) IsValid() (bool, error) {
 type UserControllerConfiguration struct {
 	// The type of the UserController to run.
 	// Possible values:
-	//   "simple" - The simple version of a controller.
-	//   "simulative" - A more realistic controller.
-	Type UserControllerType
+	//   UserControllerSimple - The simple version of a controller.
+	//   UserControllerSimulative - A more realistic controller.
+	Type userControllerType
 	// A rate multiplier that will affect the speed at which user actions are
 	// executed by the UserController.
 	// A Rate of < 1.0 will run actions at a faster pace.

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -68,7 +68,7 @@ func (t userControllerType) IsValid() (bool, error) {
 type UserControllerConfiguration struct {
 	// The type of the UserController to run.
 	// Possible values:
-	//   UserControllerSimple - The simple version of a controller.
+	//   UserControllerSimple - A simple version of a controller.
 	//   UserControllerSimulative - A more realistic controller.
 	Type userControllerType
 	// A rate multiplier that will affect the speed at which user actions are

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -5,6 +5,7 @@ package loadtest
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -72,6 +73,9 @@ func (lt *LoadTester) addUser() error {
 	lt.status.NumUsers++
 	lt.status.NumUsersAdded++
 	controller := lt.newController(activeUsers+1, lt.statusChan)
+	if err := controller.SetRate(lt.config.UserControllerConfiguration.Rate); err != nil {
+		return fmt.Errorf("loadtest: failed to set controller rate %w", err)
+	}
 	lt.wg.Add(1)
 	go func() {
 		controller.Run()

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -23,6 +23,10 @@ var ltConfig = Config{
 		AdminEmail:    "user@example.com",
 		AdminPassword: "str0ngPassword##",
 	},
+	UserControllerConfiguration: UserControllerConfiguration{
+		Type: "simple",
+		Rate: 1.0,
+	},
 	UsersConfiguration: UsersConfiguration{
 		MaxActiveUsers:     8,
 		InitialActiveUsers: 0,


### PR DESCRIPTION
#### Summary

PR will make the type of `UserController` to run during a load-test a configurable option. It also adds a configuration setting for the rate.

#### Ticket

https://mattermost.atlassian.net/browse/MM-22893

