### PR TITLE
MM-24546: Bump up connection limits to DB

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -296,6 +296,8 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	cfg.SqlSettings.DriverName = model.NewString(driverName)
 	cfg.SqlSettings.DataSource = model.NewString(clusterDSN)
 	cfg.SqlSettings.DataSourceReplicas = readerDSN
+	cfg.SqlSettings.MaxIdleConns = model.NewInt(100)
+	cfg.SqlSettings.MaxOpenConns = model.NewInt(512)
 
 	cfg.TeamSettings.MaxUsersPerTeam = model.NewInt(50000)
 	cfg.TeamSettings.EnableOpenServer = model.NewBool(true)


### PR DESCRIPTION
The default limits are too low for load testing. Bumping them alone brings down the response time by 1/4th.

![responsetimes](https://user-images.githubusercontent.com/1774000/80311182-db0fac80-87fb-11ea-976b-c794962e028f.png)


#### Ticket link

https://mattermost.atlassian.net/browse/MM-24546