### PR TITLE
MM-24393: Set GOGC=50 for ltagent service

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -50,7 +50,7 @@ pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
-	worker_connections 200000;        
+	worker_connections 200000;
 }
 
 http {
@@ -143,6 +143,7 @@ After=network.target
 
 [Service]
 Type=simple
+Environment="GOGC=50"
 ExecStart=/home/ubuntu/mattermost-load-test-ng/bin/ltagent server
 Restart=always
 RestartSec=1


### PR DESCRIPTION
Setting an aggresive GC rate has shown good results when the agent
is under memory pressure. So we use this to increase the longevity
of the agent.

![gogc](https://user-images.githubusercontent.com/1774000/80088651-6e39af80-857a-11ea-91e8-7e2781fadc13.png)

As we can see from above, the memory climb is much slower in the second case.