### PR TITLE
General refactors for terraform

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -71,7 +71,7 @@ func ReadConfig(filePath string) (*Config, error) {
 
 	v.SetDefault("LogSettings.EnableConsole", true)
 	v.SetDefault("LogSettings.ConsoleLevel", "INFO")
-	v.SetDefault("LogSettings.ConsoleJson", true)
+	v.SetDefault("LogSettings.ConsoleJson", false)
 	v.SetDefault("LogSettings.EnableFile", true)
 	v.SetDefault("LogSettings.FileLevel", "INFO")
 	v.SetDefault("LogSettings.FileJson", true)

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -4,26 +4,19 @@
 package terraform
 
 import (
-	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
-	"github.com/pkg/errors"
 )
 
-const cmdExecTimeoutMinutes = 5
+const cmdExecTimeoutMinutes = 10
 
 // TODO: fetch this dynamically. See IS-327.
 const latestReleaseURL = "https://releases.mattermost.com/5.20.1/mattermost-5.20.1-linux-amd64.tar.gz"
@@ -120,9 +113,14 @@ func (t *Terraform) Create() error {
 				}
 			}()
 
-			t.updateConfig(ip, sshc, output)
+			mlog.Info("Updating config", mlog.String("host", ip))
+			if err := t.updateConfig(ip, sshc, output); err != nil {
+				mlog.Error("error updating config", mlog.Err(err))
+				return
+			}
 
 			// Upload service file
