### PR TITLE
[MM-24756] Fix ws client leak and handle timeout event

### DIFF
--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -127,7 +127,8 @@ func (ue *UserEntity) listen(errChan chan error) {
 		}
 
 		client.Listen()
-		chanClosed := false
+		var chanClosed bool
+		var timedOut bool
 		for {
 			select {
 			case ev, ok := <-client.EventChannel:
@@ -142,7 +143,6 @@ func (ue *UserEntity) listen(errChan chan error) {
 			case _, ok := <-client.ResponseChannel:
 				if !ok {
 					chanClosed = true
-					break
 				}
 			case <-ue.wsClosing:
 				client.Close()
@@ -155,8 +155,11 @@ func (ue *UserEntity) listen(errChan chan error) {
 					break
 				}
 				client.UserTyping(msg.channelId, msg.parentId)
+			case <-client.PingTimeoutChannel:
+				timedOut = true
 			}
-			if chanClosed {
+			if chanClosed || timedOut {
+				client.Close()
 				break
 			}
 		}
@@ -167,7 +170,6 @@ func (ue *UserEntity) listen(errChan chan error) {
 		connectionFailCount++
 		select {
 		case <-ue.wsClosing:
-			client.Close()
 			// Explicit disconnect. Return.
 			close(ue.wsClosed)
 			return


### PR DESCRIPTION
#### Summary

PR fixes a ws client leak in `userentity`. In case the ws event channel was getting closed we would exit the inner loop and re-create the client without explicitly closing the previous one which meant leaking the internal writer goroutine.
PR also adds a case to handle the timeout event.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24756
