### PR TITLE
[MM-24688] Refine SimulController

### DIFF
--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -78,7 +78,7 @@ func createTeamAdmins(admin *userentity.UserEntity, numUsers int, config *loadte
 		if err != nil {
 			return err
 		}
-		u := userentity.New(store, ueConfig)
+		u := userentity.New(store, nil, ueConfig)
 
 		if err := u.SignUp(ueConfig.Email, ueConfig.Username, ueConfig.Password); err != nil {
 			mlog.Warn("error while signing up", mlog.Err(err)) // Possibly, user already exists.
@@ -127,7 +127,7 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	admin := userentity.New(store, ueConfig)
+	admin := userentity.New(store, nil, ueConfig)
 
 	start := time.Now()
 

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -94,6 +94,9 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	rate, err := cmd.Flags().GetFloat64("rate")
+	if err != nil {
+		return err
+	}
 	if rate != 1.0 {
 		config.UserControllerConfiguration.Rate = rate
 	}

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -93,6 +93,11 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		config.UsersConfiguration.InitialActiveUsers = numUsers
 	}
 
+	rate, err := cmd.Flags().GetFloat64("rate")
+	if rate != 1.0 {
+		config.UserControllerConfiguration.Rate = rate
+	}
+
 	lt, err := loadtest.New(config, newControllerFn)
 	if err != nil {
 		return fmt.Errorf("error while initializing loadtest: %w", err)
@@ -129,5 +134,6 @@ func MakeLoadTestCommand() *cobra.Command {
 	cmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
 	cmd.PersistentFlags().IntP("duration", "d", 60, "number of seconds to pass before stopping the load-test")
 	cmd.PersistentFlags().IntP("num-users", "n", 0, "number of users to run, setting this value will override the config setting")
+	cmd.PersistentFlags().Float64P("rate", "r", 1.0, "rate value for the controller")
 	return cmd
 }

--- a/config/simulcontroller.default.json
+++ b/config/simulcontroller.default.json
@@ -1,4 +1,4 @@
 {
   "MinIdleTimeMs": 1000,
-  "AvgIdleTimeMs": 5000
+  "AvgIdleTimeMs": 20000
 }

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -93,7 +93,6 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 	}
 
 	channel, err := c.user.Store().CurrentChannel()
-
 	if errors.Is(err, memstore.ErrChannelNotFound) {
 		// If the current channel is not set we switch to a random one.
 		return switchChannel(c.user)

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -88,7 +88,20 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 		return c.switchTeam(c.user)
 	}
 
-	return loadTeam(c.user, team)
+	if resp := loadTeam(c.user, team); resp.Err != nil {
+		return resp
+	}
+
+	channel, err := c.user.Store().CurrentChannel()
+
+	if errors.Is(err, memstore.ErrChannelNotFound) {
+		// If the current channel is not set we switch to a random one.
+		return switchChannel(c.user)
+	} else if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	return viewChannel(c.user, channel)
 }
 
 func (c *SimulController) fullReload(u user.User) control.UserActionResponse {
@@ -259,11 +272,10 @@ func viewChannel(u user.User, channel *model.Channel) control.UserActionResponse
 		if _, err := u.ViewChannel(&model.ChannelView{ChannelId: current.Id}); err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
-	} else if err != memstore.ErrChannelNotFound {
+	} else if !errors.Is(err, memstore.ErrChannelNotFound) {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	// TODO: use the information returned here to figure out how to properly fetch posts.
 	if _, err := u.ViewChannel(&model.ChannelView{ChannelId: channel.Id, PrevChannelId: currentChanId}); err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
@@ -277,7 +289,7 @@ func viewChannel(u user.User, channel *model.Channel) control.UserActionResponse
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 	} else {
-		postsIds, err = u.GetPostsSince(channel.Id, time.Now().Add(-1*time.Minute).Unix()*1000)
+		postsIds, err = u.GetPostsSince(channel.Id, view)
 		if err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
@@ -288,12 +300,26 @@ func viewChannel(u user.User, channel *model.Channel) control.UserActionResponse
 	// We also check if posts have any image attachments and if so we fetch the
 	// respective thumbnails.
 	var userIds []string
+	var missingStatuses []string
+	var missingUsers []string
 	for _, postId := range postsIds {
 		userId, err := u.Store().UserForPost(postId)
 		if err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 		userIds = append(userIds, userId)
+
+		if status, err := u.Store().Status(userId); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		} else if status.UserId == "" {
+			missingStatuses = append(missingStatuses, userId)
+		}
+
+		if user, err := u.Store().GetUser(userId); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		} else if user.Id == "" {
+			missingUsers = append(missingUsers, userId)
+		}
 
 		fileInfo, err := u.Store().FileInfoForPost(postId)
 		if err != nil {
@@ -307,6 +333,18 @@ func viewChannel(u user.User, channel *model.Channel) control.UserActionResponse
 			if err := u.GetFileThumbnail(info.Id); err != nil {
 				return control.UserActionResponse{Err: control.NewUserError(err)}
 			}
+		}
+	}
+
+	if len(missingStatuses) > 0 {
+		if err := u.GetUsersStatusesByIds(missingStatuses); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+	}
+
+	if len(missingUsers) > 0 {
+		if _, err := u.GetUsersByIds(missingUsers); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 	}
 

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -576,7 +576,8 @@ func (c *SimulController) attachFilesToPost(u user.User, post *model.Post) error
 	}
 
 	wg.Wait()
