### PR TITLE
MM-24910: Rewrite ws client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,5 +54,5 @@ issues:
       # This is mainly used to avoid errors regarding ids
       # We can remove this section once we decide to fix them
       - golint
-      path: "loadtest|coordinator|example|logger|cmd|api"
+      path: "loadtest|coordinator|example|logger|cmd|api|websocket"
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gavv/httpexpect v2.0.0+incompatible
 	github.com/gocolly/colly/v2 v2.0.1
 	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/websocket v1.4.1
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/mattermost/ldap v3.0.4+incompatible // indirect

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Package websocket is a tiny websocket client purpose-built for load-testing.
+// It does not have any special features other than strictly what is needed.
+package websocket
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/gorilla/websocket"
+	"github.com/mattermost/mattermost-server/v5/mlog"
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+const avgReadMsgSizeBytes = 1024
+
+// Client is the websocket client to perform all actions.
+type Client struct {
+	Url          string
+	EventChannel chan *model.WebSocketEvent
+
+	conn      *websocket.Conn
+	authToken string
+	sequence  int64
+	readWg    sync.WaitGroup
+	writeMut  sync.RWMutex
+}
+
+// NewClient4 constructs a new WebSocket client.
+func NewClient4(url, authToken string) (*Client, error) {
+	conn, _, err := websocket.DefaultDialer.Dial(url+model.API_URL_SUFFIX+"/websocket", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		Url:          url,
+		EventChannel: make(chan *model.WebSocketEvent, 100),
+
+		conn:      conn,
+		authToken: authToken,
+		sequence:  1,
+	}
+
+	client.readWg.Add(1)
+	go client.reader()
+
+	client.SendMessage(
+		model.WEBSOCKET_AUTHENTICATION_CHALLENGE,
+		map[string]interface{}{"token": authToken})
+
+	return client, nil
+}
+
+// Close closes the client.
+func (c *Client) Close() {
+	// If Close gets called concurrently during the time
+	// a connection-break happens, this will become a no-op.
+	c.conn.Close()
+	// Wait for reader to return.
+	// If the reader has already quit, this will just fall-through.
+	c.readWg.Wait()
+}
+
+func (c *Client) reader() {
+	defer func() {
+		close(c.EventChannel)
+		// Mark wg as Done.
+		c.readWg.Done()
+	}()
+
+	var buf bytes.Buffer
+	buf.Grow(avgReadMsgSizeBytes)
+
+	for {
+		// Reset buffer.
+		buf.Reset()
+		_, r, err := c.conn.NextReader()
+		if err != nil {
+			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
+				// log error
+				mlog.Warn("error from conn.NextReader", mlog.Err(err))
+			}
+			return
+		}
+		// Use pre-allocated buffer.
+		_, err = buf.ReadFrom(r)
+		if err != nil {
+			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
+				// log error
+				mlog.Warn("error from buf.ReadFrom", mlog.Err(err))
+			}
+			return
+		}
+
+		event := model.WebSocketEventFromJson(&buf)
+		if event == nil {
+			continue
+		}
+		if event.IsValid() {
+			c.EventChannel <- event
+		}
+	}
+}
+
+// SendMessage is the method to write to the websocket.
+func (c *Client) SendMessage(action string, data map[string]interface{}) error {
+	// It uses a mutex to synchronize writes.
+	// Intentionally no atomics are used to perform additional state tracking.
+	// Therefore, we let it fail if the user tries to write again on a closed connection.
+	c.writeMut.Lock()
+	defer c.writeMut.Unlock()
+
+	req := &model.WebSocketRequest{
+		Seq:    c.sequence,
+		Action: action,
+		Data:   data,
+	}
+
+	c.sequence++
+	return c.conn.WriteJSON(req)
+}
+
+// Helper utilities that call SendMessage.
+
+func (c *Client) UserTyping(channelId, parentId string) error {
+	data := map[string]interface{}{
+		"channel_id": channelId,
+		"parent_id":  parentId,
+	}
+
+	return c.SendMessage("user_typing", data)
+}
+
+func (c *Client) GetStatuses() error {
+	return c.SendMessage("get_statuses", nil)
+}
+
+func (c *Client) GetStatusesByIds(userIds []string) error {
+	data := map[string]interface{}{
+		"user_ids": userIds,
+	}
+	return c.SendMessage("get_statuses_by_ids", data)
+}

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -100,7 +100,11 @@ func (c *Client) reader() {
 			continue
 		}
 		if event.IsValid() {
-			c.EventChannel <- event
+			// non-blocking send in case event channel is full.
+			select {
+			case c.EventChannel <- event:
+			default:
+			}
 		}
 	}
 }

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -56,77 +56,77 @@ func TestClose(t *testing.T) {
 
 	t.Run("Sudden", func(t *testing.T) {
 		url := strings.Replace(s.URL, "http://", "ws://", 1)
-		cli, err := NewClient4(url, "authToken")
+		c, err := NewClient4(url, "authToken")
 		require.Nil(t, err)
 
 		go func() {
 			// Just drain the event channel
-			for range cli.EventChannel {
+			for range c.EventChannel {
 			}
 		}()
 
-		err = cli.UserTyping("channelId", "parentId")
+		err = c.UserTyping("channelId", "parentId")
 		assert.Nil(t, err)
 
-		err = cli.conn.Close()
+		err = c.conn.Close()
 		assert.Nil(t, err)
 
 		// wait for a while for reader to exit
 		time.Sleep(200 * time.Millisecond)
 
 		// Verify that event channel is closed.
-		checkEventChan(cli.EventChannel)
+		checkEventChan(c.EventChannel)
 	})
 
 	t.Run("Normal", func(t *testing.T) {
 		url := strings.Replace(s.URL, "http://", "ws://", 1)
-		cli, err := NewClient4(url, "authToken")
+		c, err := NewClient4(url, "authToken")
 		require.Nil(t, err)
 
 		go func() {
 			// Just drain the event channel
-			for range cli.EventChannel {
+			for range c.EventChannel {
 			}
 		}()
 
-		err = cli.UserTyping("channelId", "parentId")
+		err = c.UserTyping("channelId", "parentId")
 		assert.Nil(t, err)
 
-		cli.Close()
+		c.Close()
 
 		// Verify that event channel is closed.
-		checkEventChan(cli.EventChannel)
+		checkEventChan(c.EventChannel)
 	})
 
 	t.Run("Concurrent", func(t *testing.T) {
 		url := strings.Replace(s.URL, "http://", "ws://", 1)
-		cli, err := NewClient4(url, "authToken")
+		c, err := NewClient4(url, "authToken")
 		require.Nil(t, err)
 
 		go func() {
 			// Just drain the event channel
-			for range cli.EventChannel {
+			for range c.EventChannel {
 			}
 		}()
 
-		err = cli.UserTyping("channelId", "parentId")
+		err = c.UserTyping("channelId", "parentId")
 		assert.Nil(t, err)
 
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			cli.Close()
+			c.Close()
 		}()
 
 		go func() {
 			defer wg.Done()
-			cli.conn.Close()
+			c.conn.Close()
 		}()
 
 		wg.Wait()
 		// Verify that event channel is closed.
-		checkEventChan(cli.EventChannel)
+		checkEventChan(c.EventChannel)
 	})
 }
 
@@ -138,85 +138,85 @@ func TestSendMessage(t *testing.T) {
 
 	t.Run("SendAfterSuddenClose", func(t *testing.T) {
 		url := strings.Replace(s.URL, "http://", "ws://", 1)
-		cli, err := NewClient4(url, "authToken")
+		c, err := NewClient4(url, "authToken")
 		require.Nil(t, err)
 
 		go func() {
 			// Just drain the event channel
-			for range cli.EventChannel {
+			for range c.EventChannel {
 			}
 		}()
 
-		err = cli.UserTyping("channelId", "parentId")
+		err = c.UserTyping("channelId", "parentId")
 		assert.Nil(t, err)
 
-		err = cli.conn.Close()
+		err = c.conn.Close()
 		assert.Nil(t, err)
 
-		err = cli.UserTyping("channelId2", "parentId2")
+		err = c.UserTyping("channelId2", "parentId2")
 		assert.NotNil(t, err)
 	})
 
 	t.Run("SendAfterClose", func(t *testing.T) {
 		url := strings.Replace(s.URL, "http://", "ws://", 1)
-		cli, err := NewClient4(url, "authToken")
+		c, err := NewClient4(url, "authToken")
 		require.Nil(t, err)
 
 		go func() {
 			// Just drain the event channel
-			for range cli.EventChannel {
+			for range c.EventChannel {
 			}
 		}()
 
-		err = cli.UserTyping("channelId", "parentId")
+		err = c.UserTyping("channelId", "parentId")
 		assert.Nil(t, err)
 
-		cli.Close()
+		c.Close()
 
-		err = cli.UserTyping("channelId2", "parentId2")
+		err = c.UserTyping("channelId2", "parentId2")
 		assert.NotNil(t, err)
 	})
 
 	t.Run("SendDuringSuddenClose", func(t *testing.T) {
 		url := strings.Replace(s.URL, "http://", "ws://", 1)
-		cli, err := NewClient4(url, "authToken")
+		c, err := NewClient4(url, "authToken")
 		require.Nil(t, err)
 
 		go func() {
 			// Just drain the event channel
-			for range cli.EventChannel {
+			for range c.EventChannel {
 			}
 		}()
 
-		err = cli.UserTyping("channelId", "parentId")
+		err = c.UserTyping("channelId", "parentId")
 		assert.Nil(t, err)
 
 		go func() {
-			cli.UserTyping("channelId2", "parentId2")
+			c.UserTyping("channelId2", "parentId2")
 		}()
 
-		err = cli.conn.Close()
+		err = c.conn.Close()
 		assert.Nil(t, err)
 	})
 
 	t.Run("SendDuringClose", func(t *testing.T) {
 		url := strings.Replace(s.URL, "http://", "ws://", 1)
-		cli, err := NewClient4(url, "authToken")
+		c, err := NewClient4(url, "authToken")
 		require.Nil(t, err)
 
 		go func() {
 			// Just drain the event channel
-			for range cli.EventChannel {
+			for range c.EventChannel {
 			}
 		}()
 
-		err = cli.UserTyping("channelId", "parentId")
+		err = c.UserTyping("channelId", "parentId")
 		assert.Nil(t, err)
 
 		go func() {
-			cli.UserTyping("channelId2", "parentId2")
+			c.UserTyping("channelId2", "parentId2")
 		}()
 
-		cli.Close()
+		c.Close()
 	})
 }

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package websocket
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		upgrader := &websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		}
+		conn, err := upgrader.Upgrade(w, req, nil)
+		require.Nil(t, err)
+		var buf []byte
+		for {
+			_, buf, err = conn.ReadMessage()
+			if err != nil {
+				break
+			}
+			t.Logf("%s\n", buf)
+			err = conn.WriteMessage(websocket.TextMessage, []byte("hello world"))
+			if err != nil {
+				break
+			}
+		}
+	}
+}
+
+// TestClose verifies that the client is properly and safely closed in all possible ways.
+func TestClose(t *testing.T) {
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	checkEventChan := func(eventChan chan *model.WebSocketEvent) {
+		defer func() {
+			if x := recover(); x == nil {
+				require.Fail(t, "should have panicked due to closing a closed channel")
+			}
+		}()
+		close(eventChan)
+	}
+
+	t.Run("Sudden", func(t *testing.T) {
+		url := strings.Replace(s.URL, "http://", "ws://", 1)
+		cli, err := NewClient4(url, "authToken")
+		require.Nil(t, err)
+
+		go func() {
+			// Just drain the event channel
+			for range cli.EventChannel {
+			}
+		}()
+
+		err = cli.UserTyping("channelId", "parentId")
+		assert.Nil(t, err)
+
+		err = cli.conn.Close()
+		assert.Nil(t, err)
+
+		// wait for a while for reader to exit
+		time.Sleep(200 * time.Millisecond)
+
+		// Verify that event channel is closed.
+		checkEventChan(cli.EventChannel)
+	})
+
+	t.Run("Normal", func(t *testing.T) {
+		url := strings.Replace(s.URL, "http://", "ws://", 1)
+		cli, err := NewClient4(url, "authToken")
+		require.Nil(t, err)
+
+		go func() {
+			// Just drain the event channel
+			for range cli.EventChannel {
+			}
+		}()
+
+		err = cli.UserTyping("channelId", "parentId")
+		assert.Nil(t, err)
+
+		cli.Close()
+
+		// Verify that event channel is closed.
+		checkEventChan(cli.EventChannel)
+	})
+
+	t.Run("Concurrent", func(t *testing.T) {
+		url := strings.Replace(s.URL, "http://", "ws://", 1)
+		cli, err := NewClient4(url, "authToken")
+		require.Nil(t, err)
+
+		go func() {
+			// Just drain the event channel
+			for range cli.EventChannel {
+			}
+		}()
+
+		err = cli.UserTyping("channelId", "parentId")
+		assert.Nil(t, err)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cli.Close()
+		}()
+
+		go func() {
+			defer wg.Done()
+			cli.conn.Close()
+		}()
+
+		wg.Wait()
+		// Verify that event channel is closed.
+		checkEventChan(cli.EventChannel)
+	})
+}
+
+// TestSendMessage verifies that there are no races or panics during message send
+// in various conditions.
+func TestSendMessage(t *testing.T) {
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	t.Run("SendAfterSuddenClose", func(t *testing.T) {
+		url := strings.Replace(s.URL, "http://", "ws://", 1)
+		cli, err := NewClient4(url, "authToken")
+		require.Nil(t, err)
+
+		go func() {
+			// Just drain the event channel
+			for range cli.EventChannel {
+			}
+		}()
+
+		err = cli.UserTyping("channelId", "parentId")
+		assert.Nil(t, err)
+
+		err = cli.conn.Close()
+		assert.Nil(t, err)
+
+		err = cli.UserTyping("channelId2", "parentId2")
+		assert.NotNil(t, err)
+	})
+
+	t.Run("SendAfterClose", func(t *testing.T) {
+		url := strings.Replace(s.URL, "http://", "ws://", 1)
+		cli, err := NewClient4(url, "authToken")
+		require.Nil(t, err)
+
+		go func() {
+			// Just drain the event channel
+			for range cli.EventChannel {
+			}
+		}()
+
+		err = cli.UserTyping("channelId", "parentId")
+		assert.Nil(t, err)
+
+		cli.Close()
+
+		err = cli.UserTyping("channelId2", "parentId2")
+		assert.NotNil(t, err)
+	})
+
+	t.Run("SendDuringSuddenClose", func(t *testing.T) {
+		url := strings.Replace(s.URL, "http://", "ws://", 1)
+		cli, err := NewClient4(url, "authToken")
+		require.Nil(t, err)
+
+		go func() {
+			// Just drain the event channel
+			for range cli.EventChannel {
+			}
+		}()
+
+		err = cli.UserTyping("channelId", "parentId")
+		assert.Nil(t, err)
+
+		go func() {
+			cli.UserTyping("channelId2", "parentId2")
+		}()
+
+		err = cli.conn.Close()
+		assert.Nil(t, err)
+	})
+
+	t.Run("SendDuringClose", func(t *testing.T) {
+		url := strings.Replace(s.URL, "http://", "ws://", 1)
+		cli, err := NewClient4(url, "authToken")
+		require.Nil(t, err)
+
+		go func() {
+			// Just drain the event channel
+			for range cli.EventChannel {
+			}
+		}()
+
+		err = cli.UserTyping("channelId", "parentId")
+		assert.Nil(t, err)
+
+		go func() {
+			cli.UserTyping("channelId2", "parentId2")
+		}()
+
+		cli.Close()
+	})
+}


### PR DESCRIPTION
This is a complete rewrite of the websocket client stripping out the parts
that aren't necessary to make it a extremely simple, bare-bones and safe
implementation.

There is just one listener goroutine and nothing else. No timeouts, no ping handlers,
no response channels. No extra frills.

Writes are synchronized through a mutex and close is made synchronous by waiting
on the reader waitgroup to be done.


#### Ticket link

https://mattermost.atlassian.net/browse/MM-24910