### PR TITLE
[MM-23897] Fallback on defaults if expected config is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ endif
 	cp config/config.default.json $(PLATFORM_DIST_PATH)/config/config.json
 	cp config/coordinator.default.json $(PLATFORM_DIST_PATH)/config/coordinator.json
 	cp config/simplecontroller.default.json $(PLATFORM_DIST_PATH)/config/simplecontroller.json
+	cp config/simulcontroller.default.json $(PLATFORM_DIST_PATH)/config/simulcontroller.json
 	cp LICENSE.txt $(PLATFORM_DIST_PATH)
 
 	mv $(COORDINATOR) $(PLATFORM_DIST_PATH)/bin
@@ -90,9 +91,6 @@ golangci-lint:
 	golangci-lint run ./...
 
 test:
-	@if ! [ -e config/simplecontroller.json ]; then \
-    	cp config/simplecontroller.default.json config/simplecontroller.json; \
- 	fi;\
 	$(GO) test -v -mod=readonly -failfast ./...
 
 clean:

--- a/config/config.go
+++ b/config/config.go
@@ -21,9 +21,8 @@ func ReadConfigFile(v *viper.Viper, configName string) error {
 
 	if err := v.ReadInConfig(); err != nil {
 		// If we can't find the config let's rely on the default one.
-		// var configErr *viper.ConfigFileNotFoundError
 		if errors.As(err, &viper.ConfigFileNotFoundError{}) {
-			mlog.Warn("config: falling back to default configuration file")
+			mlog.Warn("config: falling back to default configuration file", mlog.String("config_name", configName))
 			v.SetConfigName(fmt.Sprintf("%s.default", configName))
 			if err := v.ReadInConfig(); err != nil {
 				return fmt.Errorf("config: unable to read configuration file: %w", err)

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
+	"github.com/spf13/viper"
+)
+
+func ReadConfigFile(v *viper.Viper, configName string) error {
+	if v == nil {
+		return errors.New("config: v should not be nil")
+	}
+	if configName == "" {
+		return errors.New("config: configName should not be empty")
+	}
+
+	if err := v.ReadInConfig(); err != nil {
+		// If we can't find the config let's rely on the default one.
+		// var configErr *viper.ConfigFileNotFoundError
+		if errors.As(err, &viper.ConfigFileNotFoundError{}) {
+			mlog.Warn("config: falling back to default configuration file")
+			v.SetConfigName(fmt.Sprintf("%s.default", configName))
+			if err := v.ReadInConfig(); err != nil {
+				return fmt.Errorf("config: unable to read configuration file: %w", err)
+			}
+		} else {
+			return fmt.Errorf("config: unable to read configuration file: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/coordinator/config.go
+++ b/coordinator/config.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mattermost/mattermost-load-test-ng/config"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/spf13/viper"
 )
 
@@ -37,7 +37,8 @@ type Config struct {
 func ReadConfig(configFilePath string) (*Config, error) {
 	v := viper.New()
 
-	v.SetConfigName("coordinator")
+	configName := "coordinator"
+	v.SetConfigName(configName)
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
 	// This is needed for the calls from the terraform package to find the config.
@@ -49,17 +50,8 @@ func ReadConfig(configFilePath string) (*Config, error) {
 		v.SetConfigFile(configFilePath)
 	}
 
-	if err := v.ReadInConfig(); err != nil {
-		// If we can't find the config let's rely on the default one.
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			mlog.Info("falling back to default configuration file")
-			v.SetConfigName("coordinator.default")
-			if err := v.ReadInConfig(); err != nil {
-				return nil, fmt.Errorf("unable to read configuration file: %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("unable to read configuration file: %w", err)
-		}
+	if err := config.ReadConfigFile(v, configName); err != nil {
+		return nil, err
 	}
 
 	var cfg *Config

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/pkg/errors"
+	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/spf13/viper"
 )
 
@@ -87,7 +87,7 @@ func (ucc *UserControllerConfiguration) IsValid() error {
 		return fmt.Errorf("could not validate configuration: %w", err)
 	}
 	if ucc.Rate < 0 {
-		return errors.New("rate cannot be < 0")
+		return fmt.Errorf("rate cannot be < 0")
 	}
 	return nil
 }
@@ -188,7 +188,16 @@ func ReadConfig(configFilePath string) (*Config, error) {
 	}
 
 	if err := v.ReadInConfig(); err != nil {
-		return nil, errors.Wrap(err, "unable to read configuration file")
+		// If we can't find the config let's rely on the default one.
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			mlog.Info("falling back to default configuration file")
+			v.SetConfigName("config.default")
+			if err := v.ReadInConfig(); err != nil {
+				return nil, fmt.Errorf("unable to read configuration file: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("unable to read configuration file: %w", err)
+		}
 	}
 
 	var cfg *Config

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mattermost/mattermost-load-test-ng/config"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/spf13/viper"
 )
 
@@ -163,7 +163,9 @@ func (c *Config) IsValid() error {
 
 func ReadConfig(configFilePath string) (*Config, error) {
 	v := viper.New()
-	v.SetConfigName("config")
+
+	configName := "config"
+	v.SetConfigName(configName)
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
 	// This is needed for the calls from the terraform package to find the config.
@@ -187,17 +189,8 @@ func ReadConfig(configFilePath string) (*Config, error) {
 		v.SetConfigFile(configFilePath)
 	}
 
-	if err := v.ReadInConfig(); err != nil {
-		// If we can't find the config let's rely on the default one.
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			mlog.Info("falling back to default configuration file")
-			v.SetConfigName("config.default")
-			if err := v.ReadInConfig(); err != nil {
-				return nil, fmt.Errorf("unable to read configuration file: %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("unable to read configuration file: %w", err)
-		}
+	if err := config.ReadConfigFile(v, configName); err != nil {
+		return nil, err
 	}
 
 	var cfg *Config

--- a/loadtest/control/simplecontroller/config.go
+++ b/loadtest/control/simplecontroller/config.go
@@ -4,10 +4,10 @@
 package simplecontroller
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/mattermost/mattermost-server/v5/mlog"
+	"github.com/mattermost/mattermost-load-test-ng/config"
+
 	"github.com/spf13/viper"
 )
 
@@ -36,7 +36,8 @@ type actionDefinition struct {
 func ReadConfig(configFilePath string) (*Config, error) {
 	v := viper.New()
 
-	v.SetConfigName("simplecontroller")
+	configName := "simplecontroller"
+	v.SetConfigName(configName)
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
 	v.AddConfigPath("./../config/")
@@ -48,21 +49,11 @@ func ReadConfig(configFilePath string) (*Config, error) {
 		v.SetConfigFile(configFilePath)
 	}
 
-	if err := v.ReadInConfig(); err != nil {
-		// If we can't find the config let's rely on the default one.
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			mlog.Info("falling back to default configuration file")
-			v.SetConfigName("simplecontroller.default")
-			if err := v.ReadInConfig(); err != nil {
-				return nil, fmt.Errorf("unable to read configuration file: %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("unable to read configuration file: %w", err)
-		}
+	if err := config.ReadConfigFile(v, configName); err != nil {
+		return nil, err
 	}
 
 	var cfg *Config
-
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, err
 	}

--- a/loadtest/control/simulcontroller/config.go
+++ b/loadtest/control/simulcontroller/config.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mattermost/mattermost-load-test-ng/config"
+
 	"github.com/spf13/viper"
 )
 
@@ -25,7 +27,8 @@ type Config struct {
 func ReadConfig(configFilePath string) (*Config, error) {
 	v := viper.New()
 
-	v.SetConfigName("simulcontroller")
+	configName := "simulcontroller"
+	v.SetConfigName(configName)
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
@@ -35,11 +38,11 @@ func ReadConfig(configFilePath string) (*Config, error) {
 		v.SetConfigFile(configFilePath)
 	}
 
-	if err := v.ReadInConfig(); err != nil {
-		return nil, fmt.Errorf("unable to read configuration file: %w", err)
+	if err := config.ReadConfigFile(v, configName); err != nil {
+		return nil, err
 	}
-	var cfg *Config
 
+	var cfg *Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Summary

PR adds the behaviour that the documentation mentions. If the expected config file is not found we rely on the default one.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23897
