### PR TITLE
[MM-23648] Add config for SimulController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ sessions.db
 config/config.json
 config/coordinator.json
 config/simplecontroller.json
+config/simulcontroller.json
 config/deployer.json
 
 # terraform stuff

--- a/api/server.go
+++ b/api/server.go
@@ -66,6 +66,21 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var ucConfig control.Config
+	switch config.UserControllerConfiguration.Type {
+	case loadtest.UserControllerSimple:
+		// TODO: pass simplecontroller path appropriately
+		ucConfig, err = simplecontroller.ReadConfig("")
+	case loadtest.UserControllerSimulative:
+		ucConfig, err = simulcontroller.ReadConfig("")
+	}
+
+	if err != nil {
+		writeResponse(w, http.StatusBadRequest, &Response{
+			Error: fmt.Errorf("failed to read controller configuration: %w", err).Error(),
+		})
+	}
+
 	newControllerFn := func(id int, status chan<- control.UserStatus) (control.UserController, error) {
 		ueConfig := userentity.Config{
 			ServerURL:    config.ConnectionConfiguration.ServerURL,
@@ -77,14 +92,9 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		ue := userentity.New(memstore.New(), ueConfig)
 		switch config.UserControllerConfiguration.Type {
 		case loadtest.UserControllerSimple:
-			// TODO: pass simplecontroller path appropriately
-			cfg, err := simplecontroller.ReadConfig("")
-			if err != nil {
-				return nil, err
-			}
-			return simplecontroller.New(id, ue, cfg, status)
+			return simplecontroller.New(id, ue, ucConfig.(*simplecontroller.Config), status)
 		case loadtest.UserControllerSimulative:
-			return simulcontroller.New(id, ue, status)
+			return simulcontroller.New(id, ue, ucConfig.(*simulcontroller.Config), status)
 		case loadtest.UserControllerNoop:
 			return noopcontroller.New(id, ue, status)
 		default:

--- a/api/server.go
+++ b/api/server.go
@@ -74,7 +74,6 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 	case loadtest.UserControllerSimulative:
 		ucConfig, err = simulcontroller.ReadConfig("")
 	}
-
 	if err != nil {
 		writeResponse(w, http.StatusBadRequest, &Response{
 			Error: fmt.Errorf("failed to read controller configuration: %w", err).Error(),

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -44,7 +44,6 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
 	var ucConfig control.Config
 	switch controllerType {
 	case loadtest.UserControllerSimple:
@@ -52,7 +51,6 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	case loadtest.UserControllerSimulative:
 		ucConfig, err = simulcontroller.ReadConfig(ucConfigPath)
 	}
-
 	if err != nil {
 		return fmt.Errorf("failed to read controller configuration: %w", err)
 	}

--- a/config/simulcontroller.default.json
+++ b/config/simulcontroller.default.json
@@ -1,0 +1,4 @@
+{
+  "MinIdleTimeMs": 1000,
+  "AvgIdleTimeMs": 5000
+}

--- a/docs/simulcontroller_config.md
+++ b/docs/simulcontroller_config.md
@@ -1,0 +1,13 @@
+# SimulController Configuration
+
+## MinIdleTimeMs
+
+*int*
+
+The minium amount of time (in milliseconds) the controlled users will wait between actions.
+
+## AvgIdleTimeMs
+
+*int*
+
+The average amount of time (in milliseconds) the controlled users will wait between actions.

--- a/loadtest/control/config.go
+++ b/loadtest/control/config.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package control
+
+type Config interface {
+	// IsValid reports whether the Config is valid or not.
+	// Returns an error if the validation fails.
+	IsValid() error
+}

--- a/loadtest/control/config.go
+++ b/loadtest/control/config.go
@@ -3,6 +3,8 @@
 
 package control
 
+// Config is an abstraction over Config structures provided by
+// UserController implementations.
 type Config interface {
 	// IsValid reports whether the Config is valid or not.
 	// Returns an error if the validation fails.

--- a/loadtest/control/simulcontroller/controller_test.go
+++ b/loadtest/control/simulcontroller/controller_test.go
@@ -13,7 +13,11 @@ import (
 )
 
 func TestSetRate(t *testing.T) {
-	c, err := New(1, &userentity.UserEntity{}, make(chan control.UserStatus))
+	config, err := ReadConfig("../../../config/simulcontroller.default.json")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	c, err := New(1, &userentity.UserEntity{}, config, make(chan control.UserStatus))
 	require.Nil(t, err)
 	require.Equal(t, 1.0, c.rate)
 
@@ -38,7 +42,12 @@ func TestRunStop(t *testing.T) {
 		WebSocketURL: "ws://localhost:8065",
 	})
 	statusChan := make(chan control.UserStatus)
-	c, err := New(1, user, statusChan)
+
+	config, err := ReadConfig("../../../config/simulcontroller.default.json")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	c, err := New(1, user, config, statusChan)
 	require.Nil(t, err)
 
 	doneRunning := make(chan struct{})


### PR DESCRIPTION
#### Summary

PR adds configuration for `SimulController`.
It also refactors a bit the code around controllers creation to avoid doing a `ReadConfig` every time a new controller/user is created.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23648
