### PR TITLE
[MM-23565] ssh: add start command

### DIFF
--- a/deployment/terraform/ssh/ssh.go
+++ b/deployment/terraform/ssh/ssh.go
@@ -81,6 +81,18 @@ func (sshc *Client) RunCommand(cmd string) error {
 	return sess.Run(cmd)
 }
 
+// StartCommand starts a given command in a new ssh session. Unlike RunCommand
+// this command does not wait command to finish.
+func (sshc *Client) StartCommand(cmd string) error {
+	sess, err := sshc.client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer sess.Close()
+
+	return sess.Start(cmd)
+}
+
 // Upload uploads a given src object to a given destination file.
 func (sshc *Client) Upload(src io.Reader, dst string, sudo bool) error {
 	if strings.ContainsAny(dst, `'\`) {

--- a/deployment/terraform/ssh/ssh.go
+++ b/deployment/terraform/ssh/ssh.go
@@ -82,7 +82,8 @@ func (sshc *Client) RunCommand(cmd string) error {
 }
 
 // StartCommand starts a given command in a new ssh session. Unlike RunCommand
-// this command does not wait command to finish.
+// this command does not wait command to finish. This is needed for running
+// commands in the background.
 func (sshc *Client) StartCommand(cmd string) error {
 	sess, err := sshc.client.NewSession()
 	if err != nil {


### PR DESCRIPTION

#### Summary
Added `Start(cmd)` method to run a command w/o waiting it to finish. I can update the PR if others (e.g. `Wait`) are needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23565

