### PR TITLE
MM-23126: Validate that keys are added to the ssh agent

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -60,6 +60,11 @@ func (t *Terraform) Create() error {
 		return err
 	}
 
+	extAgent, err := ssh.NewAgent()
+	if err != nil {
+		return err
+	}
+
 	var uploadBinary bool
 	var binaryPath string
 	if strings.HasPrefix(t.config.MattermostDownloadURL, filePrefix) {
@@ -101,7 +106,7 @@ func (t *Terraform) Create() error {
 
 	// Updating the config.json for each instance.
 	for _, ip := range output.InstanceIps.Value {
-		sshc, err := ssh.NewClient(ip)
+		sshc, err := extAgent.NewClient(ip)
 		if err != nil {
 			mlog.Error("error in getting ssh connection", mlog.String("ip", ip), mlog.Err(err))
 			continue

--- a/deployment/terraform/ssh/ssh.go
+++ b/deployment/terraform/ssh/ssh.go
@@ -6,6 +6,7 @@
 package ssh
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,6 +17,12 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
+// ExtAgent is a wrapper type over agent.ExtendedAgent
+// provding a method to return a Client.
+type ExtAgent struct {
+	agent agent.ExtendedAgent
+}
+
 // Client is a wrapper type over a ssh connection
 // that takes care of creating a channel and running
 // commands in a single method.
@@ -23,18 +30,35 @@ type Client struct {
 	client *ssh.Client
 }
 
-// NewClient returns a Client object by dialing
-// to the local ssh agent.
-func NewClient(ip string) (*Client, error) {
+// NewAgent connects to the local ssh agent and validates
+// that it has atleast one key added. It returns the agent
+// if everything looks good.
+func NewAgent() (*ExtAgent, error) {
 	conn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
 	if err != nil {
 		return nil, err
 	}
 
+	extAgent := agent.NewClient(conn)
+	// Check if keys are added.
+	keys, err := extAgent.List()
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("no identities have been added to the agent. Please run ssh-add")
+	}
+
+	return &ExtAgent{agent: extAgent}, nil
+}
+
+// NewClient returns a Client object by dialing
+// the ssh agent.
+func (ea *ExtAgent) NewClient(ip string) (*Client, error) {
 	config := &ssh.ClientConfig{
 		User: "ubuntu",
 		Auth: []ssh.AuthMethod{
-			ssh.PublicKeysCallback(agent.NewClient(conn).Signers),
+			ssh.PublicKeysCallback(ea.agent.Signers),
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
@@ -86,10 +110,7 @@ func (sshc *Client) UploadFile(src, dst string, sudo bool) error {
 		return err
 	}
 	defer f.Close()
-	if err := sshc.Upload(f, "/opt/mattermost/bin/mattermost", false); err != nil {
-		return err
-	}
-	return nil
+	return sshc.Upload(f, "/opt/mattermost/bin/mattermost", false)
 }
 
 // Close closes the underlying connection.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The ssh agent creation would succeed even if there are no keys
added to the agent. This would lead to the deployer eventually getting stuck.

We add an additional check to list the keys first and verify that at least one
key is there.

This required the connection creation to be split up by first creating an agent
and then using that to create a connection.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23126
