### PR TITLE
[MM-23627] Fix deadlock on SendTypingEvent()

### DIFF
--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -44,8 +44,8 @@ func New(store store.MutableUserStore, serverURL string) *SampleUser {
 	}
 }
 
-func (u *SampleUser) Connect() <-chan error {
-	return nil
+func (u *SampleUser) Connect() (<-chan error, error) {
+	return nil, nil
 }
 
 func (u *SampleUser) Disconnect() error {
@@ -423,7 +423,8 @@ func (u *SampleUser) SetCurrentChannel(channel *model.Channel) error {
 func (u *SampleUser) ClearUserData() {
 }
 
-func (u *SampleUser) SendTypingEvent(channelId, parentId string) {
+func (u *SampleUser) SendTypingEvent(channelId, parentId string) error {
+	return nil
 }
 
 func (u *SampleUser) UpdatePreferences(pref *model.Preferences) error {

--- a/loadtest/control/noopcontroller/controller.go
+++ b/loadtest/control/noopcontroller/controller.go
@@ -70,7 +70,11 @@ func (c *NoopController) Run() {
 		c.status <- c.newErrorStatus(resp.Err)
 	} else {
 		c.status <- c.newInfoStatus(resp.Info)
-		errChan := c.user.Connect()
+		errChan, err := c.user.Connect()
+		if err != nil {
+			c.status <- c.newErrorStatus(err)
+			return
+		}
 		go func() {
 			for err := range errChan {
 				c.status <- c.newErrorStatus(err)

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -111,17 +111,25 @@ func (c *SimpleController) reload(full bool) control.UserActionResponse {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 
-		c.connect()
+		if err := c.connect(); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
 	}
 
 	return control.Reload(c.user)
 }
 
-func (c *SimpleController) connect() {
-	errChan := c.user.Connect()
+func (c *SimpleController) connect() error {
+	errChan, err := c.user.Connect()
+	if err != nil {
+		return fmt.Errorf("connect failed %w", err)
+	}
+
 	go func() {
 		for err := range errChan {
 			c.status <- c.newErrorStatus(err)
 		}
 	}()
+
+	return nil
 }

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -68,7 +68,6 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 func (c *SimulController) login() control.UserActionResponse {
 	resp := control.Login(c.user)
 	if resp.Err != nil {
-		fmt.Println(resp.Err.Error())
 		return resp
 	}
 

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -22,23 +22,29 @@ type userAction struct {
 	frequency int
 }
 
-func (c *SimulController) connect() {
-	errChan := c.user.Connect()
+func (c *SimulController) connect() error {
+	errChan, err := c.user.Connect()
+	if err != nil {
+		return fmt.Errorf("connect failed %w", err)
+	}
 	go func() {
 		for err := range errChan {
 			c.status <- c.newErrorStatus(err)
 		}
 	}()
+
+	return nil
 }
 
 func (c *SimulController) reload(full bool) control.UserActionResponse {
 	if full {
-		err := c.user.Disconnect()
-		if err != nil {
+		if err := c.user.Disconnect(); err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 		c.user.ClearUserData()
-		c.connect()
+		if err := c.connect(); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
 	}
 
 	resp := control.Reload(c.user)
@@ -62,10 +68,13 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 func (c *SimulController) login() control.UserActionResponse {
 	resp := control.Login(c.user)
 	if resp.Err != nil {
+		fmt.Println(resp.Err.Error())
 		return resp
 	}
 
-	c.connect()
+	if err := c.connect(); err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
 
 	return resp
 }
@@ -217,7 +226,9 @@ func createPost(u user.User) control.UserActionResponse {
 
 	// TODO: possibly add some additional idle time here to simulate the
 	// user actually taking time to type a post message.
-	u.SendTypingEvent(channel.Id, "")
+	if err := u.SendTypingEvent(channel.Id, ""); err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
 
 	// This is an estimate that comes from stats on community servers.
 	// The average length (in words) for a root post (not a reply).

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -18,7 +18,7 @@ type User interface {
 	Cleanup()
 
 	// connection
-	Connect() <-chan error
+	Connect() (<-chan error, error)
 	Disconnect() error
 	// Events returns the WebSocket event chan for the controller
 	// to listen and react to events.
@@ -131,5 +131,5 @@ type User interface {
 
 	// SendTypingEvent will push a user_typing event out to all connected users
 	// who are in the specified channel.
-	SendTypingEvent(channelId, parentId string)
+	SendTypingEvent(channelId, parentId string) error
 }

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -159,9 +159,13 @@ func getWaitTime(failCount int) time.Duration {
 
 // SendTypingEvent will push a user_typing event out to all connected users
 // who are in the specified channel.
-func (ue *UserEntity) SendTypingEvent(channelId, parentId string) {
+func (ue *UserEntity) SendTypingEvent(channelId, parentId string) error {
+	if !ue.connected {
+		return fmt.Errorf("user is not connected")
+	}
 	ue.wsTyping <- userTypingMsg{
 		channelId,
 		parentId,
 	}
+	return nil
 }


### PR DESCRIPTION
#### Summary

PR fixes yet another deadlock. Similarly to https://github.com/mattermost/mattermost-load-test-ng/pull/170, a failure to login would cause the ws client not to connect. When creating a post the user would still try to send the typing event regardless of the status of the connection. This would cause the user to block forever writing on the `wsTyping` channel.

PR also makes the `UserEntity.Connect()` method return an error to avoid a possible goroutine leak.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23627
