### PR TITLE
MM-24879: Restart agents on crash

### DIFF
--- a/coordinator/agent/agent.go
+++ b/coordinator/agent/agent.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -24,6 +25,8 @@ type LoadAgent struct {
 	status *loadtest.Status
 	client *http.Client
 }
+
+var ErrAgentNotFound = errors.New("agent: not found")
 
 // New creates and initializes a new LoadAgent for the given config.
 // An error is returned if the initialization fails.
@@ -45,6 +48,9 @@ func (a *LoadAgent) apiRequest(req *http.Request) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		if resp.StatusCode == http.StatusNotFound {
+			return ErrAgentNotFound
+		}
 		return fmt.Errorf("agent: bad response status code %d", resp.StatusCode)
 	}
 	res := &api.Response{}


### PR DESCRIPTION
We assume that a 404 is semantically the same as the agent restarted.
Therefore we create a new load test in that case.

A short log of the coordinator restarting an agent

```
info    coordinator/coordinator.go:100  coordinator: incrementing active users  {"num_users": 16}
info    cluster/cluster.go:87   cluster: adding users to agent  {"num_users": 16, "agent_id": "lt0"}
error   coordinator/coordinator.go:102  coordinator: failed to increment users  {"error": "cluster: failed to add users to agent: Post \"http://localhost:4000/loadagent/lt0/addusers?amount=16\": dial tcp 127.0.0.1:4000: connect: connection refused"}
info    coordinator/coordinator.go:76   coordinator: cluster status:    {"active_users": 112, "errors": 64}
info    coordinator/coordinator.go:85   coordinator: supported users    {"supported_users": 0}
info    coordinator/coordinator.go:100  coordinator: incrementing active users  {"num_users": 16}
info    cluster/cluster.go:87   cluster: adding users to agent  {"num_users": 16, "agent_id": "lt0"}
error   coordinator/coordinator.go:102  coordinator: failed to increment users  {"error": "cluster: failed to add users to agent: Post \"http://localhost:4000/loadagent/lt0/addusers?amount=16\": dial tcp 127.0.0.1:4000: connect: connection refused"}
info    coordinator/coordinator.go:76   coordinator: cluster status:    {"active_users": 112, "errors": 64}
info    coordinator/coordinator.go:85   coordinator: supported users    {"supported_users": 0}
info    coordinator/coordinator.go:100  coordinator: incrementing active users  {"num_users": 16}
info    cluster/cluster.go:87   cluster: adding users to agent  {"num_users": 16, "agent_id": "lt0"}
error   coordinator/coordinator.go:102  coordinator: failed to increment users  {"error": "cluster: failed to add users to agent: Post \"http://localhost:4000/loadagent/lt0/addusers?amount=16\": dial tcp 127.0.0.1:4000: connect: connection refused"}
info    coordinator/coordinator.go:76   coordinator: cluster status:    {"active_users": 112, "errors": 64}
info    coordinator/coordinator.go:85   coordinator: supported users    {"supported_users": 0}
info    coordinator/coordinator.go:100  coordinator: incrementing active users  {"num_users": 16}
info    cluster/cluster.go:87   cluster: adding users to agent  {"num_users": 16, "agent_id": "lt0"}
info    agent/agent.go:135      agent: agent created    {"agent_id": "lt0"}
info    coordinator/coordinator.go:76   coordinator: cluster status:    {"active_users": 0, "errors": 0}
info    coordinator/coordinator.go:85   coordinator: supported users    {"supported_users": 0}
```

### Ticket link

https://mattermost.atlassian.net/browse/MM-24879