### PR TITLE
MM-24930: Pass along controller config too

### DIFF
--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -106,9 +106,8 @@ func (t *Terraform) StartCoordinator() error {
 			return err
 		}
 
-		rdr := bytes.NewReader(data)
 		mlog.Info(info.dstPath)
-		if out, err := sshc.Upload(rdr, info.dstPath, false); err != nil {
+		if out, err := sshc.Upload(bytes.NewReader(data), info.dstPath, false); err != nil {
 			return fmt.Errorf("error uploading file, dstPath: %s, output: %q: %w", info.dstPath, out, err)
 		}
 	}

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -8,6 +8,8 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
@@ -73,6 +75,36 @@ func (t *Terraform) StartCoordinator() error {
 	}
 	mlog.Info("Uploading updated coordinator config file")
 	dstPath = "/home/ubuntu/mattermost-load-test-ng/config/coordinator.json"
+	if out, err := sshc.Upload(bytes.NewReader(data), dstPath, false); err != nil {
+		return fmt.Errorf("error running ssh command: output: %s, error: %w", out, err)
+	}
+
+	// Uploading simul controller config
+	simulConfig, err := simulcontroller.ReadConfig("")
+	if err != nil {
+		return err
+	}
+	data, err = json.MarshalIndent(simulConfig, "", "  ")
+	if err != nil {
+		return err
+	}
+	mlog.Info("Uploading simulcontroller config file")
+	dstPath = "/home/ubuntu/mattermost-load-test-ng/config/simulcontroller.json"
+	if out, err := sshc.Upload(bytes.NewReader(data), dstPath, false); err != nil {
+		return fmt.Errorf("error running ssh command: output: %s, error: %w", out, err)
+	}
+
+	// Uploading simple controller config
+	simpleConfig, err := simplecontroller.ReadConfig("")
+	if err != nil {
+		return err
+	}
+	data, err = json.MarshalIndent(simpleConfig, "", "  ")
+	if err != nil {
+		return err
+	}
+	mlog.Info("Uploading simplecontroller config file")
+	dstPath = "/home/ubuntu/mattermost-load-test-ng/config/simplecontroller.json"
 	if out, err := sshc.Upload(bytes.NewReader(data), dstPath, false); err != nil {
 		return fmt.Errorf("error running ssh command: output: %s, error: %w", out, err)
 	}

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -169,6 +169,7 @@ func (t *Terraform) setupAppServers(output *Output, extAgent *ssh.ExtAgent, uplo
 			batch := []uploadInfo{
 				{srcData: strings.TrimSpace(serverSysctlConfig), dstPath: "/etc/sysctl.conf"},
 				{srcData: strings.TrimSpace(serviceFile), dstPath: "/lib/systemd/system/mattermost.service"},
+				{srcData: strings.TrimPrefix(limitsConfig, "\n"), dstPath: "/etc/security/limits.conf"},
 			}
 			if err := uploadBatch(sshc, batch); err != nil {
 				mlog.Error("batch upload failed", mlog.Err(err))
@@ -291,8 +292,8 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	cfg.ServiceSettings.ListenAddress = model.NewString(":8065")
 	cfg.ServiceSettings.LicenseFileLocation = model.NewString("/home/ubuntu/mattermost.mattermost-license")
 	cfg.ServiceSettings.SiteURL = model.NewString("http://" + ip + ":8065")
-	cfg.ServiceSettings.ReadTimeout = model.NewInt(10)
-	cfg.ServiceSettings.WriteTimeout = model.NewInt(10)
+	cfg.ServiceSettings.ReadTimeout = model.NewInt(60)
+	cfg.ServiceSettings.WriteTimeout = model.NewInt(60)
 	cfg.ServiceSettings.IdleTimeout = model.NewInt(90)
 
 	cfg.LogSettings.EnableConsole = model.NewBool(true)
@@ -313,7 +314,7 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	cfg.ClusterSettings.StreamingPort = model.NewInt(8075)
 	cfg.ClusterSettings.Enable = model.NewBool(true)
 	cfg.ClusterSettings.ClusterName = model.NewString(t.config.ClusterName)
-	cfg.ClusterSettings.ReadOnlyConfig = model.NewBool(false)
+	cfg.ClusterSettings.ReadOnlyConfig = model.NewBool(true)
 
 	cfg.MetricsSettings.Enable = model.NewBool(true)
 

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -102,9 +102,9 @@ server {
            client_body_timeout 60;
            send_timeout        300;
            lingering_timeout   5;
-           proxy_connect_timeout   5s;
-           proxy_send_timeout      60s;
-           proxy_read_timeout      60s;
+           proxy_connect_timeout   30s;
+           proxy_send_timeout      90s;
+           proxy_read_timeout      90s;
            proxy_pass http://backend;
    }
 
@@ -118,9 +118,9 @@ server {
            proxy_set_header X-Frame-Options SAMEORIGIN;
            proxy_buffers 256 16k;
            proxy_buffer_size 16k;
-           proxy_connect_timeout   5s;
-           proxy_read_timeout      60s;
-           proxy_send_timeout      60s;
+           proxy_connect_timeout   30s;
+           proxy_read_timeout      90s;
+           proxy_send_timeout      90s;
            proxy_cache mattermost_cache;
            proxy_cache_revalidate on;
            proxy_cache_min_uses 2;


### PR DESCRIPTION
During starting a coordinator, we were not passing the controller
config files at all. This meant that the coordinator silently used
the default configs which were not ideal. So during coordinator start
we pass the controller files too.

While here, we also fix some other things.
- Set the /etc/security/limits.conf file on app servers too.
- Tune the read/write/connect timeouts slightly on both app and nginx.
- Set the Readonly config to true which is the default and should be set.
