### PR TITLE
[MM-23715]deployment/terraform: highlight coordinator instance information

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -410,7 +410,11 @@ func (t *Terraform) displayInfo(output *terraformOutput) {
 	}
 	if len(output.Agents.Value) > 0 {
 		mlog.Info("Coordinator:" + output.Agents.Value[0].PublicIP)
-		mlog.Info(fmt.Sprintf("To start coordinator, you can use %q command.", "ltctl loadtest start"))
+		runcmd := "go run ./cmd/ltctl"
+		if strings.HasSuffix(os.Args[0], "ltctl") {
+			runcmd = "ltctl"
+		}
+		mlog.Info(fmt.Sprintf("To start coordinator, you can use %q command.", runcmd+" loadtest start"))
 	}
 	mlog.Info("Metrics server: " + output.MetricsServer.Value.PublicIP)
 	mlog.Info("DB reader endpoint: " + output.DBCluster.Value.ReaderEndpoint)

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -408,6 +408,10 @@ func (t *Terraform) displayInfo(output *terraformOutput) {
 	for _, agent := range output.Agents.Value {
 		mlog.Info(agent.Tags.Name + ": " + agent.PublicIP)
 	}
+	if len(output.Agents.Value) > 0 {
+		mlog.Info("Coordinator:" + output.Agents.Value[0].PublicIP)
+		mlog.Info(fmt.Sprintf("To start coordinator, you can use %q command.", "ltctl loadtest start"))
+	}
 	mlog.Info("Metrics server: " + output.MetricsServer.Value.PublicIP)
 	mlog.Info("DB reader endpoint: " + output.DBCluster.Value.ReaderEndpoint)
 	mlog.Info("DB cluster endpoint: " + output.DBCluster.Value.ClusterEndpoint)


### PR DESCRIPTION
#### Summary
Display coordinator's instance information at the end of the deployment creation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23715