### PR TITLE
MM-23262: Use the cluster name as a prefix for keypair

### DIFF
--- a/terraform/cluster.tf
+++ b/terraform/cluster.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_key_pair" "key" {
-  key_name   = "loadtest"
+  key_name   = "${var.cluster_name}-keypair"
   public_key = file(var.ssh_public_key)
 }
 


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This gets rid of the hardcoding. A general problem still persists
where if two people use the same cluster name, then there will be a clash again.

But then the problem with adding a random string is that we need to pass the exact
same thing during destruction too.

So for now, we will recommend users to prefix the cluster names with their names
to compartmentalize deployments.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23262
