### PR TITLE
[MM-23225] Add ability to get seed from environment variable

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -6,6 +6,8 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
@@ -31,7 +33,19 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 
 	controllerType := config.UserControllerConfiguration.Type
 
-	rand.Seed(time.Now().Unix())
+	s := os.Getenv("MM_LOADTEST_SEED")
+	var seed int64
+	if s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			mlog.Error(fmt.Sprintf("could not convert %q to a numeric value", s))
+		}
+		seed = int64(v)
+	} else {
+		seed = time.Now().Unix()
+	}
+	rand.Seed(seed)
+	mlog.Info(fmt.Sprintf("random seed value is: %d", seed))
 
 	mlog.Info(fmt.Sprintf("will run load-test with UserController of type %s", controllerType))
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
@@ -29,6 +30,12 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	controllerType := config.UserControllerConfiguration.Type
+
+	seed, err := cmd.Flags().GetInt64("seed")
+	if err != nil {
+		return err
+	}
+	rand.Seed(seed)
 
 	mlog.Info(fmt.Sprintf("will run load-test with UserController of type %s", controllerType))
 
@@ -87,6 +94,7 @@ func MakeLoadTestCommand() *cobra.Command {
 		RunE:   RunLoadTestCmdF,
 		PreRun: SetupLoadTest,
 	}
+	cmd.PersistentFlags().Int64("seed", time.Now().UnixNano(), "random seed value to seed rand")
 	cmd.PersistentFlags().StringP("simplecontroller-config", "s", "", "path to the simplecontroller configuration file to use")
 	cmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
 	return cmd

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -31,11 +31,7 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 
 	controllerType := config.UserControllerConfiguration.Type
 
-	seed, err := cmd.Flags().GetInt64("seed")
-	if err != nil {
-		return err
-	}
-	rand.Seed(seed)
+	rand.Seed(time.Now().Unix())
 
 	mlog.Info(fmt.Sprintf("will run load-test with UserController of type %s", controllerType))
 
@@ -94,7 +90,6 @@ func MakeLoadTestCommand() *cobra.Command {
 		RunE:   RunLoadTestCmdF,
 		PreRun: SetupLoadTest,
 	}
-	cmd.PersistentFlags().Int64("seed", time.Now().UnixNano(), "random seed value to seed rand")
 	cmd.PersistentFlags().StringP("simplecontroller-config", "s", "", "path to the simplecontroller configuration file to use")
 	cmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
 	return cmd

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -5,9 +5,6 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
@@ -33,18 +30,7 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 
 	controllerType := config.UserControllerConfiguration.Type
 
-	s := os.Getenv("MM_LOADTEST_SEED")
-	var seed int64
-	if s != "" {
-		v, err := strconv.Atoi(s)
-		if err != nil {
-			mlog.Error(fmt.Sprintf("could not convert %q to a numeric value", s))
-		}
-		seed = int64(v)
-	} else {
-		seed = time.Now().Unix()
-	}
-	rand.Seed(seed)
+	seed := memstore.SetRandomSeed()
 	mlog.Info(fmt.Sprintf("random seed value is: %d", seed))
 
 	mlog.Info(fmt.Sprintf("will run load-test with UserController of type %s", controllerType))

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -5,28 +5,15 @@ package simulcontroller
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"strconv"
 	"testing"
