### PR TITLE
MM-21660: Apply advanced sysctl optimizations

### DIFF
--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -86,7 +86,7 @@ func (t *Terraform) configureAndRunAgents(extAgent *ssh.ExtAgent, output *Output
 
 		batch := []uploadInfo{
 			{srcData: strings.TrimPrefix(buf.String(), "\n"), dstPath: "/lib/systemd/system/ltagent.service", msg: "Uploading agent service file"},
-			{srcData: strings.TrimPrefix(sysctlConfig, "\n"), dstPath: "/etc/sysctl.conf"},
+			{srcData: strings.TrimPrefix(clientSysctlConfig, "\n"), dstPath: "/etc/sysctl.conf"},
 			{srcData: strings.TrimPrefix(limitsConfig, "\n"), dstPath: "/etc/security/limits.conf"},
 			{srcData: strings.TrimPrefix(coordinatorServiceFile, "\n"), dstPath: "/lib/systemd/system/ltcoordinator.service", msg: "Uploading coordinator service file"},
 		}

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -73,7 +73,7 @@ http {
 const nginxSiteConfig = `
 upstream backend {
 %s
-        keepalive 32;
+        keepalive 1024;
 }
 
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_size=3g inactive=120m use_temp_path=off;
@@ -96,9 +96,9 @@ server {
            client_body_timeout 60;
            send_timeout        300;
            lingering_timeout   5;
-           proxy_connect_timeout   90;
-           proxy_send_timeout      300;
-           proxy_read_timeout      90s;
+           proxy_connect_timeout   5s;
+           proxy_send_timeout      60s;
+           proxy_read_timeout      60s;
            proxy_pass http://backend;
    }
 
@@ -112,7 +112,9 @@ server {
            proxy_set_header X-Frame-Options SAMEORIGIN;
            proxy_buffers 256 16k;
            proxy_buffer_size 16k;
-           proxy_read_timeout 600s;
+           proxy_connect_timeout   5s;
+           proxy_read_timeout      60s;
+           proxy_send_timeout      60s;
            proxy_cache mattermost_cache;
            proxy_cache_revalidate on;
            proxy_cache_min_uses 2;
@@ -131,9 +133,17 @@ const limitsConfig = `
 * hard nproc 8192
 `
 
-const sysctlConfig = `
+const clientSysctlConfig = `
 net.ipv4.ip_local_port_range = 1024 65000
 net.ipv4.tcp_fin_timeout = 30
+`
+
+const serverSysctlConfig = `
+net.ipv4.ip_local_port_range = 1024 65000
+net.ipv4.tcp_fin_timeout = 30
+net.ipv4.tcp_tw_reuse = 1
+net.core.somaxconn = 4096
+net.ipv4.tcp_max_syn_backlog = 8192
 `
 
 const baseAgentCmd = `/home/ubuntu/mattermost-load-test-ng/bin/ltagent server`


### PR DESCRIPTION
We split out the client optimizations from server optimizations
because server configs need some more help to be able to serve
connections at a high rate.

After we improved the websocket client to maintain a semaphore
for client API calls, the number of concurrent HTTP requests
increased by 8*CPU count. On a 2 core machine, this would
result in a 16x increase in connections. Therefore, when we
would have nearly 700 users, the server would be unable
to handle 11200 connections.

The nginx logs clearly showed the problem:
```
2020/04/25 09:07:11 [crit] 3642#3642: *1315161 connect() to 172.31.1.55:8065 failed (99: Cannot assign requested address) while connecting to upstream, client: 172.31.1.148, server: _, request: "POST /api
/v4/users/ids HTTP/1.1", upstream: "http://172.31.1.55:8065/api/v4/users/ids", host: "172.31.33.154"
```

Our first task was to tune the HTTP client knobs for more
idle connections and faster timeouts. But essentially if the kernel
can't handle the load, there's not much use. We set 3 specific knobs
which are essential for the kernel to be able to serve high concurrency.
The defaults are tuned down and it is recommended to bump them during load.

```
net.ipv4.tcp_tw_reuse = 1
net.core.somaxconn = 4096
net.ipv4.tcp_max_syn_backlog = 8192
```

From the kernel documentation:

tcp_tw_reuse - INTEGER
>	Enable reuse of TIME-WAIT sockets for new connections when it is
	safe from protocol viewpoint.

This would help us recycle connections at a much faster rate.

somaxconn - INTEGER
>	Limit of socket listen() backlog, known in userspace as SOMAXCONN.
	Defaults to 4096. (Was 128 before linux-5.4)
	See also tcp_max_syn_backlog for additional tuning for TCP sockets.

Ubuntu 18.04 still uses kernel 4.15, therefore it was 128. We bump it
to 4096 which is the default in newer kernels.

tcp_max_syn_backlog - INTEGER
>	Maximal number of remembered connection requests (SYN_RECV),
	which have not received an acknowledgment from connecting client.
	This is a per-listener limit.

We set this too because `dmesg` showed warnings like this:

```
172948.627905] TCP: request_sock_TCP: Possible SYN flooding on port 80. Sending cookies.  Check SNMP counters.
```

A deeper investigation in the kernel documentation shed some
light on the matter:

	Note, that syncookies is fallback facility.
	It MUST NOT be used to help highly loaded servers to stand
	against legal connection rate. If you see SYN flood warnings
	in your logs, but investigation	shows that they occur
	because of overload with legal connections, you should tune
	another parameters until this warning disappear.
	See: tcp_max_syn_backlog, tcp_synack_retries, tcp_abort_on_overflow.

After all this, there are no more connecting errors on the client.

We also bump up the number of upstream nginx keepalive connections per core.
And make timeouts to saner values.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-21660