### PR TITLE
[MM-24343] Fix creating/starting agent from API without controller config

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -65,17 +65,19 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 	switch ltConfig.UserControllerConfiguration.Type {
 	case loadtest.UserControllerSimple:
-		ucConfig = data.SimpleControllerConfig
-		if ucConfig == nil {
+		if data.SimpleControllerConfig == nil {
 			mlog.Warn("could not read controller config from the request")
 			ucConfig, err = simplecontroller.ReadConfig("")
+			break
 		}
+		ucConfig = data.SimpleControllerConfig
 	case loadtest.UserControllerSimulative:
-		ucConfig = data.SimulControllerConfig
-		if ucConfig == nil {
-			mlog.Warn("clould not read controller config from the request")
+		if data.SimulControllerConfig == nil {
+			mlog.Warn("could not read controller config from the request")
 			ucConfig, err = simulcontroller.ReadConfig("")
+			break
 		}
+		ucConfig = data.SimulControllerConfig
 	}
 	if err != nil {
 		writeResponse(w, http.StatusBadRequest, &Response{

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -110,16 +110,18 @@ func TestAPI(t *testing.T) {
 	})
 
 	t.Run("start agent with a simplecontroller.Config", func(t *testing.T) {
+		ltConfig.UserControllerConfiguration.Type = loadtest.UserControllerSimple
 		rd := requestData{
 			LoadTestConfig:         *ltConfig,
 			SimpleControllerConfig: ucConfig1,
 		}
-		ltId := "lt1"
+		ltId := "lt0"
 		obj := e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
 			Expect().Status(http.StatusCreated).
 			JSON().Object().ValueEqual("id", ltId)
 		rawMsg := obj.Value("message").String().Raw()
 		require.Equal(t, rawMsg, "load-test agent created")
+		e.POST(ltId + "/run").Expect().Status(http.StatusOK)
 		e.POST(ltId + "/stop").Expect().Status(http.StatusOK)
 		e.DELETE(ltId).Expect().Status(http.StatusOK)
 	})
@@ -130,12 +132,29 @@ func TestAPI(t *testing.T) {
 			LoadTestConfig:        *ltConfig,
 			SimulControllerConfig: ucConfig2,
 		}
-		ltId := "lt2"
+		ltId := "lt0"
 		obj := e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
 			Expect().Status(http.StatusCreated).
 			JSON().Object().ValueEqual("id", ltId)
 		rawMsg := obj.Value("message").String().Raw()
 		require.Equal(t, rawMsg, "load-test agent created")
+		e.POST(ltId + "/run").Expect().Status(http.StatusOK)
+		e.POST(ltId + "/stop").Expect().Status(http.StatusOK)
+		e.DELETE(ltId).Expect().Status(http.StatusOK)
+	})
+
+	t.Run("start agent with no controller config", func(t *testing.T) {
+		ltConfig.UserControllerConfiguration.Type = loadtest.UserControllerSimulative
+		rd := requestData{
+			LoadTestConfig: *ltConfig,
+		}
+		ltId := "lt0"
+		obj := e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
+			Expect().Status(http.StatusCreated).
+			JSON().Object().ValueEqual("id", ltId)
+		rawMsg := obj.Value("message").String().Raw()
+		require.Equal(t, rawMsg, "load-test agent created")
+		e.POST(ltId + "/run").Expect().Status(http.StatusOK)
 		e.POST(ltId + "/stop").Expect().Status(http.StatusOK)
 		e.DELETE(ltId).Expect().Status(http.StatusOK)
 	})

--- a/loadtest/control/simulcontroller/config.go
+++ b/loadtest/control/simulcontroller/config.go
@@ -31,6 +31,7 @@ func ReadConfig(configFilePath string) (*Config, error) {
 	v.SetConfigName(configName)
 	v.AddConfigPath(".")
 	v.AddConfigPath("./config/")
+	v.AddConfigPath("./../config/")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 


### PR DESCRIPTION
#### Summary

PR fixes a bug with setting the `control.Config` interface before checking if the concrete type was `nil`.  
This would only manifest when creating and agent through the API and not passing the controller's config but relying on defaults.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24343
