### PR TITLE
[MM-23140] Implement actions for SimulController (part I)

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -74,11 +74,11 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 
 	mlog.Info("loadtest started")
 
-	timeoutSec, err := cmd.Flags().GetInt("timeout")
+	durationSec, err := cmd.Flags().GetInt("duration")
 	if err != nil {
 		return err
 	}
-	time.Sleep(time.Duration(timeoutSec) * time.Second)
+	time.Sleep(time.Duration(durationSec) * time.Second)
 
 	err = lt.Stop()
 	mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))
@@ -94,6 +94,6 @@ func MakeLoadTestCommand() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringP("simplecontroller-config", "s", "", "path to the simplecontroller configuration file to use")
 	cmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
-	cmd.PersistentFlags().IntP("timeout", "t", 60, "number of seconds to pass before stopping the load-test")
+	cmd.PersistentFlags().IntP("duration", "d", 60, "number of seconds to pass before stopping the load-test")
 	return cmd
 }

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -73,7 +73,12 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	mlog.Info("loadtest started")
-	time.Sleep(1800 * time.Second)
+
+	timeoutSec, err := cmd.Flags().GetInt("timeout")
+	if err != nil {
+		return err
+	}
+	time.Sleep(time.Duration(timeoutSec) * time.Second)
 
 	err = lt.Stop()
 	mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))
@@ -89,5 +94,6 @@ func MakeLoadTestCommand() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringP("simplecontroller-config", "s", "", "path to the simplecontroller configuration file to use")
 	cmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
+	cmd.PersistentFlags().IntP("timeout", "t", 60, "number of seconds to pass before stopping the load-test")
 	return cmd
 }

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -73,7 +73,7 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	mlog.Info("loadtest started")
-	time.Sleep(60 * time.Second)
+	time.Sleep(1800 * time.Second)
 
 	err = lt.Stop()
 	mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))

