### PR TITLE
[MM-24613] Update some defaults

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -6,7 +6,7 @@
     "AdminPassword": "Sys@dmin-sample1"
   },
   "UserControllerConfiguration": {
-    "Type": "simple",
+    "Type": "simulative",
     "RatesDistribution":[
       {
         "Rate": 1.0,
@@ -34,7 +34,7 @@
   },
   "UsersConfiguration": {
     "InitialActiveUsers": 0,
-    "MaxActiveUsers": 1000,
+    "MaxActiveUsers": 2000,
     "AvgSessionsPerUser": 1
   },
   "LogSettings": {

--- a/config/coordinator.default.json
+++ b/config/coordinator.default.json
@@ -6,7 +6,7 @@
         "ApiURL": "http://localhost:4000"
       }
     ],
-    "MaxActiveUsers": 1000
+    "MaxActiveUsers": 2000
   },
   "MonitorConfig": {
     "PrometheusURL": "http://localhost:9090",


### PR DESCRIPTION
#### Summary

PR sets the default controller to `simulative` and also changes the default for max active users.
These values come from several tests and they apply to default configs.  Currently I've verified the following:

```golang
map[string]int{
  "t3.xlarge": 2000,
  "m5.xlarge": 2500,
  "m5.2xlarge": 4500,
}
```

These are the maximum number of user to be ran on a single agent instance of that type.
When I have gathered more data I'll also include this info in the documentation.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24613
