### PR TITLE
[MM-24657] cmd/ltctl: add available options for ltctl go command

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -178,10 +178,17 @@ func main() {
 		Short:   "Open browser for instance",
 		Long:    "Open browser for grafana, mattermost or prometheus",
 		Example: "ltctl go grafana",
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				fmt.Println("Available destinations:")
+				for _, arg := range cmd.ValidArgs {
+					fmt.Printf("ltctl go %s\n", arg)
+				}
+				return nil
+			}
 			return terraform.New(nil).OpenBrowserFor(args[0])
 		},
-		Args:      cobra.ExactValidArgs(1),
+		Args:      cobra.OnlyValidArgs,
 		ValidArgs: []string{"grafana", "mattermost", "prometheus"},
 	}
 	rootCmd.AddCommand(goCmd)


### PR DESCRIPTION
#### Summary
When no arg provided to the `ltctl go` it will list the available detinations.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24657
