### PR TITLE
[MM-23537] Update Makefile to produce binaries for the coordinator and the agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,16 @@
 GO=go
 
 DIST_ROOT=dist
-DIST_FOLDER_NAME=mattermost-load-test-ng
-DIST_PATH=$(DIST_ROOT)/$(DIST_FOLDER_NAME)
+# We specify version for the build; it is the branch-name by default, also we try
+# to find if there is a tag pointed to the current commit. If so, we use the tag.
+DIST_VER=$(shell git rev-parse --abbrev-ref HEAD)
+ifeq ($(shell git describe --tags $(git rev-parse @) >&/dev/null; echo $$?), 0)
+	DIST_VER=$(shell git describe --tags $(git rev-parse @))
+endif
+DIST_PATH=$(DIST_ROOT)/$(DIST_VER)
+
+COORDINATOR=lt-coordinator
+LOADTEST=lt-agent
 
 # GOOS/GOARCH of the build host, used to determine whether we're cross-compiling or not
 BUILDER_GOOS_GOARCH="$(shell $(GO) env GOOS)_$(shell $(GO) env GOARCH)"
@@ -13,15 +21,18 @@ all: install
 
 build-linux:
 	@echo Build Linux amd64
-	env GOOS=linux GOARCH=amd64 $(GO) install -mod=readonly -trimpath ./...
+	env GOOS=linux GOARCH=amd64 $(GO) build -o $(COORDINATOR) ./cmd/coordinator
+	env GOOS=linux GOARCH=amd64 $(GO) build -o $(LOADTEST) ./cmd/loadtest
 
 build-osx:
 	@echo Build OSX amd64
-	env GOOS=darwin GOARCH=amd64 $(GO) install -mod=readonly -trimpath ./...
+	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(COORDINATOR) ./cmd/coordinator
+	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(LOADTEST) ./cmd/loadtest
 
 build-windows:
 	@echo Build Windows amd64
-	env GOOS=windows GOARCH=amd64 $(GO) install -mod=readonly -trimpath ./...
+	env GOOS=windows GOARCH=amd64 $(GO) build -o $(COORDINATOR) ./cmd/coordinator
+	env GOOS=windows GOARCH=amd64 $(GO) build -o $(LOADTEST) ./cmd/loadtest
 
 assets:
 	go get github.com/kevinburke/go-bindata/go-bindata/...
@@ -33,31 +44,37 @@ build: assets build-linux build-windows build-osx
 install:
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
 	@$(MAKE) build-osx
+	@$(MAKE) install-gopath
 endif
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
 	@$(MAKE) build-windows
+	@$(MAKE) install-gopath
 endif
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
 	@$(MAKE) build-linux
+	@$(MAKE) install-gopath
 endif
 
-package: build-linux
+install-gopath: ; mv $(COORDINATOR) $(GOPATH)/bin; mv $(LOADTEST) $(GOPATH)/bin
+
+# We only support Linux to package for now. Package manually for other targets.
+package:
+ifneq ($(git diff --shortstat 2> /dev/null | tail -n1),"")
+	@echo Warning: Repository has uncommitted changes.
+endif
+	@$(MAKE) build-linux
 	rm -rf $(DIST_ROOT)
-	mkdir -p $(DIST_PATH)/bin
+	mkdir -p $(DIST_PATH)
+	mkdir -p $(DIST_PATH)/config
 
-	cp config.default.json $(DIST_PATH)/config/config.json
+	cp config/config.default.json $(DIST_PATH)/config/config.json
+	cp config/coordinator.default.json $(DIST_PATH)/config/coordinator.json
+	cp config/simplecontroller.default.json $(DIST_PATH)/config/simplecontroller.json
 	cp README.md $(DIST_PATH)
-	#cp -r testfiles $(DIST_PATH)
 
-	@# ----- PLATFORM SPECIFIC -----
-
-	@# Linux, the only supported package version for now. Build manually for other targets.
-ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
-	cp $(GOPATH)/bin/loadtest-ng $(DIST_PATH)/bin # from native bin dir, not cross-compiled
-else
-	cp $(GOPATH)/bin/linux_amd64/loadtest-ng $(DIST_PATH)/bin # from cross-compiled bin dir
-endif
-	tar -C $(DIST_ROOT) -czf $(DIST_PATH).tar.gz $(DIST_FOLDER_NAME)
+	tar cf $(COORDINATOR)_$(DIST_VER)_linux_amd64.tar.gz $(COORDINATOR) && mv $(COORDINATOR)_$(DIST_VER)_linux_amd64.tar.gz $(DIST_PATH)/
+	tar cf $(LOADTEST)_$(DIST_VER)_linux_amd64.tar.gz $(LOADTEST) && mv $(LOADTEST)_$(DIST_VER)_linux_amd64.tar.gz $(DIST_PATH)/
+	rm $(COORDINATOR) $(LOADTEST)
 
 verify-gomod:
 	$(GO) mod download
@@ -83,7 +100,8 @@ test:
 
 clean:
 	rm -f errors.log cache.db stats.log status.log
-	rm -f ./cmd/loadtest/loadtest-ng
+	rm -f $(COORDINATOR)
+	rm -f $(LOADTEST)
 	rm -f .installdeps
 	rm -f loadtest.log
 	rm -rf $(DIST_ROOT)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ifeq ($(shell git describe --tags $(git rev-parse @) >&/dev/null; echo $$?), 0)
 	DIST_VER=$(shell git describe --tags $(git rev-parse @))
 endif
 DIST_PATH=$(DIST_ROOT)/$(DIST_VER)
+STATUS=$(shell git diff-index --quiet HEAD --; echo $$?)
 
 COORDINATOR=lt-coordinator
 LOADTEST=lt-agent
@@ -59,7 +60,7 @@ install-gopath: ; mv $(COORDINATOR) $(GOPATH)/bin; mv $(LOADTEST) $(GOPATH)/bin
 
 # We only support Linux to package for now. Package manually for other targets.
 package:
-ifneq ($(git diff --shortstat 2> /dev/null | tail -n1),"")
+ifneq ($(STATUS), 0)
 	@echo Warning: Repository has uncommitted changes.
 endif
 	@$(MAKE) build-linux

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,6 @@ test:
 
 clean:
 	rm -f errors.log cache.db stats.log status.log
-	rm -f $(COORDINATOR)
-	rm -f $(LOADTEST)
 	rm -f .installdeps
 	rm -f loadtest.log
 	rm -rf $(DIST_ROOT)


### PR DESCRIPTION
#### Summary
This PR updates the `Makefile` to be able to do binary releases easier. In a nutshell, changes are:
- `make install` simply does `go install`
- The binaries and other files are now under `dist/version` (version can be either branch name or the tag)
- We make only the coordinator and the agent, default binary names are `lt-coordinator` and `lt-agent`. We may want to change :) 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23537
