### PR TITLE
Bump runtime timeout to 30 minutes

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -20,7 +20,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
-const cmdExecTimeoutMinutes = 10
+const cmdExecTimeoutMinutes = 30
 
 const (
 	latestReleaseURL           = "https://latest.mattermost.com/mattermost-enterprise-linux"


### PR DESCRIPTION
10 minutes was getting too close for deploying big clusters.
And also for cases when we want to destroy and create clusters
in the same command.
