### PR TITLE
Reduce frequency of updateProfileImage

### DIFF
--- a/config/simplecontroller.default.json
+++ b/config/simplecontroller.default.json
@@ -59,7 +59,7 @@
       {
         "ActionId": "UpdateProfileImage",
         "WaitAfterMs": 1000,
-        "RunPeriod": 1
+        "RunPeriod": 25
       },
       {
         "ActionId": "CreateGroupChannel",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
UpdateProfileImage performs image encoding and decoding
which takes a big toll on CPU. Running it once every iteration
nearly pegs the CPU to 100%. We reduce it to make things
a bit more normal.

