### PR TITLE
[MM-23450] Deploy a clustered load test agent setup using Terraform

### DIFF
--- a/config/deployer.default.json
+++ b/config/deployer.default.json
@@ -10,6 +10,9 @@
     "DBPassword": "mostest80098bigpass_",
     "MattermostDownloadURL": "https://releases.mattermost.com/5.20.1/mattermost-5.20.1-linux-amd64.tar.gz",
     "MattermostLicenseFile": "",
+    "AdminEmail": "sysadmin@sample.mattermost.com",
+    "AdminUsername": "sysadmin",
+    "AdminPassword": "Sys@dmin-sample1",
     "LogSettings": {
         "EnableConsole": true,
         "ConsoleLevel": "INFO",

--- a/config/deployer.default.json
+++ b/config/deployer.default.json
@@ -1,6 +1,7 @@
 {
     "ClusterName": "loadtest",
     "AppInstanceCount": 1,
+    "AgentCount": 2,
     "SSHPublicKey": "~/.ssh/id_rsa.pub",
     "DBInstanceCount": 1,
     "DBInstanceEngine": "aurora-mysql",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -19,9 +19,7 @@ import (
 type Config struct {
 	ClusterName      string // Name of the cluster.
 	AppInstanceCount int    // Number of application instances.
-	// Number of agents; at least 2 agents required so that one of them will work
-	// as a coordinator.
-	AgentCount       int
+	AgentCount       int    // Number of agents, first agent will also be the coordinator.
 	SSHPublicKey     string // Path to the SSH public key.
 	DBInstanceCount  int    // Number of DB instances.
 	DBInstanceClass  string // Type of the DB instance.

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -35,6 +35,9 @@ type Config struct {
 	// stable release.
 	MattermostDownloadURL string
 	MattermostLicenseFile string // Path to the Mattermost EE license file.
+	AdminEmail            string // Mattermost instance sysadmin e-mail.
+	AdminUsername         string // Mattermost instance sysadmin user name.
+	AdminPassword         string // Mattermost instance sysadmin password.
 	GoBinaryFile          string // Go binaries to compile loadtest-agents.
 	SourceCodeRef         string // loadtest-ng head reference
 	LogSettings           logger.Settings

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	AdminEmail            string // Mattermost instance sysadmin e-mail.
 	AdminUsername         string // Mattermost instance sysadmin user name.
 	AdminPassword         string // Mattermost instance sysadmin password.
-	GoBinaryFile          string // Go binaries to compile loadtest-agents.
+	GoVersion             string // Go version to download for compiling loadtest-agents.
 	SourceCodeRef         string // loadtest-ng head reference
 	LogSettings           logger.Settings
 }
@@ -88,7 +88,7 @@ func ReadConfig(filePath string) (*Config, error) {
 	v.SetDefault("LogSettings.FileJson", true)
 	v.SetDefault("LogSettings.FileLocation", "loadtest.log")
 
-	v.SetDefault("GoBinaryFile", "go1.14.1.linux-amd64.tar.gz")
+	v.SetDefault("GoVersion", "1.14.1")
 	v.SetDefault("SourceCodeRef", "master")
 
 	if filePath != "" {

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	AdminUsername         string // Mattermost instance sysadmin user name.
 	AdminPassword         string // Mattermost instance sysadmin password.
 	GoVersion             string // Go version to download for compiling loadtest-agents.
-	SourceCodeRef         string // loadtest-ng head reference
+	SourceCodeRef         string // load-test-ng head reference.
 	LogSettings           logger.Settings
 }
 
@@ -59,8 +59,8 @@ func (c *Config) IsValid() error {
 	if len(clusterName) == 0 || !unicode.IsLetter(firstRune) || !isAlphanumeric(clusterName) {
 		return fmt.Errorf("db cluster name must begin with a letter and contain only alphanumeric characters")
 	}
-	if c.AgentCount < 2 {
-		return fmt.Errorf("number of agents must be greater than 2")
+	if c.AgentCount < 1 {
+		return fmt.Errorf("at least 1 agent is required to run load tests")
 	}
 
 	return nil

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -19,7 +19,7 @@ import (
 type Config struct {
 	ClusterName      string // Name of the cluster.
 	AppInstanceCount int    // Number of application instances.
-	AgentCount       int    // Number of agents, first agent will also be the coordinator.
+	AgentCount       int    // Number of agents, first agent and coordinator will share the same instance.
 	SSHPublicKey     string // Path to the SSH public key.
 	DBInstanceCount  int    // Number of DB instances.
 	DBInstanceClass  string // Type of the DB instance.

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -128,7 +128,7 @@ func (t *Terraform) configureAndRunCoordinator(extAgent *ssh.ExtAgent, ip string
 		return fmt.Errorf("error running ssh command: %w", err)
 	}
 
-	// Starting coordinator.
+	// TODO: This is a hack to overcome an issue with go run command.
 	mlog.Info("Compiling coordinator", mlog.String("ip", ip))
 	cmd := "cd mattermost-load-test-ng && export PATH=$PATH:/usr/local/go/bin && go build -o lt-coordinator ./cmd/coordinator"
 	if err := sshc.RunCommand(cmd); err != nil {

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -1,0 +1,116 @@
+package terraform
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
+	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+	"github.com/mattermost/mattermost-server/v5/mlog"
+)
+
+func (t *Terraform) generateLoadtestAgentConfig(output *terraformOutput) loadtest.Config {
+	return loadtest.Config{
+		ConnectionConfiguration: loadtest.ConnectionConfiguration{
+			ServerURL:                   "http://" + output.Instances.Value[0].PrivateIP + ":8065",
+			WebSocketURL:                "ws://" + output.Instances.Value[0].PrivateIP + ":8065",
+			AdminEmail:                  t.config.AdminEmail,
+			AdminPassword:               t.config.AdminPassword,
+			IdleConnTimeoutMilliseconds: 90000,
+		},
+		UserControllerConfiguration: loadtest.UserControllerConfiguration{
+			Type: "simple",
+			Rate: 1.0,
+		},
+		InstanceConfiguration: loadtest.InstanceConfiguration{
+			NumTeams: 2,
+		},
+		UsersConfiguration: loadtest.UsersConfiguration{
+			InitialActiveUsers: 4,
+			MaxActiveUsers:     1000,
+		},
+	}
+}
+
+func (t *Terraform) startCoordinator(extAgent *ssh.ExtAgent, ip string) error {
+	sshc, err := extAgent.NewClient(ip)
+	if err != nil {
+		return err
+	}
+
+	srcPath := "$HOME/mattermost-load-test-ng-" + t.config.SourceCodeRef
+
+	// Populate the DB.
+	mlog.Info("Populating DB")
+	cmd := fmt.Sprintf("cd %s && go run ./cmd/loadtest init", srcPath)
+	if err := sshc.RunCommand(cmd); err != nil {
+		return err
+	}
+
+	// Starting coordinator.
+	mlog.Info("Starting coordinator", mlog.String("ip", ip))
+	cmd = fmt.Sprintf("cd %s && go run ./cmd/loadtest coordinator &", srcPath)
+	if err := sshc.RunCommand(cmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *Terraform) runAgent(extAgent *ssh.ExtAgent, ip string) error {
+	sshc, err := extAgent.NewClient(ip)
+	if err != nil {
+		return err
+	}
+
+	srcPath := "$HOME/mattermost-load-test-ng-" + t.config.SourceCodeRef
+
+	// Starting agent.
+	mlog.Info("Starting agent", mlog.String("ip", ip))
+	cmd := fmt.Sprintf("cd %s && go run ./cmd/loadtest server &", srcPath)
+	if err := sshc.RunCommand(cmd); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *Terraform) updateCoordinatorConfig(extAgent *ssh.ExtAgent, output *terraformOutput) error {
+	loadtestConfig := t.generateLoadtestAgentConfig(output)
+
+	var loadAgentConfigs []agent.LoadAgentConfig
+	for i := 1; i < len(output.Agents.Value); i++ {
+		val := output.Agents.Value[i]
+		loadAgentConfigs = append(loadAgentConfigs, agent.LoadAgentConfig{
+			Id:             val.Tags.Name,
+			ApiURL:         val.PrivateIP + ":4000",
+			LoadTestConfig: loadtestConfig,
+		})
+	}
+
+	sshc, err := extAgent.NewClient(output.Agents.Value[0].PublicIP)
+	if err != nil {
+		return err
+	}
+
+	srcPath := "$HOME/mattermost-load-test-ng-" + t.config.SourceCodeRef
+	data, err := json.Marshal(loadAgentConfigs)
+	if err != nil {
+		return err
+	}
+	for k, v := range map[string]interface{}{
+		"ClusterConfig.Agents": string(data),
+		".PrometheusURL":       output.MetricsServer.Value.PrivateIP,
+	} {
+		buf, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("invalid config: key: %s, err: %v", k, err)
+		}
+		cmd := fmt.Sprintf(`jq '%s = %s' %s/config/config.json > /tmp/agent.json && mv /tmp/agent.json %s/config/config.json`, k, string(buf), srcPath, srcPath)
+		fmt.Println(cmd)
+		if err := sshc.RunCommand(cmd); err != nil {
+			return fmt.Errorf("error running ssh command: cmd: %s, err: %v", cmd, err)
+		}
+	}
+	return nil
+}

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -78,11 +78,9 @@ func (t *Terraform) configureAndRunAgent(extAgent *ssh.ExtAgent, ip string, outp
 	// Starting agent.
 	mlog.Info("Starting agent", mlog.String("ip", ip))
 	cmd := "cd mattermost-load-test-ng && export PATH=$PATH:/usr/local/go/bin && go run ./cmd/loadtest server"
-	go func() {
-		if err := sshc.RunCommand(cmd); err != nil {
-			mlog.Error("error running command: " + err.Error())
-		}
-	}()
+	if err := sshc.StartCommand(cmd); err != nil {
+		mlog.Error("error running command: " + err.Error())
+	}
 	return nil
 }
 
@@ -134,11 +132,9 @@ func (t *Terraform) configureAndRunCoordinator(extAgent *ssh.ExtAgent, ip string
 	// Starting coordinator.
 	mlog.Info("Starting coordinator", mlog.String("ip", ip))
 	cmd := "cd mattermost-load-test-ng && export PATH=$PATH:/usr/local/go/bin && go run ./cmd/coordinator"
-	go func() {
-		if err := sshc.RunCommand(cmd); err != nil {
-			mlog.Error("error running command: " + err.Error())
-		}
-	}()
+	if err := sshc.StartCommand(cmd); err != nil {
+		mlog.Error("error running command: " + err.Error())
+	}
 
 	return nil
 }

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -279,6 +279,13 @@ resource "aws_security_group" "agent" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port = 4000
+    to_port   = 4000
+    protocol  = "tcp"
+    self      = true
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -129,11 +129,16 @@ resource "aws_instance" "loadtest_agent" {
   provisioner "remote-exec" {
       inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
+      "wget --no-check-certificate -qO - https://s3-eu-west-1.amazonaws.com/deb.robustperception.io/41EFC99D.gpg | sudo apt-key add -",
+      "sudo apt-get -y update",
+      "sudo apt-get install -y jq",
       "wget https://dl.google.com/go/${var.go_binary_file}",
-      "tar -C /usr/local -xzf ${var.go_binary_file}",
+      "sudo tar -C /usr/local -xzf ${var.go_binary_file}",
       "export PATH=$PATH:/usr/local/go/bin",
       "wget https://github.com/mattermost/mattermost-load-test-ng/archive/${var.loadtest_source_code_ref}.tar.gz",
-      "tar -xzf ${var.loadtest_source_code_ref}.tar.gz"
+      "tar -xzf ${var.loadtest_source_code_ref}.tar.gz",
+      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.json",
+      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.json"
     ] 
   }
 }

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -164,6 +164,8 @@ resource "aws_instance" "loadtest_agent" {
   provisioner "remote-exec" {
       inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
+      "wget --no-check-certificate -qO - https://s3-eu-west-1.amazonaws.com/deb.robustperception.io/41EFC99D.gpg | sudo apt-key add -",
+      "sudo apt-get -y update",
       "wget https://dl.google.com/go/go${var.go_version}.linux-amd64.tar.gz",
       "sudo tar -C /usr/local -xzf go${var.go_version}.linux-amd64.tar.gz",
       "sudo sh -c \"echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile\"",

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -129,16 +129,14 @@ resource "aws_instance" "loadtest_agent" {
   provisioner "remote-exec" {
       inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "wget --no-check-certificate -qO - https://s3-eu-west-1.amazonaws.com/deb.robustperception.io/41EFC99D.gpg | sudo apt-key add -",
-      "sudo apt-get -y update",
-      "sudo apt-get install -y jq",
       "wget https://dl.google.com/go/${var.go_binary_file}",
       "sudo tar -C /usr/local -xzf ${var.go_binary_file}",
-      "export PATH=$PATH:/usr/local/go/bin",
       "wget https://github.com/mattermost/mattermost-load-test-ng/archive/${var.loadtest_source_code_ref}.tar.gz",
       "tar -xzf ${var.loadtest_source_code_ref}.tar.gz",
-      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.json",
-      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.json"
+      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.default.json simplecontroller.json",
+      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.default.json config.json",
+      "cp -r mattermost-load-test-ng-${var.loadtest_source_code_ref}/testdata testdata",
+      "cd mattermost-load-test-ng-${var.loadtest_source_code_ref} && export PATH=$PATH:/usr/local/go/bin && go build -o agent ./cmd/loadtest && sudo mv agent /usr/local/bin"
     ] 
   }
 }

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -108,6 +108,36 @@ resource "aws_rds_cluster" "db_cluster" {
   vpc_security_group_ids = ["${aws_security_group.db.id}"]
 }
 
+resource "aws_instance" "loadtest_agent" {
+  tags = {
+    Name = "${var.cluster_name}-agent-${count.index}"
+  }
+
+  connection {
+    type = "ssh"
+    user = "ubuntu"
+    host = self.public_ip
+  }
+
+  ami           = "ami-0fc20dd1da406780b"
+  instance_type = "t2.medium"
+  key_name      = aws_key_pair.key.id
+  count         = var.loadtest_agent_count
+
+  vpc_security_group_ids = ["${aws_security_group.agent.id}"]
+
+  provisioner "remote-exec" {
+      inline = [
+      "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
+      "wget https://dl.google.com/go/${var.go_binary_file}",
+      "tar -C /usr/local -xzf ${var.go_binary_file}",
+      "export PATH=$PATH:/usr/local/go/bin",
+      "wget https://github.com/mattermost/mattermost-load-test-ng/archive/${var.loadtest_source_code_ref}.tar.gz",
+      "tar -xzf ${var.loadtest_source_code_ref}.tar.gz"
+    ] 
+  }
+}
+
 resource "aws_security_group" "app" {
   name        = "${var.cluster_name}-app-security-group"
   description = "App security group for loadtest cluster ${var.cluster_name}"
@@ -161,6 +191,32 @@ resource "aws_security_group" "db" {
     to_port         = 5432
     protocol        = "tcp"
     security_groups = ["${aws_security_group.app.id}"]
+  }
+}
+
+resource "aws_security_group" "agent" {
+  name        = "${var.cluster_name}-agent-security-group"
+  description = "Loadtest agent security group for loadtest cluster ${var.cluster_name}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 4000
+    to_port     = 4000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -164,7 +164,6 @@ resource "aws_instance" "loadtest_agent" {
   provisioner "remote-exec" {
       inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "wget --no-check-certificate -qO - https://s3-eu-west-1.amazonaws.com/deb.robustperception.io/41EFC99D.gpg | sudo apt-key add -",
       "sudo apt-get -y update",
       "wget https://dl.google.com/go/go${var.go_version}.linux-amd64.tar.gz",
       "sudo tar -C /usr/local -xzf go${var.go_version}.linux-amd64.tar.gz",

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -169,8 +169,9 @@ resource "aws_instance" "loadtest_agent" {
       "sudo sh -c \"echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile\"",
       "wget https://github.com/mattermost/mattermost-load-test-ng/archive/${var.loadtest_source_code_ref}.tar.gz",
       "tar -xzf ${var.loadtest_source_code_ref}.tar.gz",
-      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.json",
-      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.json",
+      "mv mattermost-load-test-ng-${var.loadtest_source_code_ref} mattermost-load-test-ng",
+      "cp mattermost-load-test-ng/config/simplecontroller.default.json mattermost-load-test-ng/config/simplecontroller.json",
+      "cp mattermost-load-test-ng/config/config.default.json mattermost-load-test-ng/config/config.json",
     ] 
   }
 }

--- a/deployment/terraform/cluster.tf
+++ b/deployment/terraform/cluster.tf
@@ -164,14 +164,13 @@ resource "aws_instance" "loadtest_agent" {
   provisioner "remote-exec" {
       inline = [
       "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-      "wget https://dl.google.com/go/${var.go_binary_file}",
-      "sudo tar -C /usr/local -xzf ${var.go_binary_file}",
+      "wget https://dl.google.com/go/go${var.go_version}.linux-amd64.tar.gz",
+      "sudo tar -C /usr/local -xzf go${var.go_version}.linux-amd64.tar.gz",
+      "sudo sh -c \"echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile\"",
       "wget https://github.com/mattermost/mattermost-load-test-ng/archive/${var.loadtest_source_code_ref}.tar.gz",
       "tar -xzf ${var.loadtest_source_code_ref}.tar.gz",
-      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.default.json simplecontroller.json",
-      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.default.json config.json",
-      "cp -r mattermost-load-test-ng-${var.loadtest_source_code_ref}/testdata testdata",
-      "cd mattermost-load-test-ng-${var.loadtest_source_code_ref} && export PATH=$PATH:/usr/local/go/bin && go build -o agent ./cmd/loadtest && sudo mv agent /usr/local/bin"
+      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/simplecontroller.json",
+      "cp mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.default.json mattermost-load-test-ng-${var.loadtest_source_code_ref}/config/config.json",
     ] 
   }
 }
@@ -275,13 +274,6 @@ resource "aws_security_group" "agent" {
   ingress {
     from_port   = 22
     to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 4000
-    to_port     = 4000
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
@@ -183,13 +184,16 @@ func (t *Terraform) Create() error {
 	}
 
 	// Creating the sysadmin user.
-
+	// should wait the server to start
+	time.Sleep(30 * time.Second)
 	cmd := fmt.Sprintf("/opt/mattermost/bin/mattermost user create --email %s --username %s --password %s --system_admin",
 		t.config.AdminEmail,
 		t.config.AdminUsername,
 		t.config.AdminPassword,
 	)
-	sshc, err := extAgent.NewClient("PROXY")
+	mlog.Info("Creating admin user:", mlog.String("cmd", cmd))
+	// TODO: replace with reverse nginx ip
+	sshc, err := extAgent.NewClient(output.Instances.Value[0].PublicIP)
 	if err != nil {
 		return err
 	}

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -223,7 +223,6 @@ func (t *Terraform) setupLoadtestAgents(extAgent *ssh.ExtAgent, output *terrafor
 		return err
 	}
 
-	time.Sleep(30 * time.Second)
 	// TODO: start this independently with "start" command
 	if err := t.configureAndRunCoordinator(extAgent, coordinator.PublicIP, output); err != nil {
 		return err

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -223,6 +223,7 @@ func (t *Terraform) setupLoadtestAgents(extAgent *ssh.ExtAgent, output *terrafor
 		return err
 	}
 
+	time.Sleep(30 * time.Second)
 	// TODO: start this independently with "start" command
 	if err := t.configureAndRunCoordinator(extAgent, coordinator.PublicIP, output); err != nil {
 		return err

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -212,16 +212,19 @@ func (t *Terraform) setupAppServers(output *terraformOutput, extAgent *ssh.ExtAg
 
 func (t *Terraform) setupLoadtestAgents(extAgent *ssh.ExtAgent, output *terraformOutput) error {
 	for _, val := range output.Agents.Value {
-		if err := t.runAgent(extAgent, val.PublicIP); err != nil {
+		if err := t.configureAndRunAgent(extAgent, val.PublicIP, output); err != nil {
 			return fmt.Errorf("error while setting up an agent (%s) : %w", val.Tags.Name, err)
 		}
 	}
 
-	if err := t.updateCoordinatorConfig(extAgent, output); err != nil {
+	coordinator := output.Agents.Value[0]
+	// TODO: make this optional
+	if err := t.initLoadtest(extAgent, coordinator.PublicIP); err != nil {
 		return err
 	}
 
-	if err := t.startCoordinator(extAgent, output.Agents.Value[0].PublicIP); err != nil {
+	// TODO: start this independently with "start" command
+	if err := t.configureAndRunCoordinator(extAgent, coordinator.PublicIP, output); err != nil {
 		return err
 	}
 

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -24,7 +24,7 @@ func (t *Terraform) Destroy() error {
 		"-var", fmt.Sprintf("db_password=%s", t.config.DBPassword),
 		"-var", fmt.Sprintf("mattermost_download_url=%s", t.config.MattermostDownloadURL),
 		"-var", fmt.Sprintf("mattermost_license_file=%s", t.config.MattermostLicenseFile),
-		"-var", fmt.Sprintf("go_binary_file=%s", t.config.GoBinaryFile),
+		"-var", fmt.Sprintf("go_version=%s", t.config.GoVersion),
 		"-var", fmt.Sprintf("loadtest_source_code_ref=%s", t.config.SourceCodeRef),
 		"-auto-approve",
 		"./deployment/terraform",

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -15,6 +15,7 @@ func (t *Terraform) Destroy() error {
 	return t.runCommand(nil, "destroy",
 		"-var", fmt.Sprintf("cluster_name=%s", t.config.ClusterName),
 		"-var", fmt.Sprintf("app_instance_count=%d", t.config.AppInstanceCount),
+		"-var", fmt.Sprintf("loadtest_agent_count=%d", t.config.AgentCount),
 		"-var", fmt.Sprintf("ssh_public_key=%s", t.config.SSHPublicKey),
 		"-var", fmt.Sprintf("db_instance_count=%d", t.config.DBInstanceCount),
 		"-var", fmt.Sprintf("db_instance_engine=%s", t.config.DBInstanceEngine),
@@ -23,6 +24,8 @@ func (t *Terraform) Destroy() error {
 		"-var", fmt.Sprintf("db_password=%s", t.config.DBPassword),
 		"-var", fmt.Sprintf("mattermost_download_url=%s", t.config.MattermostDownloadURL),
 		"-var", fmt.Sprintf("mattermost_license_file=%s", t.config.MattermostLicenseFile),
+		"-var", fmt.Sprintf("go_binary_file=%s", t.config.GoBinaryFile),
+		"-var", fmt.Sprintf("loadtest_source_code_ref=%s", t.config.SourceCodeRef),
 		"-auto-approve",
 		"./deployment/terraform",
 	)

--- a/deployment/terraform/outputs.tf
+++ b/deployment/terraform/outputs.tf
@@ -6,6 +6,10 @@ output "dbCluster" {
   value = "${aws_rds_cluster.db_cluster}"
 }
 
+output "agents" {
+  value = "${aws_instance.loadtest_agent.*}"
+}
+
 output "metricsServer" {
   value = "${aws_instance.metrics_server}"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -4,6 +4,9 @@ variable "cluster_name" {
 variable "app_instance_count" {
 }
 
+variable "loadtest_agent_count" {
+}
+
 variable "db_instance_count" {
 }
 
@@ -34,4 +37,10 @@ variable "mattermost_download_url" {
 }
 
 variable "mattermost_license_file" {
+}
+
+variable "go_binary_file" {
+}
+
+variable "loadtest_source_code_ref" {
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -39,7 +39,7 @@ variable "mattermost_download_url" {
 variable "mattermost_license_file" {
 }
 
-variable "go_binary_file" {
+variable "go_version" {
 }
 
 variable "loadtest_source_code_ref" {


### PR DESCRIPTION
#### Summary
This PR adds loadtest agents and a coordinator while running load tests on AWS.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23450

