### PR TITLE
[MM-24758] Fix possible deadlock in memstore

### DIFF
--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -22,6 +22,7 @@ var (
 	ErrChannelStoreEmpty = errors.New("memstore: channel store is empty")
 	ErrChannelNotFound   = errors.New("memstore: channel not found")
 	ErrPostNotFound      = errors.New("memstore: post not found")
+	ErrInvalidData       = errors.New("memstore: invalid data found")
 )
 
 func isSelectionType(st, t store.SelectionType) bool {
@@ -139,7 +140,11 @@ func (s *MemStore) RandomUser() (model.User, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	if len(s.users) < 2 {
+	minLen := 1
+	if _, ok := s.users[s.user.Id]; ok {
+		minLen++
+	}
+	if len(s.users) < minLen {
 		return model.User{}, ErrLenMismatch
 	}
 
@@ -149,8 +154,11 @@ func (s *MemStore) RandomUser() (model.User, error) {
 			return model.User{}, err
 		}
 		user := s.users[key.(string)]
+		if user == nil || user.Id == "" {
+			return model.User{}, ErrInvalidData
+		}
 		// We don't want to pick ourselves.
-		if s.user != nil && user.Id == s.user.Id {
+		if user.Id == s.user.Id {
 			continue
 		}
 		return *user, nil
@@ -162,16 +170,21 @@ func (s *MemStore) RandomUsers(n int) ([]model.User, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	if n > len(s.users) {
+	numUsers := len(s.users)
+	if _, ok := s.users[s.user.Id]; ok {
+		numUsers--
+	}
+	if n > numUsers {
 		return nil, ErrLenMismatch
 	}
-	var users []model.User
+
+	users := make([]model.User, 0, n)
 	for len(users) < n {
 		u, err := s.RandomUser()
 		if err != nil {
 			return nil, err
 		}
-		found := false
+		var found bool
 		for _, ou := range users {
 			if ou.Id == u.Id {
 				found = true

--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -140,6 +140,10 @@ func (s *MemStore) RandomUser() (model.User, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
+	// We check if the current user is present in the stored map of users.
+	// If so we increment by one minLen since we purposely skip the current user on selection.
+	// This is done to avoid spinning indefinitely in case the store holds only one
+	// user and that being the current one.
 	minLen := 1
 	if _, ok := s.users[s.user.Id]; ok {
 		minLen++
@@ -170,6 +174,11 @@ func (s *MemStore) RandomUsers(n int) ([]model.User, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
+	// We check if the current user is present in the stored map of users.
+	// If so we decrement by one the maximum number of selectable users (numUsers)
+	// since RandomUser() will never return the current one.
+	// This is done to avoid spinning indefinitely when trying to pick N users in
+	// a store of exactly N users and one of them being the current one.
 	numUsers := len(s.users)
 	if _, ok := s.users[s.user.Id]; ok {
 		numUsers--


### PR DESCRIPTION
#### Summary

PR fixes a possible deadlock in `memstore.RandomUsers()`.
It's practically the same problem we recently fixed in https://github.com/mattermost/mattermost-load-test-ng/pull/254.

We assumed the current user would not be in the map of users hence allowed for picking up to `len(s.users)` which meant that in case of `len == 2` and one of them was the current user `Randomuser()` would always the return the same user and the loop in `RandomUsers()` would spin indefinitely (with the read lock acquired) trying to get a different one.

PR also improves the logic a bit by checking whether the current user is in the store and if so decreasing by one the number of *selectable* users.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24758
