### PR TITLE
[MM-24655] Fix valid args for ltctl go command

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -182,7 +182,7 @@ func main() {
 			return terraform.New(nil).OpenBrowserFor(args[0])
 		},
 		Args:      cobra.ExactValidArgs(1),
-		ValidArgs: []string{"grafana, mattermost, prometheus"},
+		ValidArgs: []string{"grafana", "mattermost", "prometheus"},
 	}
 	rootCmd.AddCommand(goCmd)
 


### PR DESCRIPTION
#### Summary
This PR fixes a typo in the `ltctl go` subcommand.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24655

