### PR TITLE
[MM-24656] cmd/ltctl: print list when no parameter provided for ltctl ssh cmd

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -158,10 +158,13 @@ func main() {
 		Use:     "ssh [instance]",
 		Short:   "ssh into instance",
 		Example: "ltctl ssh agent-0",
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				fmt.Println("Available instances:")
+				return RunSSHListCmdF(cmd, args)
+			}
 			return terraform.New(nil).OpenSSHFor(args[0])
 		},
-		Args: cobra.MinimumNArgs(1),
 	}
 
 	sshListCmd := &cobra.Command{


### PR DESCRIPTION
#### Summary
When no arg provided for `ltctl ssh` command, it will do the same with `ltctl ssh list` command.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24656

