### PR TITLE
[MM-22884] Handle post related ws events in userentity

### DIFF
--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -110,6 +110,11 @@ func (s *SampleStore) SetPost(post *model.Post) error {
 	return nil
 }
 
+func (s *SampleStore) DeletePost(postId string) error {
+	delete(s.posts, postId)
+	return nil
+}
+
 func (s *SampleStore) SetPosts(posts []*model.Post) error {
 	for _, post := range posts {
 		s.posts[post.Id] = post

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -194,6 +194,13 @@ func (s *MemStore) SetPost(post *model.Post) error {
 	return nil
 }
 
+func (s *MemStore) DeletePost(postId string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	delete(s.posts, postId)
+	return nil
+}
+
 func (s *MemStore) SetPosts(posts []*model.Post) error {
 	if len(posts) == 0 {
 		return errors.New("memstore: posts should not be nil or empty")

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -100,6 +100,18 @@ func TestUser(t *testing.T) {
 		require.Equal(t, p, uu)
 	})
 
+	t.Run("DeletePost", func(t *testing.T) {
+		s := New()
+		require.Empty(t, s.posts)
+		p := &model.Post{Id: model.NewId()}
+		err := s.SetPost(p)
+		require.NoError(t, err)
+		require.NotEmpty(t, s.posts)
+		err = s.DeletePost(p.Id)
+		require.NoError(t, err)
+		require.Empty(t, s.posts)
+	})
+
 	t.Run("SetPosts", func(t *testing.T) {
 		err := s.SetPosts(nil)
 		require.Error(t, err)

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -91,6 +91,7 @@ type MutableUserStore interface {
 
 	// posts
 	SetPost(post *model.Post) error
+	DeletePost(postId string) error
 	SetPosts(posts []*model.Post) error
 	Post(postId string) (*model.Post, error)
 

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -18,6 +18,22 @@ const (
 	maxWebsocketFails             = 7
 )
 
+func (ue *UserEntity) handlePostEvent(ev *model.WebSocketEvent) error {
+	var post *model.Post
+	if err := json.Unmarshal([]byte(ev.Data["post"].(string)), &post); err != nil {
+		return err
+	}
+
+	evType := ev.EventType()
+	if evType == model.WEBSOCKET_EVENT_POSTED || evType == model.WEBSOCKET_EVENT_POST_EDITED {
+		return ue.store.SetPost(post)
+	} else if evType == model.WEBSOCKET_EVENT_POST_DELETED {
+		return ue.store.DeletePost(post.Id)
+	}
+
+	return nil
+}
+
 // wsEventHandler handles the given WebSocket event by calling the appropriate
 // store methods to make sure the internal user state is kept updated.
 // Handling the event at this layer is needed to keep the user state in
@@ -41,6 +57,12 @@ func (ue *UserEntity) wsEventHandler(ev *model.WebSocketEvent) error {
 		if _, err := ue.store.DeleteReaction(reaction); err != nil {
 			return err
 		}
+	case model.WEBSOCKET_EVENT_POSTED:
+		fallthrough
+	case model.WEBSOCKET_EVENT_POST_EDITED:
+		fallthrough
+	case model.WEBSOCKET_EVENT_POST_DELETED:
+		return ue.handlePostEvent(ev)
 	default:
 	}
 


### PR DESCRIPTION
#### Summary

PR adds a handler function in `userentity` for the following WebSocket events:

- `model.WEBSOCKET_EVENT_POSTED`
- `model.WEBSOCKET_EVENT_POST_EDITED`
- `model.WEBSOCKET_EVENT_POST_DELETED`

#### Ticket

https://mattermost.atlassian.net/browse/MM-22884