### PR TITLE
[MM-23628] Handle login failures in SimulController

### DIFF
--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -67,13 +67,7 @@ func (c *SimulController) Run() {
 			run: control.SignUp,
 		},
 		{
-			run: func(u user.User) control.UserActionResponse {
-				resp := c.login()
-				if resp.Err != nil {
-					return resp
-				}
-				return resp
-			},
+			run: c.login,
 		},
 		{
 			run: c.joinTeam,
@@ -134,7 +128,7 @@ func (c *SimulController) Run() {
 				u.ClearUserData()
 
 				// login
-				if resp := c.login(); resp.Err != nil {
+				if resp := c.login(c.user); resp.Err != nil {
 					c.status <- c.newErrorStatus(resp.Err)
 				} else {
 					c.status <- c.newInfoStatus(resp.Info)
@@ -176,7 +170,7 @@ func (c *SimulController) Run() {
 		select {
 		case <-c.stop:
 			return
-		case <-time.After(time.Millisecond * idleTimeMs):
+		case <-time.After(idleTimeMs * time.Millisecond):
 		}
 	}
 }


### PR DESCRIPTION
#### Summary

PR adds code to handle login failures in `SimulController` with a very simple re-try mechanism.
This will avoid having users continuously failing to run actions cause the initial login didn't succeed.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23628