### PR TITLE
[MM 24018] Improve latency when stopping multiple controllers

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -213,15 +213,11 @@ func (a *API) addUsersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var res Response
-	i := 0
-	for ; i < amount; i++ {
-		if err := lt.AddUser(); err != nil {
-			res.Error = err.Error()
-			break // stop on first error, result is reported as part of status
-		}
+	n, err := lt.AddUsers(amount)
+	if err != nil {
+		res.Error = err.Error()
 	}
-
-	res.Message = fmt.Sprintf("%d users added", i)
+	res.Message = fmt.Sprintf("%d users added", n)
 	res.Status = lt.Status()
 	writeResponse(w, http.StatusOK, &res)
 }
@@ -241,15 +237,12 @@ func (a *API) removeUsersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var res Response
-	i := 0
-	for ; i < amount; i++ {
-		if err = lt.RemoveUser(); err != nil {
-			res.Error = err.Error()
-			break // stop on first error, result is reported as part of status
-		}
+	n, err := lt.RemoveUsers(amount)
+	if err != nil {
+		res.Error = err.Error()
 	}
 
-	res.Message = fmt.Sprintf("%d users removed", i)
+	res.Message = fmt.Sprintf("%d users removed", n)
 	res.Status = lt.Status()
 	writeResponse(w, http.StatusOK, &res)
 }

--- a/loadtest/errors.go
+++ b/loadtest/errors.go
@@ -10,6 +10,7 @@ import (
 var (
 	ErrNotRunning      = errors.New("LoadTester is not running")
 	ErrNotStopped      = errors.New("LoadTester has not stopped")
-	ErrNoUsersLeft     = errors.New("No active users left")
-	ErrMaxUsersReached = errors.New("Max active users limit reached")
+	ErrNoUsersLeft     = errors.New("no active users left")
+	ErrMaxUsersReached = errors.New("max active users limit reached")
+	ErrInvalidNumUsers = errors.New("numUsers should be > 0")
 )

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -72,7 +72,7 @@ func (lt *LoadTester) AddUsers(numUsers int) (int, error) {
 	return numUsers, nil
 }
 
-// addUser is an internal API called from Run and AddUser both.
+// addUser is an internal API called from Run and AddUsers both.
 // DO NOT call this by itself, because this method is not protected by a mutex.
 func (lt *LoadTester) addUser() error {
 	activeUsers := len(lt.controllers)
@@ -116,7 +116,7 @@ func (lt *LoadTester) RemoveUsers(numUsers int) (int, error) {
 	return lt.removeUsers(numUsers)
 }
 
-// removeUsers is an internal API called from Stop and RemoveUser both.
+// removeUsers is an internal API called from Stop and RemoveUsers both.
 // DO NOT call this by itself, because this method is not protected by a mutex.
 func (lt *LoadTester) removeUsers(numUsers int) (int, error) {
 	activeUsers := len(lt.controllers)


### PR DESCRIPTION
#### Summary

PR tries to improve the time it takes to stop multiple controllers:

- Moved from a sequential approach to a concurrent approach when stopping controllers.
- Converted AddUser/RemoveUser to accept the number of users to be added/removed.
- Improved `SimpleController` early shutdown time by implementing a simple select loop for init actions.
- Improved related tests.

Some results of removing 100 users from an agent running 500:

Before:
```

$ time curl -X POST http://localhost:4000/loadagent/lt0/removeusers\?amount\=100
{"message":"100 users removed","status":{"State":"running","NumUsers":400,"NumUsersAdded":500,"NumUsersRemoved":100,"NumErrors":500,"StartTime":"2020-04-09T15:17:24.157714273Z"}}

real	2m25.001s
user	0m0.005s
sys	0m0.013s
```

After:

```
$ time curl -X POST http://localhost:4000/loadagent/lt0/removeusers\?amount\=100
{"message":"100 users removed","status":{"State":"running","NumUsers":400,"NumUsersAdded":500,"NumUsersRemoved":100,"NumErrors":504,"StartTime":"2020-04-09T15:32:50.473028081Z"}}

real	0m8.374s
user	0m0.010s
sys	0m0.005s
```


#### Ticket

https://mattermost.atlassian.net/browse/MM-24018