### PR TITLE
[MM-23536] cmd/loadtest: remove config file requirement for server mode

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/gorilla/mux"
 )
@@ -55,9 +56,9 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	logger.Init(&config.LogSettings)
 
 	agentId := r.FormValue("id")
-
 	if a.agents[agentId] != nil {
 		writeResponse(w, http.StatusBadRequest, &Response{
 			Error: fmt.Sprintf("load-test agent with id %s already exists", agentId),

--- a/cmd/loadtest/server.go
+++ b/cmd/loadtest/server.go
@@ -25,7 +25,6 @@ func MakeServerCommand() *cobra.Command {
 		Short:        "Start API agent",
 		SilenceUsage: true,
 		RunE:         RunServerCmdF,
-		PreRun:       SetupLoadTest,
 	}
 	cmd.PersistentFlags().IntP("port", "p", 4000, "Port to listen on")
 


### PR DESCRIPTION

#### Summary
This PR removes the dependency to a config file when starting the `loadtest` in server mode. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23536
