### PR TITLE
[MM-24543] Fix deadlock in memstore

### DIFF
--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -115,7 +115,7 @@ func (s *MemStore) RandomUser() (model.User, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	if len(s.users) < 1 {
+	if len(s.users) < 2 {
 		return model.User{}, ErrLenMismatch
 	}
 

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -44,23 +44,65 @@ func TestRandomUsers(t *testing.T) {
 }
 
 func TestRandomUser(t *testing.T) {
-	s := newStore(t)
-	id1 := model.NewId()
-	id2 := model.NewId()
-	err := s.SetUsers([]*model.User{
-		{Id: id1},
-		{Id: id2},
-	})
-	require.NoError(t, err)
-	u, err := s.RandomUser()
-	require.NoError(t, err)
-	assert.Condition(t, func() bool {
-		switch u.Id {
-		case id1, id2:
-			return true
-		default:
-			return false
+	t.Run("myself", func(t *testing.T) {
+		s := newStore(t)
+		user := &model.User{
+			Id: "test",
 		}
+		err := s.SetUser(user)
+		require.NoError(t, err)
+		err = s.SetUsers([]*model.User{user})
+		require.NoError(t, err)
+		u, err := s.RandomUser()
+		require.Equal(t, err, ErrLenMismatch)
+		require.Empty(t, u)
+	})
+
+	t.Run("two users", func(t *testing.T) {
+		s := newStore(t)
+		id1 := model.NewId()
+		id2 := model.NewId()
+		err := s.SetUsers([]*model.User{
+			{Id: id1},
+			{Id: id2},
+		})
+		require.NoError(t, err)
+		u, err := s.RandomUser()
+		require.NoError(t, err)
+		assert.Condition(t, func() bool {
+			switch u.Id {
+			case id1, id2:
+				return true
+			default:
+				return false
+			}
+		})
+	})
+
+	t.Run("three users, not myself", func(t *testing.T) {
+		s := newStore(t)
+		myId := model.NewId()
+		id1 := model.NewId()
+		id2 := model.NewId()
+		me := &model.User{Id: myId}
+		err := s.SetUser(me)
+		require.NoError(t, err)
+		err = s.SetUsers([]*model.User{
+			{Id: id1},
+			{Id: id2},
+			{Id: myId},
+		})
+		require.NoError(t, err)
+		u, err := s.RandomUser()
+		require.NoError(t, err)
+		assert.Condition(t, func() bool {
+			switch u.Id {
+			case id1, id2:
+				return true
+			default:
+				return false
+			}
+		})
 	})
 }
 

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -134,8 +134,8 @@ func (s *MemStore) setupQueues(config *Config) error {
 }
 
 func (s *MemStore) Id() string {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	if s.user == nil {
 		return ""
 	}


### PR DESCRIPTION
#### Summary

`memstore.RandomUser()` would spin indefinitely (with the `RLock` acquired) if at the time it was called the only user in the map of users was the current user (which we explicitly avoid picking by continuing).

This would immediately cause `memstore.Id()` to block waiting (we were actually calling `Lock()` instead of `RLock()` in it). The `loadtest.handleStatus` function would then block , the `statusChan` where all the controllers write to would get full and everything would eventually come to a stop.

Somehow I assumed (wrongly) that it wasn't possible to get the current user from the map of users in the store, hence the erroneous check for `len(s.users) < 1`.
I've also included a test that would have triggered the issue.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24543

