### PR TITLE
[MM-23372] Add currentChannel/currentTeam in memstore

### DIFF
--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -129,6 +129,14 @@ func (s *SampleStore) Channel(channelId string) (*model.Channel, error) {
 	return nil, nil
 }
 
+func (s *SampleStore) CurrentChannel() (*model.Channel, error) {
+	return nil, nil
+}
+
+func (s *SampleStore) SetCurrentChannel(channel *model.Channel) error {
+	return nil
+}
+
 // Channels return all the channels for a team.
 func (s *SampleStore) Channels(teamId string) ([]model.Channel, error) {
 	var channels []model.Channel
@@ -178,6 +186,14 @@ func (s *SampleStore) SetTeams(teams []*model.Team) error {
 	for _, team := range teams {
 		s.teams[team.Id] = team
 	}
+	return nil
+}
+
+func (s *SampleStore) CurrentTeam() (*model.Team, error) {
+	return nil, nil
+}
+
+func (s *SampleStore) SetCurrentTeam(team *model.Team) error {
 	return nil
 }
 

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -399,3 +399,11 @@ func (u *SampleUser) GetClientLicense() error {
 func (u *SampleUser) IsSysAdmin() (bool, error) {
 	return false, nil
 }
+
+func (u *SampleUser) SetCurrentTeam(team *model.Team) error {
+	return nil
+}
+
+func (u *SampleUser) SetCurrentChannel(channel *model.Channel) error {
+	return nil
+}

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -192,11 +192,9 @@ func JoinTeam(u user.User) UserActionResponse {
 
 // CreatePost creates a new post in a random channel by the given user.
 func CreatePost(u user.User) UserActionResponse {
-	team, err := u.Store().CurrentTeam()
+	team, err := u.Store().RandomTeamJoined()
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
-	} else if team == nil {
-		return UserActionResponse{Err: NewUserError(fmt.Errorf("current team should be set"))}
 	}
 	channel, err := u.Store().RandomChannelJoined(team.Id)
 	if errors.Is(err, memstore.ErrChannelStoreEmpty) {
@@ -403,11 +401,9 @@ func CreateDirectChannel(u user.User) UserActionResponse {
 // ViewChannel performs a view action in a random team/channel for the given
 // user, which will mark all posts as read in the channel.
 func ViewChannel(u user.User) UserActionResponse {
-	team, err := u.Store().CurrentTeam()
+	team, err := u.Store().RandomTeamJoined()
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
-	} else if team == nil {
-		return UserActionResponse{Err: NewUserError(fmt.Errorf("current team should be set"))}
 	}
 	channel, err := u.Store().RandomChannelJoined(team.Id)
 	if err != nil {
@@ -497,11 +493,9 @@ func SearchPosts(u user.User) UserActionResponse {
 
 // ViewUser simulates opening a random user profile for the given user.
 func ViewUser(u user.User) UserActionResponse {
-	team, err := u.Store().CurrentTeam()
+	team, err := u.Store().RandomTeamJoined()
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
-	} else if team == nil {
-		return UserActionResponse{Err: NewUserError(fmt.Errorf("current team should be set"))}
 	}
 
 	channel, err := u.Store().RandomChannelJoined(team.Id)

--- a/loadtest/control/utils_test.go
+++ b/loadtest/control/utils_test.go
@@ -36,7 +36,7 @@ func TestGetErrOrigin(t *testing.T) {
 }
 
 func TestEmulateUserTyping(t *testing.T) {
-	search := "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+	search := "this is long enough"
 	res := emulateUserTyping(search, func(term string) UserActionResponse {
 		return UserActionResponse{Info: term}
 	})

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -28,6 +28,8 @@ type MemStore struct {
 	reactions      map[string][]*model.Reaction
 	roles          map[string]*model.Role
 	license        map[string]string
+	currentChannel *model.Channel
+	currentTeam    *model.Team
 }
 
 // New returns a new instance of MemStore.
@@ -233,6 +235,26 @@ func (s *MemStore) SetChannel(channel *model.Channel) error {
 	return nil
 }
 
+func (s *MemStore) CurrentChannel() (*model.Channel, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if s.currentChannel == nil {
+		return nil, nil
+	}
+	chanCopy := *s.currentChannel
+	return &chanCopy, nil
+}
+
+func (s *MemStore) SetCurrentChannel(channel *model.Channel) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if channel == nil {
+		return errors.New("memstore: channel should not be nil")
+	}
+	s.currentChannel = channel
+	return nil
+}
+
 // Channels return all the channels for a team.
 func (s *MemStore) Channels(teamId string) ([]model.Channel, error) {
 	s.lock.RLock()
@@ -274,6 +296,26 @@ func (s *MemStore) SetTeam(team *model.Team) error {
 	defer s.lock.Unlock()
 
 	s.teams[team.Id] = team
+	return nil
+}
+
+func (s *MemStore) CurrentTeam() (*model.Team, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if s.currentTeam == nil {
+		return nil, nil
+	}
+	teamCopy := *s.currentTeam
+	return &teamCopy, nil
+}
+
+func (s *MemStore) SetCurrentTeam(team *model.Team) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if team == nil {
+		return errors.New("memstore: team should not be nil")
+	}
+	s.currentTeam = team
 	return nil
 }
 

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -240,6 +240,26 @@ func TestChannel(t *testing.T) {
 	})
 }
 
+func TestCurrentChannel(t *testing.T) {
+	s := New()
+	channel, err := s.CurrentChannel()
+	require.Nil(t, channel)
+	require.NoError(t, err)
+	err = s.SetCurrentChannel(nil)
+	require.Error(t, err)
+	c := &model.Channel{
+		Id: "ch" + model.NewId(),
+	}
+	err = s.SetCurrentChannel(c)
+	require.NoError(t, err)
+	channel, err = s.CurrentChannel()
+	require.Nil(t, err)
+	require.Equal(t, c, channel)
+	require.Condition(t, func() bool {
+		return channel != c
+	})
+}
+
 func TestReactions(t *testing.T) {
 	t.Run("SetReactions", func(t *testing.T) {
 		s := New()
@@ -401,6 +421,26 @@ func TestChannelMembers(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(s.channelMembers[channel.Id]))
 		require.Equal(t, channelMember2, (*members)[0])
+	})
+}
+
+func TestCurrentTeam(t *testing.T) {
+	s := New()
+	team, err := s.CurrentTeam()
+	require.Nil(t, team)
+	require.NoError(t, err)
+	err = s.SetCurrentTeam(nil)
+	require.Error(t, err)
+	tm := &model.Team{
+		Id: "tm" + model.NewId(),
+	}
+	err = s.SetCurrentTeam(tm)
+	require.NoError(t, err)
+	team, err = s.CurrentTeam()
+	require.Nil(t, err)
+	require.Equal(t, tm, team)
+	require.Condition(t, func() bool {
+		return team != tm
 	})
 }
 

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -27,6 +27,8 @@ type UserStore interface {
 	Channel(channelId string) (*model.Channel, error)
 	// Channels returns the channels for a team.
 	Channels(teamId string) ([]model.Channel, error)
+	// CurrentChannel gets the channel the user is currently viewing.
+	CurrentChannel() (*model.Channel, error)
 	// ChannelMember returns the ChannelMember for the given channelId and userId.
 	ChannelMember(channelId, userId string) (model.ChannelMember, error)
 	// ChannelPosts returns all posts for given channelId
@@ -35,6 +37,8 @@ type UserStore interface {
 	ChannelPostsSorted(channelId string, asc bool) ([]*model.Post, error)
 	// Teams returns the teams a user belong to.
 	Teams() ([]model.Team, error)
+	// CurrentTeam gets the currently selected team for the user.
+	CurrentTeam() (*model.Team, error)
 	// TeamMember returns the TeamMember for the given teamId and userId.
 	TeamMember(teamdId, userId string) (model.TeamMember, error)
 	// Preferences returns the preferences of the user.
@@ -108,6 +112,8 @@ type MutableUserStore interface {
 	// channels
 	SetChannel(channel *model.Channel) error
 	SetChannels(channels []*model.Channel) error
+	// SetCurrentChannel sets the channel the user is currently viewing.
+	SetCurrentChannel(channel *model.Channel) error
 	// SetChannelMembers stores the given channel members in the store.
 	SetChannelMembers(channelMembers *model.ChannelMembers) error
 	ChannelMembers(channelId string) (*model.ChannelMembers, error)
@@ -118,6 +124,8 @@ type MutableUserStore interface {
 	SetTeam(team *model.Team) error
 	Team(teamId string) (*model.Team, error)
 	SetTeams(teams []*model.Team) error
+	// SetCurrentTeam sets the currently selected team for the user.
+	SetCurrentTeam(team *model.Team) error
 	SetTeamMember(teamId string, teamMember *model.TeamMember) error
 	RemoveTeamMember(teamId, memberId string) error
 	SetTeamMembers(teamId string, teamMember []*model.TeamMember) error

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -117,4 +117,6 @@ type User interface {
 	// utils
 	// IsSysAdmin will return true if the user is a SystemAdmin, false otherwise.
 	IsSysAdmin() (bool, error)
+	SetCurrentTeam(team *model.Team) error
+	SetCurrentChannel(channel *model.Channel) error
 }


### PR DESCRIPTION
#### Summary

PR adds information about the current team/channel to the `memstore`.
I've also included a couple of fixes to issues with populating the store.
There might be some more places where to use `currentChannel`/`currentTeam` but I'll leave it for another PR.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23372