### PR TITLE
Fix default config for coordinator

### DIFF
--- a/config/coordinator.default.json
+++ b/config/coordinator.default.json
@@ -6,7 +6,7 @@
         "ApiURL": "http://localhost:4000"
       }
     ],
-    "MaxActiveUsers": 10000
+    "MaxActiveUsers": 1000
   },
   "MonitorConfig": {
     "PrometheusURL": "http://localhost:9090",


### PR DESCRIPTION
#### Summary

PR fixes a problem with the default config for `coordinator`.
`MaxActiveUsers` needs to be less or equal to what is configured by the load-test agent or it will fail to start with default configs.