+			mlog.Info("Uploading service file", mlog.String("host", ip))
 			rdr := strings.NewReader(strings.TrimSpace(serviceFile))
 			if err := sshc.Upload(rdr, "/lib/systemd/system/mattermost.service", true); err != nil {
 				mlog.Error("error uploading systemd file", mlog.Err(err))
@@ -131,6 +129,7 @@ func (t *Terraform) Create() error {
 
 			// Upload binary if needed.
 			if uploadBinary {
+				mlog.Info("Uploading binary", mlog.String("host", ip))
 				if err := sshc.UploadFile(binaryPath, "/opt/mattermost/bin/mattermost", false); err != nil {
 					mlog.Error("error uploading file", mlog.String("file", binaryPath), mlog.Err(err))
 					return
@@ -138,6 +137,7 @@ func (t *Terraform) Create() error {
 			}
 
 			// Starting mattermost.
+			mlog.Info("Starting mattermost", mlog.String("host", ip))
 			cmd := fmt.Sprintf("sudo service mattermost start")
 			if err := sshc.RunCommand(cmd); err != nil {
 				mlog.Error("error running ssh command", mlog.String("cmd", cmd), mlog.Err(err))
@@ -146,12 +146,14 @@ func (t *Terraform) Create() error {
 		}()
 	}
 
+	// TODO: display the entire cluster info from terraformOutput later
+	// when we have cluster support.
+	mlog.Info("Deployment complete.")
+
 	return nil
 }
 
-func (t *Terraform) updateConfig(ip string, sshc *ssh.Client, output *terraformOutput) {
-	mlog.Info("Updating config", mlog.String("host", ip))
-
+func (t *Terraform) updateConfig(ip string, sshc *ssh.Client, output *terraformOutput) error {
 	var dsn string
 	switch t.config.DBInstanceEngine {
 	case "postgres":
@@ -159,7 +161,6 @@ func (t *Terraform) updateConfig(ip string, sshc *ssh.Client, output *terraformO
 	case "mysql":
 		dsn = t.config.DBUserName + ":" + t.config.DBPassword + "@tcp(" + output.DBEndpoint.Value + ")/" + t.config.ClusterName + "db?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"
 	}
-	mlog.Info("dsn: " + dsn) // TODO: remove this later.
 
 	for k, v := range map[string]interface{}{
 		".ServiceSettings.ListenAddress":       ":8065",
@@ -173,15 +174,14 @@ func (t *Terraform) updateConfig(ip string, sshc *ssh.Client, output *terraformO
 	} {
 		buf, err := json.Marshal(v)
 		if err != nil {
-			mlog.Error("invalid config", mlog.String("key", k), mlog.Err(err))
-			return
+			return fmt.Errorf("invalid config: key: %s, err: %v", k, err)
 		}
 		cmd := fmt.Sprintf(`jq '%s = %s' /opt/mattermost/config/config.json > /tmp/mmcfg.json && mv /tmp/mmcfg.json /opt/mattermost/config/config.json`, k, string(buf))
 		if err := sshc.RunCommand(cmd); err != nil {
-			mlog.Error("error running ssh command", mlog.String("cmd", cmd), mlog.Err(err))
-			return
+			return fmt.Errorf("error running ssh command: cmd: %s, err: %v", cmd, err)
 		}
 	}
+	return nil
 }
 
 func (t *Terraform) preFlightCheck() error {
@@ -223,67 +223,4 @@ func (t *Terraform) getOutput() (*terraformOutput, error) {
 		return nil, err
 	}
 	return &output, nil
-}
-
-// runCommand runs terraform with the args supplied. If dst is not nil, it writes the output there.
-// Otherwise, it logs the output to console.
-func (t *Terraform) runCommand(dst io.Writer, args ...string) error {
-	terraformBin := "terraform"
-	if _, err := exec.LookPath(terraformBin); err != nil {
-		return errors.Wrap(err, "terraform not installed. Please install terraform. (https://www.terraform.io/downloads.html)")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), cmdExecTimeoutMinutes*time.Minute)
-	defer cancel()
-
-	mlog.Info("Running terraform command", mlog.String("args", fmt.Sprintf("%v", args)))
-	cmd := exec.CommandContext(ctx, terraformBin, args...)
-
-	// If dst is set, that means we want to capture the output.
-	// We write a simple case to handle that using CombinedOutput.
-	if dst != nil {
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return err
-		}
-		_, err = dst.Write(out)
-		return err
-	}
-
-	// From here, we want to stream the output concurrently from stderr and stdout
-	// to mlog.
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			mlog.Info(scanner.Text())
-		}
-	}()
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		mlog.Info(scanner.Text())
-	}
-	// No need to check for scanner.Error as cmd.Wait() already does that.
-	wg.Wait()
-
-	if err := cmd.Wait(); err != nil {
-		return err
-	}
-	return nil
 }

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package terraform
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
+)
+
+// runCommand runs terraform with the args supplied. If dst is not nil, it writes the output there.
+// Otherwise, it logs the output to console.
+func (t *Terraform) runCommand(dst io.Writer, args ...string) error {
+	terraformBin := "terraform"
+	if _, err := exec.LookPath(terraformBin); err != nil {
+		return fmt.Errorf("terraform not installed. Please install terraform. (https://www.terraform.io/downloads.html): %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cmdExecTimeoutMinutes*time.Minute)
+	defer cancel()
+
+	mlog.Info("Running terraform command", mlog.String("args", fmt.Sprintf("%v", args)))
+	cmd := exec.CommandContext(ctx, terraformBin, args...)
+
+	// If dst is set, that means we want to capture the output.
+	// We write a simple case to handle that using CombinedOutput.
+	if dst != nil {
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return err
+		}
+		_, err = dst.Write(out)
+		return err
+	}
+
+	// From here, we want to stream the output concurrently from stderr and stdout
+	// to mlog.
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			mlog.Info(scanner.Text())
+		}
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		mlog.Info(scanner.Text())
+	}
+	// No need to check for scanner.Error as cmd.Wait() already does that.
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Some general refactors which didn't fit into a ticket.

- Set `ConsoleJSON` to false from code also.
- Moved the runCommand method to a separate file as everything was being
shoved into create.go.
- Changed the updateConfig method to return an error and perform
logging only from Create.
- Removed some TODOs
- Added some logging which gives an indication as to what is happening
after a terraform deployment finishes because there's still some things
that are done from inside the code.
- Increased the command timeout to 10 minutes because RDS deployment
sometimes takes close to 4.40 minutes and when we move to cluster
deployment, it's sure going to take a lot more.
- Replaced errors.Wrap with fmt.Errorf which is used more consistently.
