### PR TITLE
[MM-24280] Fix error check in handleReactionEvent

### DIFF
--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -35,7 +35,7 @@ func (ue *UserEntity) handleReactionEvent(ev *model.WebSocketEvent) error {
 	}
 
 	currentChannel, err := ue.store.CurrentChannel()
-	if !errors.Is(err, memstore.ErrChannelNotFound) {
+	if err != nil && !errors.Is(err, memstore.ErrChannelNotFound) {
 		return fmt.Errorf("failed to get current channel from store: %w", err)
 	} else if currentChannel == nil {
 		return nil


### PR DESCRIPTION
#### Summary

PR fixes a bad check in case `memstore.CurrentChannel()` returns a `nil` error.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24280