-	"time"
 
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
-	s := os.Getenv("MM_LOADTEST_SEED")
-	var seed int64
-	if s != "" {
-		v, err := strconv.Atoi(s)
-		if err != nil {
-			panic(err)
-		}
-		seed = int64(v)
-	} else {
-		seed = time.Now().Unix()
-	}
-	rand.Seed(seed)
+	seed := memstore.SetRandomSeed()
 	fmt.Printf("Seed value is: %d\n", seed)
 	os.Exit(m.Run())
 }

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -4,10 +4,28 @@
 package simulcontroller
 
 import (
+	"math/rand"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	s := os.Getenv("LOADTEST_SEED")
+	if s != "" {
+		seed, err := strconv.Atoi(s)
+		if err != nil {
+			panic(err)
+		}
+		rand.Seed(int64(seed))
+	} else {
+		rand.Seed(time.Now().Unix())
+	}
+	os.Exit(m.Run())
+}
 
 func TestPickAction(t *testing.T) {
 	t.Run("Empty slice", func(t *testing.T) {

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -4,6 +4,7 @@
 package simulcontroller
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -14,16 +15,19 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	s := os.Getenv("LOADTEST_SEED")
+	s := os.Getenv("MM_LOADTEST_SEED")
+	var seed int64
 	if s != "" {
-		seed, err := strconv.Atoi(s)
+		v, err := strconv.Atoi(s)
 		if err != nil {
 			panic(err)
 		}
-		rand.Seed(int64(seed))
+		seed = int64(v)
 	} else {
-		rand.Seed(time.Now().Unix())
+		seed = time.Now().Unix()
 	}
+	rand.Seed(seed)
+	fmt.Printf("Seed value is: %d\n", seed)
 	os.Exit(m.Run())
 }
 

--- a/loadtest/control/utils.go
+++ b/loadtest/control/utils.go
@@ -38,13 +38,6 @@ const (
 var re = regexp.MustCompile(`-[[:alpha:]]+`)
 var words []string
 
-// TODO: this is currently unused. Should be probably called once when starting
-// the load-test cmd or API server. It should also be called only when running
-// a load-test in production.
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 // getErrOrigin returns a string indicating the location of the error that
 // just occurred. It's a utility function used to find out exactly where an
 // error has happened since actions inside a UserController might get called

--- a/loadtest/control/utils_test.go
+++ b/loadtest/control/utils_test.go
@@ -6,31 +6,18 @@ package control
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
-	"time"
 
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
-	s := os.Getenv("MM_LOADTEST_SEED")
-	var seed int64
-	if s != "" {
-		v, err := strconv.Atoi(s)
-		if err != nil {
-			panic(err)
-		}
-		seed = int64(v)
-	} else {
-		seed = time.Now().Unix()
-	}
-	rand.Seed(seed)
+	seed := memstore.SetRandomSeed()
 	fmt.Printf("Seed value is: %d\n", seed)
 	os.Exit(m.Run())
 }

--- a/loadtest/control/utils_test.go
+++ b/loadtest/control/utils_test.go
@@ -6,13 +6,31 @@ package control
 import (
 	"errors"
 	"fmt"
+	"math/rand"
+	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	s := os.Getenv("LOADTEST_SEED")
+	if s != "" {
+		seed, err := strconv.Atoi(s)
+		if err != nil {
+			panic(err)
+		}
+		rand.Seed(int64(seed))
+	} else {
+		rand.Seed(time.Now().Unix())
+	}
+	os.Exit(m.Run())
+}
 
 func TestRandomizeUserName(t *testing.T) {
 	name := RandomizeUserName("test-agent-1-user-4")

--- a/loadtest/control/utils_test.go
+++ b/loadtest/control/utils_test.go
@@ -19,16 +19,19 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	s := os.Getenv("LOADTEST_SEED")
+	s := os.Getenv("MM_LOADTEST_SEED")
+	var seed int64
 	if s != "" {
-		seed, err := strconv.Atoi(s)
+		v, err := strconv.Atoi(s)
 		if err != nil {
 			panic(err)
 		}
-		rand.Seed(int64(seed))
+		seed = int64(v)
 	} else {
-		rand.Seed(time.Now().Unix())
+		seed = time.Now().Unix()
 	}
+	rand.Seed(seed)
+	fmt.Printf("Seed value is: %d\n", seed)
 	os.Exit(m.Run())
 }
 

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -6,11 +6,8 @@ package memstore
 import (
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -20,18 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	s := os.Getenv("MM_LOADTEST_SEED")
-	var seed int64
-	if s != "" {
-		v, err := strconv.Atoi(s)
-		if err != nil {
-			panic(err)
-		}
-		seed = int64(v)
-	} else {
-		seed = time.Now().Unix()
-	}
-	rand.Seed(seed)
+	seed := SetRandomSeed()
 	fmt.Printf("Seed value is: %d\n", seed)
 	os.Exit(m.Run())
 }

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -5,6 +5,7 @@ package memstore
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -19,16 +20,19 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	s := os.Getenv("LOADTEST_SEED")
+	s := os.Getenv("MM_LOADTEST_SEED")
+	var seed int64
 	if s != "" {
-		seed, err := strconv.Atoi(s)
+		v, err := strconv.Atoi(s)
 		if err != nil {
 			panic(err)
 		}
-		rand.Seed(int64(seed))
+		seed = int64(v)
 	} else {
-		rand.Seed(time.Now().Unix())
+		seed = time.Now().Unix()
 	}
+	rand.Seed(seed)
+	fmt.Printf("Seed value is: %d\n", seed)
 	os.Exit(m.Run())
 }
 

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -5,7 +5,11 @@ package memstore
 
 import (
 	"errors"
+	"math/rand"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -13,6 +17,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	s := os.Getenv("LOADTEST_SEED")
+	if s != "" {
+		seed, err := strconv.Atoi(s)
+		if err != nil {
+			panic(err)
+		}
+		rand.Seed(int64(seed))
+	} else {
+		rand.Seed(time.Now().Unix())
+	}
+	os.Exit(m.Run())
+}
 
 func TestRandomUsers(t *testing.T) {
 	s := New()

--- a/loadtest/store/memstore/utils.go
+++ b/loadtest/store/memstore/utils.go
@@ -4,6 +4,12 @@
 package memstore
 
 import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
@@ -43,4 +49,21 @@ func restorePrivateData(old, new *model.User) {
 	if new.MfaSecret == "" {
 		new.MfaSecret = old.MfaSecret
 	}
+}
+
+// SetRandomSeed sets the global random seed and returns it's value.
+func SetRandomSeed() int64 {
+	s := os.Getenv("MM_LOADTEST_SEED")
+	var seed int64
+	if s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			panic(fmt.Sprintf("could not convert %q to a numeric value", s))
+		}
+		seed = int64(v)
+	} else {
+		seed = time.Now().Unix()
+	}
+	rand.Seed(seed)
+	return seed
 }


### PR DESCRIPTION
#### Summary
This PR adds:
- Global seed when running 'loadtest`
- `TestMain` functions to be able to set rand seed. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23225

