### PR TITLE
[MM-23512] Fix deadlock in SimulController

### DIFF
--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -48,6 +48,9 @@ func (c *SimulController) Run() {
 		return
 	}
 
+	// Start listening for websocket events.
+	go c.wsEventHandler()
+
 	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
 
 	defer func() {
@@ -69,7 +72,6 @@ func (c *SimulController) Run() {
 				if resp.Err != nil {
 					return resp
 				}
-				go c.wsEventHandler()
 				return resp
 			},
 		},


### PR DESCRIPTION
#### Summary

If initial login failed `SimulController` would never run the websocket event handler.
This in turn would create a deadlock when the underlying ws client (in `userentity`) would be trying to write to the `wsEventChan` without anyone reading.

@agnivade spotted this when running a load-test with several (100+) users. After a call to `Stop()` the `LoadTester` would block on a certain controller (cause of the mentioned deadlock) and the rest of controllers coming after it in the slice of controllers would continue running indefinitely.

We might still need a strategy to handle the initial login failure case, maybe stop the controller completely. Need some thinking about so I'll leave it for a separate PR.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23512