### PR TITLE
MM-23183: fix deadlock in emulateUserTyping

### DIFF
--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -211,6 +211,7 @@ func (c *SimpleController) Stop() {
 	if err := c.user.Disconnect(); err != nil {
 		c.status <- c.newErrorStatus(err)
 	}
+	c.user.Cleanup()
 	close(c.stop)
 }
 

--- a/loadtest/control/utils.go
+++ b/loadtest/control/utils.go
@@ -57,12 +57,11 @@ func RandomizeUserName(name string) string {
 }
 
 func emulateUserTyping(t string, cb func(term string) UserActionResponse) UserActionResponse {
-	ticker := time.Tick(time.Duration(rand.Intn(10)) * 1e1 * time.Millisecond)
 	runes := []rune(t)
 	var term string
 	var resp UserActionResponse
 	for i := range runes {
-		<-ticker
+		time.Sleep(time.Duration(rand.Intn(10)) * 1e1 * time.Millisecond)
 		term += string(runes[i])
 		resp = cb(term)
 		if resp.Err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
In rare cases, the random duration in time.Ticker be zero, and
then it would get stuck because it returns a nil channel if d <=0.
This would prevent the controller from moving forward in it's loop,
and eventually not even receive the stop signal. We fix this
by simply changing it to a time.Sleep. This is much better and also
bypasses the problem of the ticker not being garbage collected.

Fun debugging session. Moral of the story: don't try complicated things
when simple works :)

We also fix the missing case of not calling the cleanup function.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23183
