### PR TITLE
MM-22773: provision a local mattermost build

### DIFF
--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -134,7 +134,7 @@ type DeploymentConfiguration struct {
 	DBInstanceEngine string // Type of the DB instance - postgres or mysql.
 	DBUserName       string // Username to connect to the DB.
 	DBPassword       string // Password to connect to the DB.
-	// URL from where to download Mattermost distribution.
+	// URL from where to download Mattermost release.
 	// This can also point to a local binary path if the user wants to run loadtest
 	// on a custom build. The path should be prefixed with "file://". In that case,
 	// only the binary gets replaced, and the rest of the build comes from the latest

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -126,15 +126,20 @@ func (uc *UsersConfiguration) IsValid() error {
 // DeploymentConfiguration contains the necessary data
 // to deploy and provision a load test environment through terraform.
 type DeploymentConfiguration struct {
-	ClusterName           string // Name of the cluster.
-	AppInstanceCount      int    // Number of application instances.
-	SSHPublicKey          string // Path to the SSH public key.
-	DBInstanceCount       int    // Number of DB instances.
-	DBInstanceClass       string // Type of the DB instance.
-	DBInstanceEngine      string // Type of the DB instance - postgres or mysql.
-	DBUserName            string // Username to connect to the DB.
-	DBPassword            string // Password to connect to the DB.
-	MattermostDownloadURL string // URL from where to download Mattermost distribution.
+	ClusterName      string // Name of the cluster.
+	AppInstanceCount int    // Number of application instances.
+	SSHPublicKey     string // Path to the SSH public key.
+	DBInstanceCount  int    // Number of DB instances.
+	DBInstanceClass  string // Type of the DB instance.
+	DBInstanceEngine string // Type of the DB instance - postgres or mysql.
+	DBUserName       string // Username to connect to the DB.
+	DBPassword       string // Password to connect to the DB.
+	// URL from where to download Mattermost distribution.
+	// This can also point to a local binary path if the user wants to run loadtest
+	// on a custom build. The path should be prefixed with "file://". In that case,
+	// only the binary gets replaced, and the rest of the build comes from the latest
+	// stable release.
+	MattermostDownloadURL string
 	MattermostLicenseFile string // Path to the Mattermost EE license file.
 }
 

--- a/terraform/create.go
+++ b/terraform/create.go
@@ -26,6 +26,11 @@ import (
 
 const cmdExecTimeoutMinutes = 5
 
+// TODO: fetch this dynamically. See IS-327.
+const latestReleaseURL = "https://releases.mattermost.com/5.20.1/mattermost-5.20.1-linux-amd64.tar.gz"
+
+const filePrefix = "file://"
+
 // Terraform manages all operations related to interacting with
 // an AWS environment using Terraform.
 type Terraform struct {
@@ -55,6 +60,22 @@ func (t *Terraform) Create() error {
 	err := t.preFlightCheck()
 	if err != nil {
 		return err
+	}
+
+	uploadBinary := false
+	binaryPath := ""
+	if strings.HasPrefix(t.config.DeploymentConfiguration.MattermostDownloadURL, filePrefix) {
+		binaryPath = strings.TrimPrefix(t.config.DeploymentConfiguration.MattermostDownloadURL, filePrefix)
+		info, err := os.Stat(binaryPath)
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("binary path %s has to be a regular file", binaryPath)
+		}
+
+		t.config.DeploymentConfiguration.MattermostDownloadURL = latestReleaseURL
+		uploadBinary = true
 	}
 
 	err = t.runCommand(nil, "apply",
@@ -102,6 +123,20 @@ func (t *Terraform) Create() error {
 			if err := sshc.Upload(rdr, true, "/lib/systemd/system/mattermost.service"); err != nil {
 				mlog.Error("error uploading systemd file", mlog.Err(err))
 				return
+			}
+
+			// Upload binary if needed.
+			if uploadBinary {
+				f, err := os.Open(binaryPath)
+				if err != nil {
+					mlog.Error("error opening file", mlog.String("file", binaryPath), mlog.Err(err))
+					return
+				}
+				defer f.Close()
+				if err := sshc.Upload(f, false, "/opt/mattermost/bin/mattermost"); err != nil {
+					mlog.Error("error uploading file", mlog.String("file", binaryPath), mlog.Err(err))
+					return
+				}
 			}
 
 			// Starting mattermost.

--- a/terraform/create.go
+++ b/terraform/create.go
@@ -62,8 +62,8 @@ func (t *Terraform) Create() error {
 		return err
 	}
 
-	uploadBinary := false
-	binaryPath := ""
+	var uploadBinary bool
+	var binaryPath string
 	if strings.HasPrefix(t.config.DeploymentConfiguration.MattermostDownloadURL, filePrefix) {
 		binaryPath = strings.TrimPrefix(t.config.DeploymentConfiguration.MattermostDownloadURL, filePrefix)
 		info, err := os.Stat(binaryPath)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Overload the `MattermostDownloadURL` to have a file:// prefix
which indicates a local build. In that case, we can download everything
from a stable release, and just copy the binary from local.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22773
