### PR TITLE
[MM-24019] Reduce overall memory consumption for controllers

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -288,7 +288,7 @@ func SetupAPIRouter() *mux.Router {
 
 	// Add profile endpoints
 	p := router.PathPrefix("/debug/pprof").Subrouter()
-	p.HandleFunc("/", agent.pprofIndexHandler).Methods("Get")
+	p.HandleFunc("/", agent.pprofIndexHandler).Methods("GET")
 	p.Handle("/heap", pprof.Handler("heap")).Methods("GET")
 	p.HandleFunc("/profile", pprof.Profile).Methods("GET")
 	p.HandleFunc("/trace", pprof.Trace).Methods("GET")

--- a/example/samplestore/store.go
+++ b/example/samplestore/store.go
@@ -97,8 +97,8 @@ func (s *SampleStore) ChannelPostsSorted(channelId string, asc bool) ([]*model.P
 	return nil, nil
 }
 
-func (s *SampleStore) PostsSince(ts int64) ([]model.Post, error) {
-	return []model.Post{}, nil
+func (s *SampleStore) PostsIdsSince(ts int64) ([]string, error) {
+	return nil, nil
 }
 
 func (s *SampleStore) SetUser(user *model.User) error {

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -281,19 +281,19 @@ func CreatePostReply(u user.User) UserActionResponse {
 // AddReaction adds a reaction by the user to a random post.
 func AddReaction(u user.User) UserActionResponse {
 	// get posts from UserStore that have been created in the last minute
-	posts, err := u.Store().PostsSince(time.Now().Add(-1*time.Minute).Unix() * 1000)
+	postsIds, err := u.Store().PostsIdsSince(time.Now().Add(-1*time.Minute).Unix() * 1000)
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
 	}
-	if len(posts) == 0 {
+	if len(postsIds) == 0 {
 		return UserActionResponse{Info: "no posts to add reaction to"}
 	}
 
-	post := posts[rand.Intn(len(posts))]
+	postId := postsIds[rand.Intn(len(postsIds))]
 
 	err = u.SaveReaction(&model.Reaction{
 		UserId:    u.Store().Id(),
-		PostId:    post.Id,
+		PostId:    postId,
 		EmojiName: "grinning",
 	})
 
@@ -301,22 +301,22 @@ func AddReaction(u user.User) UserActionResponse {
 		return UserActionResponse{Err: NewUserError(err)}
 	}
 
-	return UserActionResponse{Info: fmt.Sprintf("added reaction to post %s", post.Id)}
+	return UserActionResponse{Info: fmt.Sprintf("added reaction to post %s", postId)}
 }
 
 // RemoveReaction removes a reaction from a random post which is added by the user.
 func RemoveReaction(u user.User) UserActionResponse {
 	// get posts from UserStore that have been created in the last minute
-	posts, err := u.Store().PostsSince(time.Now().Add(-1*time.Minute).Unix() * 1000)
+	postsIds, err := u.Store().PostsIdsSince(time.Now().Add(-1*time.Minute).Unix() * 1000)
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
 	}
-	if len(posts) == 0 {
+	if len(postsIds) == 0 {
 		return UserActionResponse{Info: "no posts to remove reaction from"}
 	}
 
-	post := posts[rand.Intn(len(posts))]
-	reactions, err := u.Store().Reactions(post.Id)
+	postId := postsIds[rand.Intn(len(postsIds))]
+	reactions, err := u.Store().Reactions(postId)
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
 	}
@@ -331,7 +331,7 @@ func RemoveReaction(u user.User) UserActionResponse {
 			if err != nil {
 				return UserActionResponse{Err: NewUserError(err)}
 			}
-			return UserActionResponse{Info: "removed reaction"}
+			return UserActionResponse{Info: fmt.Sprintf("removed reaction from post %s", postId)}
 		}
 	}
 

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -184,16 +184,16 @@ func (s *MemStore) ChannelPostsSorted(channelId string, asc bool) ([]*model.Post
 	return posts, nil
 }
 
-func (s *MemStore) PostsSince(ts int64) ([]model.Post, error) {
+func (s *MemStore) PostsIdsSince(ts int64) ([]string, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	var posts []model.Post
+	var postsIds []string
 	for _, post := range s.posts {
 		if post.CreateAt > ts {
-			posts = append(posts, *post)
+			postsIds = append(postsIds, post.Id)
 		}
 	}
-	return posts, nil
+	return postsIds, nil
 }
 
 func (s *MemStore) SetPost(post *model.Post) error {
@@ -387,17 +387,16 @@ func (s *MemStore) SetChannelMembers(channelMembers *model.ChannelMembers) error
 		return errors.New("memstore: channelMembers should not be nil")
 	}
 
-	for _, member := range *channelMembers {
-		member := member
-		// Initialize the maps as necessary.
+	cms := *channelMembers
+	for i := range cms {
+		cm := &cms[i]
 		if s.channelMembers == nil {
 			s.channelMembers = make(map[string]map[string]*model.ChannelMember)
 		}
-		if s.channelMembers[member.ChannelId] == nil {
-			s.channelMembers[member.ChannelId] = make(map[string]*model.ChannelMember)
+		if s.channelMembers[cm.ChannelId] == nil {
+			s.channelMembers[cm.ChannelId] = make(map[string]*model.ChannelMember)
 		}
-		// Set value.
-		s.channelMembers[member.ChannelId][member.UserId] = &member
+		s.channelMembers[cm.ChannelId][cm.UserId] = cm
 	}
 
 	return nil

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -166,7 +166,7 @@ func TestUser(t *testing.T) {
 		require.Equal(t, p[0].Id, channelPosts[1].Id)
 	})
 
-	t.Run("PostsSince", func(t *testing.T) {
+	t.Run("PostsIdsSince", func(t *testing.T) {
 		posts := make([]*model.Post, 10)
 		for i := 0; i < 10; i++ {
 			posts[i] = &model.Post{
@@ -174,16 +174,16 @@ func TestUser(t *testing.T) {
 				CreateAt: int64(i),
 			}
 		}
-		postsSince, err := s.PostsSince(0)
+		postsIdsSince, err := s.PostsIdsSince(0)
 		require.NoError(t, err)
-		require.Empty(t, postsSince)
+		require.Empty(t, postsIdsSince)
 		err = s.SetPosts(posts)
 		require.NoError(t, err)
-		postsSince, err = s.PostsSince(5)
+		postsIdsSince, err = s.PostsIdsSince(5)
 		require.NoError(t, err)
-		require.Len(t, postsSince, 4)
+		require.Len(t, postsIdsSince, 4)
 		for i := 6; i < 10; i++ {
-			require.Contains(t, postsSince, *posts[i])
+			require.Contains(t, postsIdsSince, posts[i].Id)
 		}
 	})
 

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -67,8 +67,8 @@ type UserStore interface {
 	// Roles returns the roles of the user.
 	Roles() ([]model.Role, error)
 
-	// PostsSince returns posts created after a specified timestamp in milliseconds.
-	PostsSince(ts int64) ([]model.Post, error)
+	// PostsIdsSince returns a slice of ids for posts created after a specified timestamp in milliseconds.
+	PostsIdsSince(ts int64) ([]string, error)
 
 	// Reactions returns reactions for a given postId.
 	Reactions(postId string) ([]model.Reaction, error)

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -76,7 +76,8 @@ func (ue *UserEntity) handlePostEvent(ev *model.WebSocketEvent) error {
 
 	switch ev.EventType() {
 	case model.WEBSOCKET_EVENT_POSTED, model.WEBSOCKET_EVENT_POST_EDITED:
-		if currentChannel, err := ue.store.CurrentChannel(); err == nil && currentChannel.Id == post.ChannelId {
+		currentChannel, err := ue.store.CurrentChannel()
+		if err == nil && currentChannel.Id == post.ChannelId {
 			return ue.store.SetPost(post)
 		} else if !errors.Is(err, memstore.ErrChannelNotFound) {
 			return fmt.Errorf("failed to get current channel from store: %w", err)

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -26,7 +26,7 @@ func (ue *UserEntity) handleReactionEvent(ev *model.WebSocketEvent) error {
 	if el, ok := ev.Data["reaction"]; !ok {
 		return fmt.Errorf("reaction data is missing")
 	} else if data, ok = el.(string); !ok {
-		return fmt.Errorf("reaction data not of type string")
+		return fmt.Errorf("type of the reaction data should be a string, but it is %T", el)
 	}
 
 	var reaction *model.Reaction
@@ -54,7 +54,7 @@ func (ue *UserEntity) handleReactionEvent(ev *model.WebSocketEvent) error {
 		if ok, err := ue.store.DeleteReaction(reaction); err != nil {
 			return err
 		} else if !ok {
-			return fmt.Errorf("failed to delete reaction")
+			return fmt.Errorf("could not find reaction in the store")
 		}
 	}
 
@@ -66,7 +66,7 @@ func (ue *UserEntity) handlePostEvent(ev *model.WebSocketEvent) error {
 	if el, ok := ev.Data["post"]; !ok {
 		return fmt.Errorf("post data is missing")
 	} else if data, ok = el.(string); !ok {
-		return fmt.Errorf("post data not of type string")
+		return fmt.Errorf("type of the post data should be a string, but it is %T", el)
 	}
 
 	var post *model.Post


### PR DESCRIPTION
#### Summary

PR addresses a few issues we encountered during testing that had to do with allocated memory growing very fast and eventually causing OOM crashes.

Main changes are:

- Store only new posts and reactions if they are made in the current channel.
- Changed `memstore.PostsSince` to return Ids instead of full posts.
- Added a minor optimization in `memstore.SetChannelMembers` to avoid an additional allocation.

This is a diff of heap profiles on a ltagent running 500 controllers before and after the changes in this PR.
```
Showing nodes accounting for -347.02MB, 70.39% of 493.01MB total
Dropped 142 nodes (cum <= 2.47MB)
Showing top 50 nodes out of 67
      flat  flat%   sum%        cum   cum%
 -124.03MB 25.16% 25.16%  -124.03MB 25.16%  reflect.New
  -58.50MB 11.87% 37.02%   -62.50MB 12.68%  encoding/json.(*decodeState).literalStore
  -43.55MB  8.83% 45.86%   -43.55MB  8.83%  bytes.makeSlice
  -25.03MB  5.08% 50.93%   -25.03MB  5.08%  encoding/json.(*Decoder).refill
  -17.48MB  3.55% 54.48%   -17.48MB  3.55%  github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore.(*MemStore).PostsSince
  -12.91MB  2.62% 57.10%   -12.91MB  2.62%  github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore.(*MemStore).SetPost
   -9.50MB  1.93% 59.03%    -9.50MB  1.93%  reflect.makemap
   -9.02MB  1.83% 60.86%    -9.02MB  1.83%  github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore.(*MemStore).SetChannelMembers
    7.11MB  1.44% 59.41%     7.11MB  1.44%  reflect.unsafe_NewArray
      -7MB  1.42% 60.83%       -9MB  1.83%  encoding/json.(*decodeState).objectInterface
      -7MB  1.42% 62.25%       -7MB  1.42%  encoding/json.NewDecoder (inline)
   -5.58MB  1.13% 63.39%    -5.58MB  1.13%  github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore.(*MemStore).SetReaction
   -4.50MB  0.91% 64.30%   -12.50MB  2.54%  encoding/json.mapEncoder.encode
   -4.50MB  0.91% 65.21%    -4.50MB  0.91%  encoding/json.(*decodeState).unquoteBytes
      -4MB  0.81% 66.02%  -211.04MB 42.81%  encoding/json.(*decodeState).object
      -4MB  0.81% 66.84%       -4MB  0.81%  reflect.copyVal
   -2.50MB  0.51% 67.34%  -179.44MB 36.40%  github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity.(*UserEntity).handlePostEvent
   -2.50MB  0.51% 67.85%    -2.50MB  0.51%  reflect.mapassign
   -2.50MB  0.51% 68.36%    -5.50MB  1.12%  reflect.Value.MapKeys
   -2.50MB  0.51% 68.87%  -179.53MB 36.42%  encoding/json.Unmarshal
   -2.01MB  0.41% 69.27%    -2.01MB  0.41%  bufio.NewWriterSize (inline)
      -2MB  0.41% 69.68%       -2MB  0.41%  bytes.NewReader
      -1MB   0.2% 69.88%   -13.50MB  2.74%  encoding/json.Marshal
      -1MB   0.2% 70.08%    -4.51MB  0.92%  net/http.(*Transport).dialConn
   -0.50MB   0.1% 70.19%  -202.02MB 40.98%  github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity.(*UserEntity).wsEventHandler
   -0.50MB   0.1% 70.29%  -203.02MB 41.18%  github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity.(*UserEntity).listen
   -0.50MB   0.1% 70.39%   -83.05MB 16.85%  github.com/mattermost/mattermost-server/v5/model.WebSocketEventFromJson
```

#### Ticket

https://mattermost.atlassian.net/browse/MM-24019