### PR TITLE
MM-24313: Bump up instance class of agents

### DIFF
--- a/config/deployer.default.json
+++ b/config/deployer.default.json
@@ -3,7 +3,7 @@
   "AppInstanceCount": 1,
   "AppInstanceType": "c5.xlarge",
   "AgentInstanceCount": 2,
-  "AgentInstanceType": "t2.medium",
+  "AgentInstanceType": "t3.xlarge",
   "ProxyInstanceType": "m4.xlarge",
   "SSHPublicKey": "~/.ssh/id_rsa.pub",
   "DBInstanceCount": 1,


### PR DESCRIPTION
Load test agents require much more CPU and memory than a t2.medium can provide.
Let's bump it higher.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-24313