### PR TITLE
MM-23711: add update team action

### DIFF
--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -83,7 +83,7 @@ func createTeamAdmins(admin *userentity.UserEntity, numUsers int, config *loadte
 		}
 		id := u.Store().Id()
 
-		if err = admin.UpdateUserRoles(id, model.SYSTEM_USER_ROLE_ID+" "+model.TEAM_ADMIN_ROLE_ID); err != nil {
+		if err := admin.UpdateUserRoles(id, model.SYSTEM_USER_ROLE_ID+" "+model.TEAM_ADMIN_ROLE_ID); err != nil {
 			return err
 		}
 		mlog.Info("user created", mlog.String("user_id", id))

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -77,8 +77,7 @@ func createTeamAdmins(admin *userentity.UserEntity, numUsers int, config *loadte
 		store := memstore.New()
 		u := userentity.New(store, ueConfig)
 
-		err := u.SignUp(ueConfig.Email, ueConfig.Username, ueConfig.Password)
-		if err != nil {
+		if err := u.SignUp(ueConfig.Email, ueConfig.Username, ueConfig.Password); err != nil {
 			mlog.Warn("error while signing up", mlog.Err(err)) // Possibly, user already exists.
 			continue
 		}

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -83,6 +84,14 @@ func createTeamAdmins(admin *userentity.UserEntity, numUsers int, config *loadte
 			continue
 		}
 		id := u.Store().Id()
+
+		ok, err := admin.IsSysAdmin()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.New("admin user is not a sysadmin")
+		}
 
 		err = admin.UpdateUserRoles(id, model.SYSTEM_USER_ROLE_ID+" "+model.TEAM_ADMIN_ROLE_ID)
 		if err != nil {

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -15,7 +15,8 @@
     "InstanceConfiguration": {
         "NumTeams": 2,
         "NumChannels": 10,
-        "NumTeamAdmins": 10
+        "NumTeamAdmins": 10,
+        "TeamAdminInterval": 10
     },
     "UsersConfiguration": {
         "InitialActiveUsers": 4,

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -13,7 +13,9 @@
       "Rate": 1.0
     },
     "InstanceConfiguration": {
-        "NumTeams": 2
+        "NumTeams": 2,
+        "NumChannels": 10,
+        "NumTeamAdmins": 10
     },
     "UsersConfiguration": {
         "InitialActiveUsers": 4,

--- a/config/simplecontroller.default.json
+++ b/config/simplecontroller.default.json
@@ -52,6 +52,11 @@
         "RunPeriod": 1
       },
       {
+        "ActionId": "UpdateTeam",
+        "WaitAfterMs": 1000,
+        "RunPeriod": 50
+      },
+      {
         "ActionId": "UpdateProfileImage",
         "WaitAfterMs": 1000,
         "RunPeriod": 1

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -280,6 +280,10 @@ func (u *SampleUser) UpdateUser(user *model.User) error {
 	return nil
 }
 
+func (u *SampleUser) UpdateUserRoles(userId, roles string) error {
+	return nil
+}
+
 func (u *SampleUser) PatchUser(userId string, patch *model.UserPatch) error {
 	return nil
 }
@@ -303,6 +307,10 @@ func (u *SampleUser) CreateTeam(team *model.Team) (string, error) {
 }
 
 func (u *SampleUser) GetTeam(teamId string) error {
+	return nil
+}
+
+func (u *SampleUser) UpdateTeam(team *model.Team) error {
 	return nil
 }
 
@@ -409,6 +417,10 @@ func (u *SampleUser) GetClientLicense() error {
 }
 
 func (u *SampleUser) IsSysAdmin() (bool, error) {
+	return false, nil
+}
+
+func (u *SampleUser) IsTeamAdmin() (bool, error) {
 	return false, nil
 }
 

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -93,7 +93,10 @@ func (ucc *UserControllerConfiguration) IsValid() error {
 }
 
 type InstanceConfiguration struct {
-	NumTeams int
+	NumTeams          int
+	NumChannels       int
+	NumTeamAdmins     int
+	TeamAdminInterval int
 }
 
 // IsValid reports whether a given InstanceConfiguration is valid or not.

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -102,6 +102,14 @@ func (c *SimpleController) updateProfile(u user.User) control.UserActionResponse
 }
 
 func (c *SimpleController) updateTeam(user.User) control.UserActionResponse {
+	ok, err := c.user.IsTeamAdmin()
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+	if !ok {
+		return control.UserActionResponse{Info: "user doesn't have permission to update"}
+	}
+
 	team, err := c.user.Store().RandomTeam(store.SelectMemberOf)
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -101,6 +101,21 @@ func (c *SimpleController) updateProfile(u user.User) control.UserActionResponse
 	return control.UserActionResponse{Info: "user patched"}
 }
 
+func (c *SimpleController) updateTeam(user.User) control.UserActionResponse {
+	team, err := c.user.Store().RandomTeam(store.SelectMemberOf)
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+	team.DisplayName = control.RandomizeTeamDisplayName(team.DisplayName)
+
+	err = c.user.UpdateTeam(&team)
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	return control.UserActionResponse{Info: "team updated"}
+}
+
 // reload performs all actions done when a user reloads the browser.
 // If full parameter is enabled, it also disconnects and reconnects
 // the WebSocket connection.

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -102,11 +102,9 @@ func (c *SimpleController) updateProfile(u user.User) control.UserActionResponse
 }
 
 func (c *SimpleController) updateTeam(user.User) control.UserActionResponse {
-	ok, err := c.user.IsTeamAdmin()
-	if err != nil {
+	if ok, err := c.user.IsTeamAdmin(); err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-	if !ok {
+	} else if !ok {
 		return control.UserActionResponse{Info: "user doesn't have permission to update"}
 	}
 
@@ -116,8 +114,7 @@ func (c *SimpleController) updateTeam(user.User) control.UserActionResponse {
 	}
 	team.DisplayName = control.RandomizeTeamDisplayName(team.DisplayName)
 
-	err = c.user.UpdateTeam(&team)
-	if err != nil {
+	if err := c.user.UpdateTeam(&team); err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -170,6 +170,7 @@ func (c *SimpleController) createActions(definitions []actionDefinition) error {
 		"ViewChannel":        control.ViewChannel,
 		"ViewUser":           control.ViewUser,
 		"FetchStaticAssets":  control.FetchStaticAssets,
+		"UpdateTeam":         c.updateTeam,
 	}
 
 	for _, def := range definitions {

--- a/loadtest/control/utils.go
+++ b/loadtest/control/utils.go
@@ -23,8 +23,11 @@ const (
 	letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 )
 
-var re = regexp.MustCompile(`-[[:alpha:]]+`)
-var words []string
+var (
+	userNameRe        = regexp.MustCompile(`-[[:alpha:]]+`)
+	teamDisplayNameRe = regexp.MustCompile(`team[0-9]+(.*)`)
+	words             []string
+)
 
 // getErrOrigin returns a string indicating the location of the error that
 // just occurred. It's a utility function used to find out exactly where an
@@ -47,10 +50,21 @@ func getErrOrigin() string {
 // Assumes the given name has a pattern of {{agent-id}}-{{user-name}}-{{user-number}}.
 // If the pattern is not found it will return the input string unaltered.
 func RandomizeUserName(name string) string {
-	parts := re.FindAllString(name, -1)
+	parts := userNameRe.FindAllString(name, -1)
 	if len(parts) > 0 {
 		random := letters[rand.Intn(len(letters))]
 		name = strings.Replace(name, parts[len(parts)-1], "-user"+string(random), 1)
+	}
+	return name
+}
+
+// RandomizeTeamDisplayName is a utility function to set a random team display name
+// while keeping the basic pattern unchanged.
+// Assumes the given name has a pattern of team{{number}}[-letter].
+func RandomizeTeamDisplayName(name string) string {
+	matches := teamDisplayNameRe.FindStringSubmatch(name)
+	if len(matches) == 2 {
+		name = matches[0] + "-" + string(letters[rand.Intn(len(letters))])
 	}
 	return name
 }

--- a/loadtest/control/utils_test.go
+++ b/loadtest/control/utils_test.go
@@ -33,6 +33,17 @@ func TestRandomizeUserName(t *testing.T) {
 	assert.Equal(t, name, "testuser")
 }
 
+func TestRandomizeTeamDisplayName(t *testing.T) {
+	name :=  RandomizeTeamDisplayName("badname")
+	assert.Equal(t, "badname", name)
+
+	name = RandomizeTeamDisplayName("team9")
+	assert.True(t, strings.HasPrefix(name, "team9-"))
+
+	name = RandomizeTeamDisplayName("team9-k")
+	assert.True(t, strings.HasPrefix(name, "team9-"))
+}
+
 func TestGetErrOrigin(t *testing.T) {
 	var origin string
 	test := func() {

--- a/loadtest/control/utils_test.go
+++ b/loadtest/control/utils_test.go
@@ -34,7 +34,7 @@ func TestRandomizeUserName(t *testing.T) {
 }
 
 func TestRandomizeTeamDisplayName(t *testing.T) {
-	name :=  RandomizeTeamDisplayName("badname")
+	name := RandomizeTeamDisplayName("badname")
 	assert.Equal(t, "badname", name)
 
 	name = RandomizeTeamDisplayName("team9")

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -37,6 +37,8 @@ type User interface {
 	UpdatePreferences(pref *model.Preferences) error
 	CreateUser(user *model.User) (string, error)
 	UpdateUser(user *model.User) error
+	// UpdateUserRoles updates the given userId with the given role ids.
+	UpdateUserRoles(userId, roles string) error
 	PatchUser(userId string, patch *model.UserPatch) error
 	GetUsersByIds(userIds []string) ([]string, error)
 	GetUsersByUsernames(usernames []string) ([]string, error)
@@ -104,6 +106,8 @@ type User interface {
 	GetTeamStats(teamId string) error
 	GetTeamsUnread(teamIdToExclude string) ([]*model.TeamUnread, error)
 	AddTeamMemberFromInvite(token, inviteId string) error
+	// UpdateTeam updates the given team.
+	UpdateTeam(team *model.Team) error
 
 	// roles
 	// GetRolesByNames returns a list of role ids based on the provided role names.
@@ -121,8 +125,10 @@ type User interface {
 	GetClientLicense() error
 
 	// utils
-	// IsSysAdmin will return true if the user is a SystemAdmin, false otherwise.
+	// IsSysAdmin returns whether a user is a SysAdmin or not.
 	IsSysAdmin() (bool, error)
+	// IsTeamAdmin returns whether a user is a TeamAdmin or not.
+	IsTeamAdmin() (bool, error)
 	SetCurrentTeam(team *model.Team) error
 	SetCurrentChannel(channel *model.Channel) error
 

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -135,6 +135,22 @@ func (ue *UserEntity) UpdateUser(user *model.User) error {
 	return nil
 }
 
+func (ue *UserEntity) UpdateUserRoles(userId, roles string) error {
+	ok, err := ue.IsSysAdmin()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	_, resp := ue.client.UpdateUserRoles(userId, roles)
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return nil
+}
+
 func (ue *UserEntity) PatchUser(userId string, patch *model.UserPatch) error {
 	user, resp := ue.client.PatchUser(userId, patch)
 
@@ -458,6 +474,21 @@ func (ue *UserEntity) CreateTeam(team *model.Team) (string, error) {
 
 func (ue *UserEntity) GetTeam(teamId string) error {
 	team, resp := ue.client.GetTeam(teamId, "")
+	if resp.Error != nil {
+		return resp.Error
+	}
+	return ue.store.SetTeam(team)
+}
+
+func (ue *UserEntity) UpdateTeam(team *model.Team) error {
+	ok, err := ue.IsTeamAdmin()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	team, resp := ue.client.UpdateTeam(team)
 	if resp.Error != nil {
 		return resp.Error
 	}

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -136,13 +136,6 @@ func (ue *UserEntity) UpdateUser(user *model.User) error {
 }
 
 func (ue *UserEntity) UpdateUserRoles(userId, roles string) error {
-	ok, err := ue.IsSysAdmin()
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return nil
-	}
 	_, resp := ue.client.UpdateUserRoles(userId, roles)
 	if resp.Error != nil {
 		return resp.Error
@@ -481,13 +474,6 @@ func (ue *UserEntity) GetTeam(teamId string) error {
 }
 
 func (ue *UserEntity) UpdateTeam(team *model.Team) error {
-	ok, err := ue.IsTeamAdmin()
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return nil
-	}
 	team, resp := ue.client.UpdateTeam(team)
 	if resp.Error != nil {
 		return resp.Error

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -163,6 +163,15 @@ func (ue *UserEntity) IsSysAdmin() (bool, error) {
 	return user.IsInRole(model.SYSTEM_ADMIN_ROLE_ID), nil
 }
 
+func (ue *UserEntity) IsTeamAdmin() (bool, error) {
+	user, err := ue.getUserFromStore()
+	if err != nil {
+		return false, err
+	}
+
+	return user.IsInRole(model.TEAM_ADMIN_ROLE_ID), nil
+}
+
 func (ue *UserEntity) getUserFromStore() (*model.User, error) {
 	user, err := ue.store.User()
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- We modify the init command to create users as team admins,
so that when the load test is run, some users should be able to change
team names.
- We add a new action to update the team display name and check
whether the user is a team admin or not.
- We add a new random function to randomly modify the team display name
while keeping the naming scheme consistent.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23711