--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -334,3 +334,11 @@ func (s *SampleStore) SetUsers(users []*model.User) error {
 
 func (s *SampleStore) Clear() {
 }
+
+func (s *SampleStore) SetChannelView(channelId string) error {
+	return nil
+}
+
+func (s *SampleStore) ChannelView(channelId string) (int64, error) {
+	return 0, nil
+}

--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -342,3 +342,11 @@ func (s *SampleStore) SetChannelView(channelId string) error {
 func (s *SampleStore) ChannelView(channelId string) (int64, error) {
 	return 0, nil
 }
+
+func (s *SampleStore) Status(userId string) (model.Status, error) {
+	return model.Status{}, nil
+}
+
+func (s *SampleStore) SetStatus(userId string, status *model.Status) error {
+	return nil
+}

--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -350,3 +350,7 @@ func (s *SampleStore) Status(userId string) (model.Status, error) {
 func (s *SampleStore) SetStatus(userId string, status *model.Status) error {
 	return nil
 }
+
+func (s *SampleStore) GetUser(userId string) (model.User, error) {
+	return model.User{}, nil
+}

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -419,3 +419,6 @@ func (u *SampleUser) SetCurrentTeam(team *model.Team) error {
 func (u *SampleUser) SetCurrentChannel(channel *model.Channel) error {
 	return nil
 }
+
+func (u *SampleUser) ClearUserData() {
+}

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -425,3 +425,7 @@ func (u *SampleUser) ClearUserData() {
 
 func (u *SampleUser) SendTypingEvent(channelId, parentId string) {
 }
+
+func (u *SampleUser) UpdatePreferences(pref *model.Preferences) error {
+	return nil
+}

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -422,3 +422,6 @@ func (u *SampleUser) SetCurrentChannel(channel *model.Channel) error {
 
 func (u *SampleUser) ClearUserData() {
 }
+
+func (u *SampleUser) SendTypingEvent(channelId, parentId string) {
+}

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -429,3 +429,11 @@ func (u *SampleUser) SendTypingEvent(channelId, parentId string) {
 func (u *SampleUser) UpdatePreferences(pref *model.Preferences) error {
 	return nil
 }
+
+func (u *SampleUser) GetUsersInChannel(channelId string, page, perPage int) error {
+	return nil
+}
+
+func (u *SampleUser) GetUsers(page, perPage int) error {
+	return nil
+}

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -585,25 +585,24 @@ func Reload(u user.User) UserActionResponse {
 		return UserActionResponse{Err: NewUserError(err)}
 	}
 
-	prefs, _ := u.Store().Preferences()
+	prefs, err := u.Store().Preferences()
+	if err != nil {
+		return UserActionResponse{Err: NewUserError(err)}
+	}
+
 	var userIds []string
-	var chanId string
-	// TODO: possibly remove this. Data should probably come from the store.
 	for _, p := range prefs {
 		switch {
-		case p.Name == model.PREFERENCE_NAME_LAST_CHANNEL:
-			chanId = p.Value
 		case p.Category == model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW:
 			userIds = append(userIds, p.Name)
 		}
 	}
 
-	if chanId == "" {
-		if c, err := u.Store().CurrentChannel(); err == nil {
-			chanId = c.Id
-		} else if err != nil && err != memstore.ErrChannelNotFound {
-			return UserActionResponse{Err: NewUserError(err)}
-		}
+	var chanId string
+	if c, err := u.Store().CurrentChannel(); err == nil {
+		chanId = c.Id
+	} else if err != nil && err != memstore.ErrChannelNotFound {
+		return UserActionResponse{Err: NewUserError(err)}
 	}
 
 	if chanId != "" {

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -595,6 +595,10 @@ func Reload(u user.User) UserActionResponse {
 		switch {
 		case p.Category == model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW:
 			userIds = append(userIds, p.Name)
+		case p.Category == "group_channel_show":
+			if err := u.GetUsersInChannel(p.Name, 0, 8); err != nil {
+				return UserActionResponse{Err: NewUserError(err)}
+			}
 		}
 	}
 

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -599,11 +599,11 @@ func Reload(u user.User) UserActionResponse {
 	}
 
 	if chanId == "" {
-		c, err := u.Store().CurrentChannel()
-		if err != nil {
+		if c, err := u.Store().CurrentChannel(); err == nil {
+			chanId = c.Id
+		} else if err != nil && err != memstore.ErrChannelNotFound {
 			return UserActionResponse{Err: NewUserError(err)}
 		}
-		chanId = c.Id
 	}
 
 	if chanId != "" {

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -170,3 +170,24 @@ func (c *SimulController) getUsersStatuses() control.UserActionResponse {
 
 	return control.UserActionResponse{Info: fmt.Sprintf("got statuses")}
 }
+
+func createPost(u user.User) control.UserActionResponse {
+	channel, err := u.Store().CurrentChannel()
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	// This is an estimate that comes from stats on community servers.
+	// The average length (in words) for a root post (not a reply).
+	wordCount := 34
+	postId, err := u.CreatePost(&model.Post{
+		Message:   control.GenerateRandomSentences(wordCount),
+		ChannelId: channel.Id,
+		CreateAt:  time.Now().Unix() * 1000,
+	})
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	return control.UserActionResponse{Info: fmt.Sprintf("post created, id %v", postId)}
+}

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -34,7 +34,6 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 		if err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
-
 		c.connect()
 	}
 
@@ -141,4 +140,13 @@ func switchChannel(u user.User) control.UserActionResponse {
 	}
 
 	return control.UserActionResponse{Info: fmt.Sprintf("switched to channel %s", channel.Id)}
+}
+
+func (c *SimulController) getUsersStatuses() control.UserActionResponse {
+	err := c.user.GetUsersStatusesByIds([]string{c.user.Store().Id()})
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	return control.UserActionResponse{Info: fmt.Sprintf("got statuses")}
 }

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -41,11 +41,12 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 		c.connect()
 	}
 
-	if resp := control.Reload(c.user); resp.Err != nil {
+	resp := control.Reload(c.user)
+	if resp.Err != nil {
 		return resp
-	} else {
-		c.status <- c.newInfoStatus(resp.Info)
 	}
+
+	c.status <- c.newInfoStatus(resp.Info)
 
 	team, err := c.user.Store().CurrentTeam()
 	if err != nil {
@@ -59,13 +60,14 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 }
 
 func (c *SimulController) login() control.UserActionResponse {
-	if resp := control.Login(c.user); resp.Err != nil {
-		return resp
-	} else {
-		c.connect()
-		go c.wsEventHandler()
+	resp := control.Login(c.user)
+	if resp.Err != nil {
 		return resp
 	}
+
+	c.connect()
+
+	return resp
 }
 
 func (c *SimulController) joinTeam(u user.User) control.UserActionResponse {

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -5,6 +5,7 @@ package simulcontroller
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
@@ -177,9 +178,19 @@ func createPost(u user.User) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
+	// TODO: possibly add some additional idle time here to simulate the
+	// user actually taking time to type a post message.
+	u.SendTypingEvent(channel.Id, "")
+
 	// This is an estimate that comes from stats on community servers.
 	// The average length (in words) for a root post (not a reply).
-	wordCount := 34
+	// TODO: should be part of some advanced configuration.
+	avgWordCount := 34
+	minWordCount := 1
+
+	// TODO: make a util function out of this behaviour.
+	wordCount := rand.Intn(avgWordCount*2-minWordCount*2) + minWordCount
+
 	postId, err := u.CreatePost(&model.Post{
 		Message:   control.GenerateRandomSentences(wordCount),
 		ChannelId: channel.Id,

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -240,7 +240,7 @@ func createPost(u user.User) control.UserActionResponse {
 	return control.UserActionResponse{Info: fmt.Sprintf("post created, id %v", postId)}
 }
 
-func createDirectChannel(u user.User) control.UserActionResponse {
+func (c *SimulController) createDirectChannel(u user.User) control.UserActionResponse {
 	// Here we make a call to GetUsers to simulate the user opening the users
 	// list when creating a direct channel.
 	if err := u.GetUsers(0, 100); err != nil {
@@ -293,10 +293,12 @@ func createDirectChannel(u user.User) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	return control.UserActionResponse{Info: fmt.Sprintf("direct channel created, id %s", channelId)}
+	c.status <- c.newInfoStatus(fmt.Sprintf("direct channel created, id %s", channelId))
+
+	return createPost(u)
 }
 
-func createGroupChannel(u user.User) control.UserActionResponse {
+func (c *SimulController) createGroupChannel(u user.User) control.UserActionResponse {
 	// Here we make a call to GetUsers to simulate the user opening the users
 	// list when creating a group channel.
 	if err := u.GetUsers(0, 100); err != nil {
@@ -348,5 +350,7 @@ func createGroupChannel(u user.User) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	return control.UserActionResponse{Info: fmt.Sprintf("group channel created, id %s with users %+v", channelId, userIds)}
+	c.status <- c.newInfoStatus(fmt.Sprintf("group channel created, id %s with users %+v", channelId, userIds))
+
+	return createPost(u)
 }

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -118,7 +119,7 @@ func switchChannel(u user.User) control.UserActionResponse {
 		if _, err := u.ViewChannel(&model.ChannelView{ChannelId: current.Id}); err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
-	} else {
+	} else if err != memstore.ErrChannelNotFound {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -56,18 +56,7 @@ func (c *SimulController) Run() {
 		},
 		{
 			run: func(u user.User) control.UserActionResponse {
-				resp := control.Login(u)
-				if resp.Err != nil {
-					return resp
-				}
-				c.connect()
-				go c.wsEventHandler()
-				return resp
-			},
-		},
-		{
-			run: func(u user.User) control.UserActionResponse {
-				return c.reload(false)
+				return c.login()
 			},
 		},
 		{
@@ -137,7 +126,6 @@ func (c *SimulController) Run() {
 		},
 		{
 			run: func(u user.User) control.UserActionResponse {
-				u.ClearUserData()
 				return c.reload(true)
 			},
 			frequency: 40,
@@ -145,19 +133,19 @@ func (c *SimulController) Run() {
 		{
 			run: func(u user.User) control.UserActionResponse {
 				// logout
-				if resp := control.Logout(c.user); resp.Err != nil {
+				if resp := control.Logout(u); resp.Err != nil {
 					c.status <- c.newErrorStatus(resp.Err)
 				} else {
 					c.status <- c.newInfoStatus(resp.Info)
 				}
 
+				u.ClearUserData()
+
 				// login
-				if resp := control.Login(c.user); resp.Err != nil {
+				if resp := c.login(); resp.Err != nil {
 					c.status <- c.newErrorStatus(resp.Err)
 				} else {
 					c.status <- c.newInfoStatus(resp.Info)
-					c.connect()
-					go c.wsEventHandler()
 				}
 
 				// reload

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -109,11 +109,11 @@ func (c *SimulController) Run() {
 			frequency: 55,
 		},
 		{
-			run:       createDirectChannel,
+			run:       c.createDirectChannel,
 			frequency: 1,
 		},
 		{
-			run:       createGroupChannel,
+			run:       c.createGroupChannel,
 			frequency: 1,
 		},
 		{

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -101,6 +101,10 @@ func (c *SimulController) Run() {
 			frequency: 60,
 		},
 		{
+			run:       createPost,
+			frequency: 55,
+		},
+		{
 			run: func(u user.User) control.UserActionResponse {
 				u.ClearUserData()
 				return c.reload(true)

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -94,22 +94,26 @@ func (c *SimulController) Run() {
 	actions := []userAction{
 		{
 			run:       switchChannel,
-			frequency: 165,
+			frequency: 300,
 		},
 		{
 			run:       c.switchTeam,
-			frequency: 60,
+			frequency: 110,
 		},
 		{
 			run:       createPost,
-			frequency: 55,
+			frequency: 100,
+		},
+		{
+			run:       createDirectChannel,
+			frequency: 1,
 		},
 		{
 			run: func(u user.User) control.UserActionResponse {
 				u.ClearUserData()
 				return c.reload(true)
 			},
-			frequency: 20,
+			frequency: 40,
 		},
 		{
 			run: func(u user.User) control.UserActionResponse {
@@ -132,7 +136,7 @@ func (c *SimulController) Run() {
 				// reload
 				return c.reload(false)
 			},
-			frequency: 1,
+			frequency: 3,
 		},
 	}
 

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -74,9 +74,7 @@ func (c *SimulController) Run() {
 			},
 		},
 		{
-			run: func(u user.User) control.UserActionResponse {
-				return c.joinTeam(u)
-			},
+			run: c.joinTeam,
 		},
 	}
 

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -109,6 +109,10 @@ func (c *SimulController) Run() {
 			frequency: 1,
 		},
 		{
+			run:       createGroupChannel,
+			frequency: 1,
+		},
+		{
 			run: func(u user.User) control.UserActionResponse {
 				u.ClearUserData()
 				return c.reload(true)

--- a/loadtest/control/simulcontroller/controller_test.go
+++ b/loadtest/control/simulcontroller/controller_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package simulcontroller
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetRate(t *testing.T) {
+	c, err := New(1, &userentity.UserEntity{}, make(chan control.UserStatus))
+	require.Nil(t, err)
+	require.Equal(t, 1.0, c.rate)
+
+	err = c.SetRate(-1.0)
+	require.NotNil(t, err)
+	require.Equal(t, 1.0, c.rate)
+
+	err = c.SetRate(0.0)
+	require.Nil(t, err)
+	require.Equal(t, 0.0, c.rate)
+
+	err = c.SetRate(1.5)
+	require.Nil(t, err)
+	require.Equal(t, 1.5, c.rate)
+}
+
+func TestRunStop(t *testing.T) {
+	store := memstore.New()
+
+	user := userentity.New(store, userentity.Config{
+		ServerURL:    "http://localhost:8065",
+		WebSocketURL: "ws://localhost:8065",
+	})
+	statusChan := make(chan control.UserStatus)
+	c, err := New(1, user, statusChan)
+	require.Nil(t, err)
+
+	doneRunning := make(chan struct{})
+	go func() {
+		c.Run()
+		close(doneRunning)
+	}()
+
+	status := <-statusChan
+	require.NoError(t, status.Err)
+	require.Equal(t, "user started", status.Info)
+
+	doneHandlingStatus := make(chan struct{})
+	go func() {
+		var last control.UserStatus
+		for {
+			status, ok := <-statusChan
+			if !ok {
+				require.Equal(t, "user stopped", last.Info)
+				break
+			}
+			last = status
+		}
+		close(doneHandlingStatus)
+	}()
+
+	c.Stop()
+	<-doneRunning
+	close(statusChan)
+	<-doneHandlingStatus
+}

--- a/loadtest/control/simulcontroller/periodic.go
+++ b/loadtest/control/simulcontroller/periodic.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package simulcontroller
+
+import (
+	"time"
+)
+
+const (
+	getUsersStatusByIdsInterval = 60 * time.Second
+)
+
+func (c *SimulController) periodicActions() {
+	for {
+		select {
+		case <-time.After(getUsersStatusByIdsInterval):
+			if resp := c.getUsersStatuses(); resp.Err != nil {
+				c.status <- c.newErrorStatus(resp.Err)
+			} else {
+				c.status <- c.newInfoStatus(resp.Info)
+			}
+		// We can add more periodic actions here.
+		case <-c.stop:
+			return
+		}
+	}
+}

--- a/loadtest/control/simulcontroller/websocket.go
+++ b/loadtest/control/simulcontroller/websocket.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package simulcontroller
+
+import (
+// "github.com/mattermost/mattermost-server/v5/model"
+)
+
+// wsEventHandler listens for WebSocket events to be handled.
+// This is used to model user behaviour by responding to certain events with
+// the appropriate actions. It differs from userentity.wsEventHandler which is
+// instead used to manage the internal user state.
+func (c *SimulController) wsEventHandler() {
+	for ev := range c.user.Events() {
+		switch ev.EventType() {
+		default:
+		}
+	}
+}

--- a/loadtest/control/simulcontroller/websocket.go
+++ b/loadtest/control/simulcontroller/websocket.go
@@ -4,7 +4,9 @@
 package simulcontroller
 
 import (
-// "github.com/mattermost/mattermost-server/v5/model"
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 // wsEventHandler listens for WebSocket events to be handled.
@@ -14,7 +16,48 @@ import (
 func (c *SimulController) wsEventHandler() {
 	for ev := range c.user.Events() {
 		switch ev.EventType() {
-		default:
+		case model.WEBSOCKET_EVENT_TYPING:
+			userId, ok := ev.Data["user_id"].(string)
+			if !ok || len(userId) == 0 {
+				c.status <- c.newErrorStatus(fmt.Errorf("simulcontroller: invalid data found in event data"))
+				break
+			}
+
+			user, err := c.user.Store().GetUser(userId)
+			if err != nil {
+				c.status <- c.newErrorStatus(fmt.Errorf("simulcontroller: GetUser failed %w", err))
+				break
+			}
+
+			// The user was found, we check if we have the status for it.
+			if len(user.Id) != 0 {
+				status, err := c.user.Store().Status(userId)
+				if err != nil {
+					c.status <- c.newErrorStatus(fmt.Errorf("simulcontroller: Status failed %w", err))
+					break
+				}
+
+				// If we can't find the user status in the store we fetch it.
+				if len(status.UserId) == 0 {
+					if err := c.user.GetUsersStatusesByIds([]string{user.Id}); err != nil {
+						c.status <- c.newErrorStatus(fmt.Errorf("simulcontroller: GetUsersStatusesByIds failed %w", err))
+						break
+					}
+				}
+
+				break
+			}
+
+			// We couldn't find the user so we fetch it and its status.
+			if _, err := c.user.GetUsersByIds([]string{userId}); err != nil {
+				c.status <- c.newErrorStatus(fmt.Errorf("simulcontroller: GetUsersByIds failed %w", err))
+				break
+			}
+
+			if err := c.user.GetUsersStatusesByIds([]string{userId}); err != nil {
+				c.status <- c.newErrorStatus(fmt.Errorf("simulcontroller: GetUsersStatusesByIds failed %w", err))
+				break
+			}
 		}
 	}
 }

--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -115,11 +115,23 @@ func (s *MemStore) RandomUser() (model.User, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	key, err := pickRandomKeyFromMap(s.users)
-	if err != nil {
-		return model.User{}, err
+	if len(s.users) < 1 {
+		return model.User{}, ErrLenMismatch
 	}
-	return *s.users[key.(string)], nil
+
+	for {
+		key, err := pickRandomKeyFromMap(s.users)
+		if err != nil {
+			return model.User{}, err
+		}
+		user := s.users[key.(string)]
+		// We don't want to pick ourselves.
+		if user.Id == s.user.Id {
+			continue
+		}
+
+		return *user, nil
+	}
 }
 
 // RandomUsers returns N random users from the set of users.

--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -126,10 +126,9 @@ func (s *MemStore) RandomUser() (model.User, error) {
 		}
 		user := s.users[key.(string)]
 		// We don't want to pick ourselves.
-		if user.Id == s.user.Id {
+		if s.user != nil && user.Id == s.user.Id {
 			continue
 		}
-
 		return *user, nil
 	}
 }

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -113,6 +113,7 @@ func (s *MemStore) SetConfig(config *model.Config) {
 func (s *MemStore) User() (*model.User, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
+
 	return s.user, nil
 }
 
@@ -556,6 +557,23 @@ func (s *MemStore) Users() ([]*model.User, error) {
 		i++
 	}
 	return users, nil
+}
+
+func (s *MemStore) GetUser(userId string) (model.User, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	var user model.User
+
+	if len(userId) == 0 {
+		return user, errors.New("memstore: userId should not be empty")
+	}
+
+	if u, ok := s.users[userId]; ok {
+		user = *u
+	}
+
+	return user, nil
 }
 
 func (s *MemStore) SetUsers(users []*model.User) error {

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -230,7 +230,8 @@ func (s *MemStore) Channel(channelId string) (*model.Channel, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if channel, ok := s.channels[channelId]; ok {
-		return channel, nil
+		channelCopy := *channel
+		return &channelCopy, nil
 	}
 	return nil, nil
 }

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -26,6 +26,7 @@ type MemStore struct {
 	channelMembers map[string]map[string]*model.ChannelMember
 	teamMembers    map[string]map[string]*model.TeamMember
 	users          map[string]*model.User
+	statuses       map[string]*model.Status
 	reactions      map[string][]*model.Reaction
 	roles          map[string]*model.Role
 	license        map[string]string
@@ -54,6 +55,7 @@ func (s *MemStore) Clear() {
 	s.channelMembers = map[string]map[string]*model.ChannelMember{}
 	s.teamMembers = map[string]map[string]*model.TeamMember{}
 	s.users = map[string]*model.User{}
+	s.statuses = map[string]*model.Status{}
 	s.reactions = map[string][]*model.Reaction{}
 	s.roles = map[string]*model.Role{}
 	s.license = map[string]string{}
@@ -564,6 +566,39 @@ func (s *MemStore) SetUsers(users []*model.User) error {
 	for _, user := range users {
 		s.users[user.Id] = user
 	}
+	return nil
+}
+
+func (s *MemStore) Status(userId string) (model.Status, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	var status model.Status
+
+	if len(userId) == 0 {
+		return status, errors.New("memstore: userId should not be empty")
+	}
+
+	if st, ok := s.statuses[userId]; ok {
+		status = *st
+	}
+	return status, nil
+}
+
+func (s *MemStore) SetStatus(userId string, status *model.Status) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if len(userId) == 0 {
+		return errors.New("memstore: userId should not be empty")
+	}
+
+	if status == nil {
+		return errors.New("memstore: status should not be nil")
+	}
+
+	s.statuses[userId] = status
+
 	return nil
 }
 

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -50,6 +50,9 @@ type UserStore interface {
 	// ChannelView return the timestamp of the last view for the given channelId.
 	ChannelView(channelId string) (int64, error)
 
+	// GetUser returns the user for the given userId.
+	GetUser(userId string) (model.User, error)
+
 	// Status returns the status for the given userId.
 	Status(userId string) (model.Status, error)
 

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -47,7 +47,7 @@ type UserStore interface {
 	ChannelPosts(channelId string) ([]*model.Post, error)
 	// ChannelPostsSorted returns all posts for given channelId, sorted by CreateAt
 	ChannelPostsSorted(channelId string, asc bool) ([]*model.Post, error)
-	// ChannelView return the timestamp of the last view for the given channelId.
+	// ChannelView returns the timestamp of the last view for the given channelId.
 	ChannelView(channelId string) (int64, error)
 
 	// GetUser returns the user for the given userId.

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -50,6 +50,9 @@ type UserStore interface {
 	// ChannelView return the timestamp of the last view for the given channelId.
 	ChannelView(channelId string) (int64, error)
 
+	// Status returns the status for the given userId.
+	Status(userId string) (model.Status, error)
+
 	// Teams returns the teams a user belong to.
 	Teams() ([]model.Team, error)
 	// CurrentTeam gets the currently selected team for the user.
@@ -104,6 +107,9 @@ type MutableUserStore interface {
 	User() (*model.User, error)
 	SetUsers(users []*model.User) error
 	Users() ([]*model.User, error)
+
+	// statuses
+	SetStatus(userId string, status *model.Status) error
 
 	// posts
 	SetPost(post *model.Post) error

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -47,6 +47,9 @@ type UserStore interface {
 	ChannelPosts(channelId string) ([]*model.Post, error)
 	// ChannelPostsSorted returns all posts for given channelId, sorted by CreateAt
 	ChannelPostsSorted(channelId string, asc bool) ([]*model.Post, error)
+	// ChannelView return the timestamp of the last view for the given channelId.
+	ChannelView(channelId string) (int64, error)
+
 	// Teams returns the teams a user belong to.
 	Teams() ([]model.Team, error)
 	// CurrentTeam gets the currently selected team for the user.
@@ -121,6 +124,9 @@ type MutableUserStore interface {
 	SetChannels(channels []*model.Channel) error
 	// SetCurrentChannel sets the channel the user is currently viewing.
 	SetCurrentChannel(channel *model.Channel) error
+	// SetChannelView marks a channel as viewed and updates the store with the
+	// current timestamp.
+	SetChannelView(channelId string) error
 	// SetChannelMembers stores the given channel members in the store.
 	SetChannelMembers(channelMembers *model.ChannelMembers) error
 	ChannelMembers(channelId string) (*model.ChannelMembers, error)

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -42,6 +42,8 @@ type User interface {
 	GetUsersByUsernames(usernames []string) ([]string, error)
 	GetUserStatus() error
 	GetUsersStatusesByIds(userIds []string) error
+	GetUsersInChannel(channelId string, page, perPage int) error
+	GetUsers(page, perPage int) error
 	SetProfileImage(data []byte) error
 	GetProfileImage() error
 	GetProfileImageForUser(userId string) error

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -125,4 +125,8 @@ type User interface {
 
 	// Clear clears the underlying UserStore
 	ClearUserData()
+
+	// SendTypingEvent will push a user_typing event out to all connected users
+	// who are in the specified channel.
+	SendTypingEvent(channelId, parentId string)
 }

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -122,4 +122,7 @@ type User interface {
 	IsSysAdmin() (bool, error)
 	SetCurrentTeam(team *model.Team) error
 	SetCurrentChannel(channel *model.Channel) error
+
+	// Clear clears the underlying UserStore
+	ClearUserData()
 }

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -34,6 +34,7 @@ type User interface {
 	// user
 	GetMe() (string, error)
 	GetPreferences() error
+	UpdatePreferences(pref *model.Preferences) error
 	CreateUser(user *model.User) (string, error)
 	UpdateUser(user *model.User) error
 	PatchUser(userId string, patch *model.UserPatch) error

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -552,9 +552,15 @@ func (ue *UserEntity) GetUserStatus() error {
 }
 
 func (ue *UserEntity) GetUsersStatusesByIds(userIds []string) error {
-	_, resp := ue.client.GetUsersStatusesByIds(userIds)
+	statusList, resp := ue.client.GetUsersStatusesByIds(userIds)
 	if resp.Error != nil {
 		return resp.Error
+	}
+
+	for _, status := range statusList {
+		if err := ue.store.SetStatus(status.UserId, status); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -93,6 +93,26 @@ func (ue *UserEntity) GetPreferences() error {
 	return nil
 }
 
+func (ue *UserEntity) UpdatePreferences(pref *model.Preferences) error {
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return err
+	}
+
+	if pref == nil {
+		return errors.New("userentity: pref should not be nil")
+	}
+
+	ok, resp := ue.client.UpdatePreferences(user.Id, pref)
+	if resp.Error != nil {
+		return resp.Error
+	} else if !ok {
+		return errors.New("userentity: failed to update preferences")
+	}
+
+	return nil
+}
+
 func (ue *UserEntity) CreateUser(user *model.User) (string, error) {
 	user, resp := ue.client.CreateUser(user)
 	if resp.Error != nil {

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -359,6 +359,10 @@ func (ue *UserEntity) ViewChannel(view *model.ChannelView) (*model.ChannelViewRe
 		return nil, resp.Error
 	}
 
+	if err := ue.store.SetChannelView(view.ChannelId); err != nil {
+		return nil, err
+	}
+
 	return channelViewResponse, nil
 }
 
@@ -773,4 +777,8 @@ func (ue *UserEntity) SetCurrentTeam(team *model.Team) error {
 
 func (ue *UserEntity) SetCurrentChannel(channel *model.Channel) error {
 	return ue.store.SetCurrentChannel(channel)
+}
+
+func (ue *UserEntity) ClearUserData() {
+	ue.store.Clear()
 }

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -552,6 +552,7 @@ func (ue *UserEntity) GetUsersStatusesByIds(userIds []string) error {
 	if resp.Error != nil {
 		return resp.Error
 	}
+
 	return nil
 }
 

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -586,6 +586,28 @@ func (ue *UserEntity) GetUsersStatusesByIds(userIds []string) error {
 	return nil
 }
 
+func (ue *UserEntity) GetUsersInChannel(channelId string, page, perPage int) error {
+	if len(channelId) == 0 {
+		return errors.New("userentity: channelId should not be empty")
+	}
+
+	users, resp := ue.client.GetUsersInChannel(channelId, page, perPage, "")
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return ue.store.SetUsers(users)
+}
+
+func (ue *UserEntity) GetUsers(page, perPage int) error {
+	users, resp := ue.client.GetUsers(page, perPage, "")
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return ue.store.SetUsers(users)
+}
+
 func (ue *UserEntity) GetTeamStats(teamId string) error {
 	_, resp := ue.client.GetTeamStats(teamId, "")
 	if resp.Error != nil {

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -81,6 +81,7 @@ func New(store store.MutableUserStore, config Config) *UserEntity {
 	}
 	ue.store = store
 	ue.wsEventChan = make(chan *model.WebSocketEvent)
+	ue.wsTyping = make(chan userTypingMsg)
 	return &ue
 }
 
@@ -89,7 +90,6 @@ func (ue *UserEntity) Connect() <-chan error {
 	ue.wsClosing = make(chan struct{})
 	ue.wsClosed = make(chan struct{})
 	ue.wsErrorChan = make(chan error, 1)
-	ue.wsTyping = make(chan userTypingMsg)
 	if ue.client.AuthToken == "" {
 		ue.wsErrorChan <- errors.New("user is not authenticated")
 		return ue.wsErrorChan
@@ -150,6 +150,7 @@ func (ue *UserEntity) Events() <-chan *model.WebSocketEvent {
 // can be called multiple times.
 func (ue *UserEntity) Cleanup() {
 	close(ue.wsEventChan)
+	close(ue.wsTyping)
 }
 
 func (ue *UserEntity) IsSysAdmin() (bool, error) {

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -23,6 +23,7 @@ type UserEntity struct {
 	wsClosed    chan struct{}
 	wsErrorChan chan error
 	wsEventChan chan *model.WebSocketEvent
+	wsTyping    chan userTypingMsg
 	connected   bool
 	config      Config
 }
@@ -39,6 +40,11 @@ type Config struct {
 	Email string
 	// The password to be used by the entity.
 	Password string
+}
+
+type userTypingMsg struct {
+	channelId string
+	parentId  string
 }
 
 // Store returns the underlying store of the user.
@@ -83,6 +89,7 @@ func (ue *UserEntity) Connect() <-chan error {
 	ue.wsClosing = make(chan struct{})
 	ue.wsClosed = make(chan struct{})
 	ue.wsErrorChan = make(chan error, 1)
+	ue.wsTyping = make(chan userTypingMsg)
 	if ue.client.AuthToken == "" {
 		ue.wsErrorChan <- errors.New("user is not authenticated")
 		return ue.wsErrorChan

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -116,6 +116,8 @@ func (ue *UserEntity) listen(errChan chan error) {
 				// Explicit disconnect. Return.
 				close(ue.wsClosed)
 				return
+			case msg := <-ue.wsTyping:
+				client.UserTyping(msg.channelId, msg.parentId)
 			}
 			if chanClosed {
 				break
@@ -149,4 +151,13 @@ func getWaitTime(failCount int) time.Duration {
 		}
 	}
 	return waitTime
+}
+
+// SendTypingEvent will push a user_typing event out to all connected users
+// who are in the specified channel.
+func (ue *UserEntity) SendTypingEvent(channelId, parentId string) {
+	ue.wsTyping <- userTypingMsg{
+		channelId,
+		parentId,
+	}
 }

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -116,7 +116,11 @@ func (ue *UserEntity) listen(errChan chan error) {
 				// Explicit disconnect. Return.
 				close(ue.wsClosed)
 				return
-			case msg := <-ue.wsTyping:
+			case msg, ok := <-ue.wsTyping:
+				if !ok {
+					chanClosed = true
+					break
+				}
 				client.UserTyping(msg.channelId, msg.parentId)
 			}
 			if chanClosed {


### PR DESCRIPTION
#### Summary

This PR mainly implements or refactors several actions for `SimulController` in the quest to improve the overall simulation quality.

My strategy was to begin with the most frequent API calls and try to simulate the related user behaviour as best as possible.

In the end I've decided to split this since it was becoming way too big to be easily reviewed and also was taking a lot of time.

Included in the PR are:

- Signup/Login/Logout/Reload actions.
- Action to join a team.
- Actions to switch teams/channels.
- Action to create a post.
- Actions to create direct/group channels.
- Event handler for `user_typing`.

A bit of a **note**:

`SimulController` is still under heavy development and nothing is set in stone. As you might notice I've left several `TODOs` to speed up development and avoid getting stuck into smaller details.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23140