### PR TITLE
[MM-23819] Remove hard-coded config defaults from deployment related code

### DIFF
--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -94,7 +94,12 @@ func createTeamAdmins(admin *userentity.UserEntity, numUsers int, config *loadte
 func RunInitCmdF(cmd *cobra.Command, args []string) error {
 	mlog.Info("init started")
 
-	config, err := loadtest.GetConfig()
+	configFilePath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return err
+	}
+
+	config, err := loadtest.ReadConfig(configFilePath)
 	if err != nil {
 		return err
 	}
@@ -156,17 +161,15 @@ func MakeInitCommand() *cobra.Command {
 }
 
 func SetupLoadTest(cmd *cobra.Command, args []string) {
-	configFilePath, _ := cmd.Flags().GetString("config")
-
-	if err := loadtest.ReadConfig(configFilePath); err != nil {
-		mlog.Error("Failed to initialize config", mlog.Err(err))
+	configFilePath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		mlog.Error("failed to get config flag", mlog.Err(err))
 		os.Exit(1)
 	}
 
-	cfg, err := loadtest.GetConfig()
-
+	cfg, err := loadtest.ReadConfig(configFilePath)
 	if err != nil {
-		mlog.Error("Failed to get logging config:", mlog.Err(err))
+		mlog.Error("failed to read config", mlog.Err(err))
 		os.Exit(1)
 	}
 

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -19,7 +19,12 @@ import (
 )
 
 func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
-	config, err := loadtest.GetConfig()
+	configFilePath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return err
+	}
+
+	config, err := loadtest.ReadConfig(configFilePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/ltcoordinator/main.go
+++ b/cmd/ltcoordinator/main.go
@@ -24,17 +24,25 @@ func RunCoordinatorCmdF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ltConfig, err := loadtest.GetConfig()
+
+	ltConfigFilePath, err := cmd.Flags().GetString("ltagent-config")
 	if err != nil {
 		return err
 	}
+	ltConfig, err := loadtest.ReadConfig(ltConfigFilePath)
+	if err != nil {
+		return err
+	}
+
 	for i := 0; i < len(cfg.ClusterConfig.Agents); i++ {
 		cfg.ClusterConfig.Agents[i].LoadTestConfig = *ltConfig
 	}
+
 	c, err := coordinator.New(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create coordinator: %w", err)
 	}
+
 	return c.Run()
 }
 
@@ -54,15 +62,7 @@ func main() {
 }
 
 func initConfig(cmd *cobra.Command, args []string) error {
-	configFilePath, err := cmd.Flags().GetString("ltagent-config")
-	if err != nil {
-		return err
-	}
-	if err := loadtest.ReadConfig(configFilePath); err != nil {
-		return err
-	}
-
-	configFilePath, err = cmd.Flags().GetString("config")
+	configFilePath, err := cmd.Flags().GetString("config")
 	if err != nil {
 		return err
 	}

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -79,7 +79,7 @@ func main() {
 		SilenceUsage: true,
 		Short:        "Manage and control load-test deployments",
 	}
-	rootCmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
+	rootCmd.PersistentFlags().StringP("config", "c", "", "path to the deployer configuration file to use")
 
 	deploymentCmd := &cobra.Command{
 		Use:   "deployment",

--- a/coordinator/config.go
+++ b/coordinator/config.go
@@ -40,6 +40,8 @@ func ReadConfig(configFilePath string) (*Config, error) {
 	v.SetConfigName("coordinator")
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
+	// This is needed for the calls from the terraform package to find the config.
+	v.AddConfigPath("../../config")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -84,7 +84,6 @@ func ReadConfig(filePath string) (*Config, error) {
 	v.SetConfigName("deployer")
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
-	v.AddConfigPath("./../../../config/")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -95,7 +95,7 @@ func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, output *terraformOutput
 	if err != nil {
 		return err
 	}
-	mlog.Info("Populating initial data for load-test", mlog.String("agent", ip))
+	mlog.Info("Generating load-test config")
 	cfg, err := t.generateLoadtestAgentConfig(output)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, output *terraformOutput
 		return fmt.Errorf("error uploading file, output: %q: %w", out, err)
 	}
 
-	mlog.Info("Running init command")
+	mlog.Info("Populating initial data for load-test", mlog.String("agent", ip))
 	cmd := "cd mattermost-load-test-ng && ./bin/ltagent init"
 	if out, err := sshc.RunCommand(cmd); err != nil {
 		return fmt.Errorf("error running ssh command, output: %q, error: %w", out, err)

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -65,6 +65,7 @@ func (t *Terraform) StartCoordinator() error {
 		return err
 	}
 	coordinatorConfig.ClusterConfig.Agents = loadAgentConfigs
+	coordinatorConfig.MonitorConfig.PrometheusURL = "http://" + output.MetricsServer.Value.PrivateIP + ":9090"
 
 	data, err = json.MarshalIndent(coordinatorConfig, "", "  ")
 	if err != nil {

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -7,9 +7,6 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
-	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
-	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance"
-	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
@@ -48,26 +45,14 @@ func (t *Terraform) StartCoordinator() error {
 	}
 
 	mlog.Info("Setting up coordinator", mlog.String("ip", ip))
-	clusterConfig := coordinator.Config{
-		ClusterConfig: cluster.LoadAgentClusterConfig{
-			Agents:         loadAgentConfigs,
-			MaxActiveUsers: 100,
-		},
-		MonitorConfig: performance.MonitorConfig{
-			PrometheusURL:    "http://" + output.MetricsServer.Value.PrivateIP + ":9090",
-			UpdateIntervalMs: 2000,
-			Queries: []prometheus.Query{
-				{
-					Description: "Request Duration",
-					Query:       "rate(mattermost_http_request_duration_seconds_sum[1m])/rate(mattermost_http_request_duration_seconds_count[1m])",
-					Threshold:   2.0,
-					Alert:       true,
-				},
-			},
-		},
-	}
 
-	data, err := json.MarshalIndent(clusterConfig, "", "  ")
+	coordinatorConfig, err := coordinator.ReadConfig("")
+	if err != nil {
+		return err
+	}
+	coordinatorConfig.ClusterConfig.Agents = loadAgentConfigs
+
+	data, err := json.MarshalIndent(coordinatorConfig, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -166,6 +166,8 @@ func ReadConfig(configFilePath string) (*Config, error) {
 	v.SetConfigName("config")
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
+	// This is needed for the calls from the terraform package to find the config.
+	v.AddConfigPath("../../config")
 	v.SetEnvPrefix("mmloadtest")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -161,40 +161,36 @@ func (c *Config) IsValid() error {
 	return nil
 }
 
-func ReadConfig(configFilePath string) error {
-	viper.SetConfigName("config")
-	viper.AddConfigPath(".")
-	viper.AddConfigPath("./config/")
-	viper.SetEnvPrefix("mmloadtest")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.AutomaticEnv()
+func ReadConfig(configFilePath string) (*Config, error) {
+	v := viper.New()
+	v.SetConfigName("config")
+	v.AddConfigPath(".")
+	v.AddConfigPath("./config/")
+	v.SetEnvPrefix("mmloadtest")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.AutomaticEnv()
 
-	viper.SetDefault("LogSettings.EnableConsole", true)
-	viper.SetDefault("LogSettings.ConsoleLevel", "INFO")
-	viper.SetDefault("LogSettings.ConsoleJson", true)
-	viper.SetDefault("LogSettings.EnableFile", true)
-	viper.SetDefault("LogSettings.FileLevel", "INFO")
-	viper.SetDefault("LogSettings.FileJson", true)
-	viper.SetDefault("LogSettings.FileLocation", "loadtest.log")
-	viper.SetDefault("ConnectionConfiguration.MaxIdleConns", 100)
-	viper.SetDefault("ConnectionConfiguration.MaxIdleConnsPerHost", 128)
-	viper.SetDefault("ConnectionConfiguration.IdleConnTimeoutMilliseconds", 90000)
+	v.SetDefault("LogSettings.EnableConsole", true)
+	v.SetDefault("LogSettings.ConsoleLevel", "INFO")
+	v.SetDefault("LogSettings.ConsoleJson", true)
+	v.SetDefault("LogSettings.EnableFile", true)
+	v.SetDefault("LogSettings.FileLevel", "INFO")
+	v.SetDefault("LogSettings.FileJson", true)
+	v.SetDefault("LogSettings.FileLocation", "loadtest.log")
+	v.SetDefault("ConnectionConfiguration.MaxIdleConns", 100)
+	v.SetDefault("ConnectionConfiguration.MaxIdleConnsPerHost", 128)
+	v.SetDefault("ConnectionConfiguration.IdleConnTimeoutMilliseconds", 90000)
 
 	if configFilePath != "" {
-		viper.SetConfigFile(configFilePath)
+		v.SetConfigFile(configFilePath)
 	}
 
-	if err := viper.ReadInConfig(); err != nil {
-		return errors.Wrap(err, "unable to read configuration file")
+	if err := v.ReadInConfig(); err != nil {
+		return nil, errors.Wrap(err, "unable to read configuration file")
 	}
 
-	return nil
-}
-
-func GetConfig() (*Config, error) {
 	var cfg *Config
-
-	if err := viper.Unmarshal(&cfg); err != nil {
+	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, err
 	}
 

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -21,7 +21,7 @@ type TestHelper struct {
 func Setup(tb testing.TB) *TestHelper {
 	var th TestHelper
 	th.tb = tb
-	config, err := loadtest.GetConfig()
+	config, err := loadtest.ReadConfig("../../../config/config.default.json")
 	require.Nil(th.tb, err)
 	require.NotNil(th.tb, config)
 	th.config = config

--- a/loadtest/user/userentity/user_test.go
+++ b/loadtest/user/userentity/user_test.go
@@ -33,7 +33,7 @@ func TestGetUserFromStore(t *testing.T) {
 }
 
 func TestFetchStaticAssets(t *testing.T) {
-	config, err := loadtest.GetConfig()
+	config, err := loadtest.ReadConfig("../../../config/config.default.json")
 	require.Nil(t, err)
 	mux := http.NewServeMux()
 	ts := httptest.NewServer(mux)


### PR DESCRIPTION
#### Summary

PR removes hard-coded config defaults from deployment code.
It also makes sure we upload configs when starting a new load-test.

I didn't implement passing the configs via command line since it requires some extra work/thinking and might get confusing passing three separate configs.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23819
