### PR TITLE
[Hotfix] deployment/terraform: fix a bug fith the string interpretation

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -411,7 +411,7 @@ func (t *Terraform) displayInfo(output *terraformOutput) {
 	if len(output.Agents.Value) > 0 {
 		mlog.Info("Coordinator:" + output.Agents.Value[0].PublicIP)
 		runcmd := "go run ./cmd/ltctl"
-		if strings.HasSuffix(os.Args[0], "ltctl") {
+		if strings.HasPrefix(os.Args[0], "ltctl") {
 			runcmd = "ltctl"
 		}
 		mlog.Info(fmt.Sprintf("To start coordinator, you can use %q command.", runcmd+" loadtest start"))


### PR DESCRIPTION
#### Summary
This PR fixes a bug when displaying the `loadtest start` command. Where it should print `go run ./cmd/ltctl ...` when the code is executed with `go run ./cmd/ltctl ...`.