-	for i := 0; i < len(fileIds); i++ {
+	numFiles := len(fileIds)
+	for i := 0; i < numFiles; i++ {
 		post.FileIds = append(post.FileIds, <-fileIds)
 	}
 

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -104,28 +104,24 @@ func (c *SimulController) Run() {
 
 	actions := []userAction{
 		{
+			run:       switchChannel,
+			frequency: 120,
+		},
+		{
 			run:       openDirectOrGroupChannel,
-			frequency: 200,
+			frequency: 50,
 		},
 		{
 			run:       c.switchTeam,
-			frequency: 110,
-		},
-		{
-			run:       switchChannel,
-			frequency: 100,
+			frequency: 30,
 		},
 		{
 			run:       c.createPost,
-			frequency: 55,
-		},
-		{
-			run:       c.fullReload,
-			frequency: 40,
+			frequency: 25,
 		},
 		{
 			run:       c.createPostReply,
-			frequency: 20,
+			frequency: 15,
 		},
 		{
 			run:       c.joinChannel,
@@ -133,11 +129,15 @@ func (c *SimulController) Run() {
 		},
 		{
 			run:       c.addReaction,
-			frequency: 6,
+			frequency: 12,
+		},
+		{
+			run:       c.fullReload,
+			frequency: 8,
 		},
 		{
 			run:       editPost,
-			frequency: 3,
+			frequency: 8,
 		},
 		{
 			run:       c.logoutLogin,
@@ -145,7 +145,7 @@ func (c *SimulController) Run() {
 		},
 		{
 			run:       c.createDirectChannel,
-			frequency: 1,
+			frequency: 2,
 		},
 		{
 			run:       c.createGroupChannel,

--- a/loadtest/control/simulcontroller/controller_test.go
+++ b/loadtest/control/simulcontroller/controller_test.go
@@ -39,7 +39,7 @@ func TestRunStop(t *testing.T) {
 	require.NotNil(t, store)
 	require.NoError(t, err)
 
-	user := userentity.New(store, userentity.Config{
+	user := userentity.New(store, nil, userentity.Config{
 		ServerURL:    "http://localhost:8065",
 		WebSocketURL: "ws://localhost:8065",
 	})

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -47,7 +47,7 @@ func newController(id int, status chan<- control.UserStatus) (control.UserContro
 	if err != nil {
 		return nil, err
 	}
-	ue := userentity.New(store, ueConfig)
+	ue := userentity.New(store, nil, ueConfig)
 	cfg, err := simplecontroller.ReadConfig("")
 	if err != nil {
 		return nil, err

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -42,7 +42,7 @@ func (th *TestHelper) CreateUser() *UserEntity {
 	s, err := memstore.New(nil)
 	require.NotNil(th.tb, s)
 	require.NoError(th.tb, err)
-	u := New(s, Config{
+	u := New(s, nil, Config{
 		th.config.ConnectionConfiguration.ServerURL,
 		th.config.ConnectionConfiguration.WebSocketURL,
 		"testuser",


### PR DESCRIPTION
#### Summary

PR further refines actions frequencies for `SimulController` to better match those of a real user.
Data from our community servers has been used to perform the tuning.
Other notable changes included are:

- Tuned average idle time.
- Improved fetching users statuses.
- Made clients use a shared `http.Transport`. This should help improving overall connectivity performance.
- Fixed a bug with file uploads. Not sure if it was related with the errors we've been seeing server side but it's a possibility.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24688
