### PR TITLE
MM-24452: fix info crash after a setup is destroyed

### DIFF
--- a/deployment/terraform/info.go
+++ b/deployment/terraform/info.go
@@ -20,6 +20,9 @@ func (t *Terraform) Info() error {
 }
 
 func (t *Terraform) displayInfo(output *Output) {
+	if output.IsEmpty() {
+		return
+	}
 	fmt.Println("==================================================")
 	fmt.Println("Deployment information:")
 	if output.HasProxy() {

--- a/deployment/terraform/output.go
+++ b/deployment/terraform/output.go
@@ -56,3 +56,9 @@ type Output struct {
 func (o *Output) HasProxy() bool {
 	return len(o.Proxy.Value) > 0
 }
+
+// IsEmpty returns whether a deployment has some data or not.
+// This is useful to check if info is being checked after a cluster is destroyed.
+func (o *Output) IsEmpty() bool {
+	return len(o.Instances.Value) == 0
+}


### PR DESCRIPTION
We add another helper IsEmpty to determine if a setup has any data or not.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-24452