### PR TITLE
[MM-23900] api/server: accept loadtest.Config and control.Config for agent creation

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
-	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -48,8 +47,7 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		SimpleControllerConfig *simplecontroller.Config `json:",omitempty"`
 		SimulControllerConfig  *simulcontroller.Config  `json:",omitempty"`
 	}
-	err := json.NewDecoder(r.Body).Decode(&data)
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 		writeResponse(w, http.StatusBadRequest, &Response{
 			Error: fmt.Sprintf("could not read request: %s", err),
 		})
@@ -63,26 +61,21 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Init(&ltConfig.LogSettings)
-
 	var ucConfig control.Config
+	var err error
 	switch ltConfig.UserControllerConfiguration.Type {
 	case loadtest.UserControllerSimple:
-		var scc *simplecontroller.Config
-		scc = data.SimpleControllerConfig
-		if scc == nil {
-			mlog.Error("could not read controller config from the request")
-			scc, err = simplecontroller.ReadConfig("")
+		ucConfig = data.SimpleControllerConfig
+		if ucConfig == nil {
+			mlog.Warn("could not read controller config from the request")
+			ucConfig, err = simplecontroller.ReadConfig("")
 		}
-		ucConfig = scc
 	case loadtest.UserControllerSimulative:
-		var scc *simulcontroller.Config
-		scc = data.SimulControllerConfig
-		if scc == nil {
-			mlog.Error("clould not read controller config from the request")
-			scc, err = simulcontroller.ReadConfig("")
+		ucConfig = data.SimulControllerConfig
+		if ucConfig == nil {
+			mlog.Warn("clould not read controller config from the request")
+			ucConfig, err = simulcontroller.ReadConfig("")
 		}
-		ucConfig = scc
 	}
 	if err != nil {
 		writeResponse(w, http.StatusBadRequest, &Response{

--- a/api/server.go
+++ b/api/server.go
@@ -18,9 +18,9 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
-	"github.com/mattermost/mattermost-server/v5/mlog"
 
 	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
 // API contains information about all load tests.
@@ -71,7 +71,7 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		var scc *simplecontroller.Config
 		scc = data.SimpleControllerConfig
 		if scc == nil {
-			mlog.Error("clould not read controller config from the request")
+			mlog.Error("could not read controller config from the request")
 			scc, err = simplecontroller.ReadConfig("")
 		}
 		ucConfig = scc

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -10,12 +10,18 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 
 	"github.com/gavv/httpexpect"
 	"github.com/stretchr/testify/require"
 )
+
+type requestData struct {
+	LoadTestConfig         loadtest.Config
+	SimpleControllerConfig *simplecontroller.Config `json:",omitempty"`
+	SimulControllerConfig  *simulcontroller.Config  `json:",omitempty"`
+}
 
 func TestAPI(t *testing.T) {
 	// create http.Handler
@@ -35,69 +41,102 @@ func TestAPI(t *testing.T) {
 
 	ltConfig, err := loadtest.ReadConfig("../config/config.default.json")
 	require.NoError(t, err)
-	ucConfig, err := simplecontroller.ReadConfig("../config/simplecontroller.default.json")
-	require.NoError(t, err)
 
 	ltConfig.ConnectionConfiguration.ServerURL = "http://fakesitetotallydoesntexist.com"
 	ltConfig.UsersConfiguration.MaxActiveUsers = 100
 
-	var data = struct {
-		LoadTestConfig   loadtest.Config
-		ControllerConfig control.Config
-	}{
-		LoadTestConfig:   *ltConfig,
-		ControllerConfig: ucConfig,
-	}
-	ltId := "lt0"
-	obj := e.POST("/create").WithQuery("id", ltId).WithJSON(data).
-		Expect().Status(http.StatusCreated).
-		JSON().Object().ValueEqual("id", ltId)
-	rawMsg := obj.Value("message").String().Raw()
-	require.Equal(t, rawMsg, "load-test agent created")
+	ucConfig1, err := simplecontroller.ReadConfig("../config/simplecontroller.default.json")
+	require.NoError(t, err)
 
-	obj = e.POST("/create").WithQuery("id", ltId).WithJSON(data).
-		Expect().Status(http.StatusBadRequest).
-		JSON().Object().ContainsKey("error")
-	rawMsg = obj.Value("error").String().Raw()
-	require.Equal(t, fmt.Sprintf("load-test agent with id %s already exists", ltId), rawMsg)
+	ucConfig2, err := simulcontroller.ReadConfig("../config/simulcontroller.default.json")
+	require.NoError(t, err)
 
-	e.GET(ltId + "/status").
-		Expect().
-		Status(http.StatusOK).
-		JSON().Object().NotContainsKey("error")
+	t.Run("test with loadtest.Config only", func(t *testing.T) {
+		rd := requestData{
+			LoadTestConfig: *ltConfig,
+		}
+		ltId := "lt0"
+		obj := e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
+			Expect().Status(http.StatusCreated).
+			JSON().Object().ValueEqual("id", ltId)
+		rawMsg := obj.Value("message").String().Raw()
+		require.Equal(t, rawMsg, "load-test agent created")
 
-	e.GET(ltId).
-		Expect().
-		Status(http.StatusOK).
-		JSON().Object().NotContainsKey("error")
+		e.GET(ltId + "/status").
+			Expect().
+			Status(http.StatusOK).
+			JSON().Object().NotContainsKey("error")
 
-	e.POST(ltId + "/run").Expect().Status(http.StatusOK)
-	e.POST(ltId+"/addusers").WithQuery("amount", 10).Expect().Status(http.StatusOK)
-	e.POST(ltId+"/removeusers").WithQuery("amount", 3).Expect().Status(http.StatusOK)
-	e.POST(ltId+"/addusers").WithQuery("amount", 0).Expect().
-		Status(http.StatusBadRequest).
-		JSON().Object().ContainsKey("error")
+		e.GET(ltId).
+			Expect().
+			Status(http.StatusOK).
+			JSON().Object().NotContainsKey("error")
 
-	e.POST(ltId+"/addusers").WithQuery("amount", -2).Expect().
-		Status(http.StatusBadRequest).
-		JSON().Object().ContainsKey("error")
+		obj = e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
+			Expect().Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
+		rawMsg = obj.Value("error").String().Raw()
+		require.Equal(t, fmt.Sprintf("load-test agent with id %s already exists", ltId), rawMsg)
 
-	e.POST(ltId+"/addusers").WithQuery("amount", "bad").Expect().
-		Status(http.StatusBadRequest).
-		JSON().Object().ContainsKey("error")
+		e.POST(ltId + "/run").Expect().Status(http.StatusOK)
+		e.POST(ltId+"/addusers").WithQuery("amount", 10).Expect().Status(http.StatusOK)
+		e.POST(ltId+"/removeusers").WithQuery("amount", 3).Expect().Status(http.StatusOK)
+		e.POST(ltId+"/addusers").WithQuery("amount", 0).Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
 
-	e.POST(ltId+"/removeusers").WithQuery("amount", 0).Expect().
-		Status(http.StatusBadRequest).
-		JSON().Object().ContainsKey("error")
+		e.POST(ltId+"/addusers").WithQuery("amount", -2).Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
 
-	e.POST(ltId+"/removeusers").WithQuery("amount", -2).Expect().
-		Status(http.StatusBadRequest).
-		JSON().Object().ContainsKey("error")
+		e.POST(ltId+"/addusers").WithQuery("amount", "bad").Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
 
-	e.POST(ltId+"/removeusers").WithQuery("amount", "bad").Expect().
-		Status(http.StatusBadRequest).
-		JSON().Object().ContainsKey("error")
+		e.POST(ltId+"/removeusers").WithQuery("amount", 0).Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
 
-	e.POST(ltId + "/stop").Expect().Status(http.StatusOK)
-	e.DELETE(ltId).Expect().Status(http.StatusOK)
+		e.POST(ltId+"/removeusers").WithQuery("amount", -2).Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
+
+		e.POST(ltId+"/removeusers").WithQuery("amount", "bad").Expect().
+			Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
+
+		e.POST(ltId + "/stop").Expect().Status(http.StatusOK)
+		e.DELETE(ltId).Expect().Status(http.StatusOK)
+	})
+
+	t.Run("start agent with a simplecontroller.Config", func(t *testing.T) {
+		rd := requestData{
+			LoadTestConfig:         *ltConfig,
+			SimpleControllerConfig: ucConfig1,
+		}
+		ltId := "lt1"
+		obj := e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
+			Expect().Status(http.StatusCreated).
+			JSON().Object().ValueEqual("id", ltId)
+		rawMsg := obj.Value("message").String().Raw()
+		require.Equal(t, rawMsg, "load-test agent created")
+		e.POST(ltId + "/stop").Expect().Status(http.StatusOK)
+		e.DELETE(ltId).Expect().Status(http.StatusOK)
+	})
+
+	t.Run("start agent with simulcontroller.Config", func(t *testing.T) {
+		ltConfig.UserControllerConfiguration.Type = loadtest.UserControllerSimulative
+		rd := requestData{
+			LoadTestConfig:        *ltConfig,
+			SimulControllerConfig: ucConfig2,
+		}
+		ltId := "lt2"
+		obj := e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
+			Expect().Status(http.StatusCreated).
+			JSON().Object().ValueEqual("id", ltId)
+		rawMsg := obj.Value("message").String().Raw()
+		require.Equal(t, rawMsg, "load-test agent created")
+		e.POST(ltId + "/stop").Expect().Status(http.StatusOK)
+		e.DELETE(ltId).Expect().Status(http.StatusOK)
+	})
 }

--- a/cmd/ltagent/server.go
+++ b/cmd/ltagent/server.go
@@ -8,12 +8,24 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost-load-test-ng/api"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
+
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/spf13/cobra"
 )
 
 func RunServerCmdF(cmd *cobra.Command, args []string) error {
 	port, _ := cmd.Flags().GetInt("port")
+
+	logger.Init(&logger.Settings{
+		EnableConsole: true,
+		ConsoleLevel:  "INFO",
+		ConsoleJson:   false,
+		EnableFile:    true,
+		FileLevel:     "INFO",
+		FileJson:      true,
+		FileLocation:  "ltagent.log",
+	})
 
 	mlog.Info("API server started, listening on", mlog.Int("port", port))
 	return http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), api.SetupAPIRouter())

--- a/coordinator/agent/agent.go
+++ b/coordinator/agent/agent.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/api"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 
@@ -80,25 +79,27 @@ func (a *LoadAgent) RemoveUsers(n int) error {
 
 func (a *LoadAgent) Start() error {
 	a.config.LoadTestConfig.UsersConfiguration.InitialActiveUsers = 0
+	var data = struct {
+		LoadTestConfig         loadtest.Config
+		SimpleControllerConfig *simplecontroller.Config `json:",omitempty"`
+		SimulControllerConfig  *simulcontroller.Config  `json:",omitempty"`
+	}{
+		LoadTestConfig: a.config.LoadTestConfig,
+	}
 
-	var ucConfig control.Config
 	var err error
 	switch a.config.LoadTestConfig.UserControllerConfiguration.Type {
 	case loadtest.UserControllerSimple:
-		ucConfig, err = simplecontroller.ReadConfig("")
+		var scc *simplecontroller.Config
+		scc, err = simplecontroller.ReadConfig("")
+		data.SimpleControllerConfig = scc
 	case loadtest.UserControllerSimulative:
-		ucConfig, err = simulcontroller.ReadConfig("")
+		var scc *simulcontroller.Config
+		scc, err = simulcontroller.ReadConfig("")
+		data.SimulControllerConfig = scc
 	}
 	if err != nil {
 		return err
-	}
-
-	var data = struct {
-		LoadTestConfig   loadtest.Config
-		ControllerConfig control.Config
-	}{
-		LoadTestConfig:   a.config.LoadTestConfig,
-		ControllerConfig: ucConfig,
 	}
 
 	configData, err := json.MarshalIndent(data, "", "  ")

--- a/docs/local_loadtest.md
+++ b/docs/local_loadtest.md
@@ -92,7 +92,7 @@ To start a new load-test agent via API, the request structure should be in the f
 The API will create controller specific configuration from the request. However, if there is no controller configuration or errors while reading it from the request, the server will read the default controller configuration locally.
 
 ```sh
-curl -d @config/data.json http://localhost:4000/loadagent/create?id=lt0
+curl -d "{\"LoadTestConfig\": $(cat config/config.json)}" http://localhost:4000/loadagent/create\?id\=lt0
 ```
 
 ### Start the load-test agent

--- a/docs/local_loadtest.md
+++ b/docs/local_loadtest.md
@@ -73,8 +73,26 @@ Using a different terminal it's possible to issue commands to create and run a l
 
 ### Create a new load-test agent
 
+To start a new load-test agent via API, the request structure should be in the form of:
+
+```json
+{
+  "LoadTestConfig": {
+    ...
+  },
+  "SimpleControllerConfig": {
+    ...
+  },
+  "SimulControllerConfig": {
+    ...
+  }
+}
+```
+
+The API will create controller specific configuration from the request. However, if there is no controller configuration or errors while reading it from the request, the server will read the default controller configuration locally.
+
 ```sh
-curl -d @config/config.json http://localhost:4000/loadagent/create?id=lt0
+curl -d @config/data.json http://localhost:4000/loadagent/create?id=lt0
 ```
 
 ### Start the load-test agent


### PR DESCRIPTION
#### Summary
This PR adds ability to upload the specific controller's config as part of the load-test creation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23900

