### PR TITLE
[MM-23566] deployment/terraform: add server ping

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -421,13 +421,15 @@ func pingServer(addr string) error {
 		select {
 		case <-timeout:
 			return fmt.Errorf("timeout after 30 seconds, server is not responding")
-		case <-time.Tick(3 * time.Second):
+		case <-time.After(3 * time.Second):
 			_, resp := client.GetPingWithServerStatus()
-			if resp.Header.Get("database_status") == "OK" {
-				mlog.Info("Database status is OK")
-				return nil
+			if resp.Error != nil {
+				mlog.Debug("got error", mlog.Err(resp.Error))
+				mlog.Info("Waiting for the server...")
+				continue
 			}
-			mlog.Info("Waiting for the server...")
+			mlog.Info("Server status is OK")
+			return nil
 		}
 	}
 }

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -157,7 +157,10 @@ func (t *Terraform) Create() error {
 	// Updating the nginx config on proxy server
 	t.setupProxyServer(output, extAgent)
 
-	time.Sleep(30 * time.Second)
+	if err := pingServer("http://" + output.Proxy.Value.PublicDNS); err != nil {
+		return fmt.Errorf("error whiling pinging server: %w", err)
+	}
+
 	if err := t.createAdminUser(extAgent, output); err != nil {
 		return fmt.Errorf("could not create admin user: %w", err)
 	}
@@ -421,4 +424,25 @@ func (t *Terraform) displayInfo(output *terraformOutput) {
 	mlog.Info("Metrics server: " + output.MetricsServer.Value.PublicIP)
 	mlog.Info("DB reader endpoint: " + output.DBCluster.Value.ReaderEndpoint)
 	mlog.Info("DB cluster endpoint: " + output.DBCluster.Value.ClusterEndpoint)
+}
+
+func pingServer(addr string) error {
+	mlog.Info("Checking server status:", mlog.String("host", addr))
+	client := model.NewAPIv4Client(addr)
+	client.HttpClient.Timeout = 10 * time.Second
+	timeout := time.After(30 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout after 30 seconds, server is not responding")
+		case <-time.Tick(3 * time.Second):
+			_, resp := client.GetPingWithServerStatus()
+			if resp.Header.Get("database_status") == "OK" {
+				mlog.Info("Database status is OK")
+				return nil
+			}
+			mlog.Info("Waiting for the server...")
+		}
+	}
 }


### PR DESCRIPTION
#### Summary
We hardcoded a 30 second sleep to wait server to get up. Instead of sleeping, we can ping the system endpoint and check the response to verify whether it is up or not.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23566

