### PR TITLE
MM-25049: Add cluster controller

### DIFF
--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -19,7 +19,6 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
-	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/spf13/cobra"
 )
 
@@ -105,15 +104,8 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 			// For cluster controller, we only use the sysadmin
 			// because we are just testing system console APIs.
 			ueConfig.Username = ""
-			ueConfig.Email = ""
-			ueConfig.Password = ""
-			err = store.SetUser(&model.User{
-				Email:    config.ConnectionConfiguration.AdminEmail,
-				Password: config.ConnectionConfiguration.AdminPassword,
-			})
-			if err != nil {
-				return nil, err
-			}
+			ueConfig.Email = config.ConnectionConfiguration.AdminEmail
+			ueConfig.Password = config.ConnectionConfiguration.AdminPassword
 
 			admin := userentity.New(store, transport, ueConfig)
 			return clustercontroller.New(id, admin, status)

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/clustercontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/noopcontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
+
 	"github.com/mattermost/mattermost-server/v5/mlog"
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/spf13/cobra"
 )
 
@@ -98,6 +101,22 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 			return simulcontroller.New(id, ue, ucConfig.(*simulcontroller.Config), status)
 		case loadtest.UserControllerNoop:
 			return noopcontroller.New(id, ue, status)
+		case loadtest.UserControllerCluster:
+			// For cluster controller, we only use the sysadmin
+			// because we are just testing system console APIs.
+			ueConfig.Username = ""
+			ueConfig.Email = ""
+			ueConfig.Password = ""
+			err = store.SetUser(&model.User{
+				Email:    config.ConnectionConfiguration.AdminEmail,
+				Password: config.ConnectionConfiguration.AdminPassword,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			admin := userentity.New(store, transport, ueConfig)
+			return clustercontroller.New(id, admin, status)
 		default:
 			panic("controller type must be valid")
 		}

--- a/example/sampleuser/user.go
+++ b/example/sampleuser/user.go
@@ -455,3 +455,23 @@ func (u *SampleUser) GetUsers(page, perPage int) ([]string, error) {
 func (u *SampleUser) AutoCompleteUsersInChannel(teamId, channelId, username string, limit int) (map[string]bool, error) {
 	return nil, nil
 }
+
+func (u *SampleUser) GetLogs(page, perPage int) error {
+	return nil
+}
+
+func (u *SampleUser) GetAnalytics() error {
+	return nil
+}
+
+func (u *SampleUser) GetClusterStatus() error {
+	return nil
+}
+
+func (u *SampleUser) GetPluginStatuses() error {
+	return nil
+}
+
+func (u *SampleUser) UpdateConfig(*model.Config) error {
+	return nil
+}

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -47,13 +47,14 @@ const (
 	UserControllerSimple     userControllerType = "simple"
 	UserControllerSimulative                    = "simulative"
 	UserControllerNoop                          = "noop"
+	UserControllerCluster                       = "cluster"
 )
 
 // IsValid reports whether a given UserControllerType is valid or not.
 // Returns an error if the validation fails.
 func (t userControllerType) IsValid() error {
 	switch t {
-	case UserControllerSimple, UserControllerSimulative:
+	case UserControllerSimple, UserControllerSimulative, UserControllerCluster:
 		return nil
 	case "":
 		return fmt.Errorf("UserControllerType cannot be empty")

--- a/loadtest/control/clustercontroller/controller.go
+++ b/loadtest/control/clustercontroller/controller.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package clustercontroller
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
+)
+
+type ClusterController struct {
+	id      int
+	user    user.User
+	stop    chan struct{}
+	stopped chan struct{}
+	status  chan<- control.UserStatus
+	rate    float64
+}
+
+func New(id int, user user.User, status chan<- control.UserStatus) (*ClusterController, error) {
+	return &ClusterController{
+		id:      id,
+		user:    user,
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+		status:  status,
+		rate:    1.0,
+	}, nil
+}
+
+// Run begins performing a set of actions in a loop with a defined wait
+// in between the actions. It keeps on doing it until Stop is invoked.
+// This is also a blocking function, so it is recommended to invoke it
+// inside a goroutine.
+func (c *ClusterController) Run() {
+	if c.user == nil {
+		c.sendFailStatus("controller was not initialized")
+		return
+	}
+
+	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
+
+	defer func() {
+		c.sendStopStatus()
+		close(c.stopped)
+	}()
+
+	if resp := control.Login(c.user); resp.Err != nil {
+		c.status <- c.newErrorStatus(resp.Err)
+	} else {
+		c.status <- c.newInfoStatus(resp.Info)
+	}
+
+	actions := []control.UserAction{
+		func(u user.User) control.UserActionResponse {
+			err := u.GetLogs(0, 100)
+			if err != nil {
+				return control.UserActionResponse{
+					Err: control.NewUserError(err),
+				}
+			}
+			return control.UserActionResponse{
+				Info: fmt.Sprintf("got logs"),
+			}
+		},
+		func(u user.User) control.UserActionResponse {
+			err := u.GetAnalytics()
+			if err != nil {
+				return control.UserActionResponse{
+					Err: control.NewUserError(err),
+				}
+			}
+			return control.UserActionResponse{
+				Info: fmt.Sprintf("got analytics"),
+			}
+		},
+		func(u user.User) control.UserActionResponse {
+			err := u.GetClusterStatus()
+			if err != nil {
+				return control.UserActionResponse{
+					Err: control.NewUserError(err),
+				}
+			}
+			return control.UserActionResponse{
+				Info: fmt.Sprintf("got cluster stats"),
+			}
+		},
+		func(u user.User) control.UserActionResponse {
+			err := u.GetPluginStatuses()
+			if err != nil {
+				return control.UserActionResponse{
+					Err: control.NewUserError(err),
+				}
+			}
+			return control.UserActionResponse{
+				Info: fmt.Sprintf("got plugin statuses"),
+			}
+		},
+		func(u user.User) control.UserActionResponse {
+			err := u.GetConfig()
+			if err != nil {
+				return control.UserActionResponse{
+					Err: control.NewUserError(err),
+				}
+			}
+			cfg := u.Store().Config()
+			// We just flip the enable developer flag to trigger a config update
+			// across the cluster.
+			*cfg.ServiceSettings.EnableDeveloper = !*cfg.ServiceSettings.EnableDeveloper
+			err = u.UpdateConfig(&cfg)
+			if err != nil {
+				return control.UserActionResponse{
+					Err: control.NewUserError(err),
+				}
+			}
+			return control.UserActionResponse{
+				Info: fmt.Sprintf("updated config"),
+			}
+		},
+	}
+
+	for {
+		for _, action := range actions {
+			if resp := action(c.user); resp.Err != nil {
+				c.status <- c.newErrorStatus(resp.Err)
+			} else {
+				c.status <- c.newInfoStatus(resp.Info)
+			}
+
+			idleTime := time.Duration(math.Round(float64(1000) * c.rate))
+			select {
+			case <-c.stop:
+				return
+			case <-time.After(time.Millisecond * idleTime):
+			}
+		}
+	}
+}
+
+// SetRate sets the relative speed of execution of actions by the user.
+func (c *ClusterController) SetRate(rate float64) error {
+	if rate < 0 {
+		return errors.New("rate should be a positive value")
+	}
+	c.rate = rate
+	return nil
+}
+
+// Stop stops the controller.
+func (c *ClusterController) Stop() {
+	close(c.stop)
+	<-c.stopped
+	c.stop = make(chan struct{})
+	c.stopped = make(chan struct{})
+}
+
+func (c *ClusterController) sendFailStatus(reason string) {
+	c.status <- control.UserStatus{
+		ControllerId: c.id,
+		User:         c.user,
+		Code:         control.USER_STATUS_FAILED,
+		Err:          errors.New(reason),
+	}
+}
+
+func (c *ClusterController) sendStopStatus() {
+	c.status <- control.UserStatus{
+		ControllerId: c.id,
+		User:         c.user,
+		Info:         "user stopped",
+		Code:         control.USER_STATUS_STOPPED,
+	}
+}
+
+func (c *ClusterController) newInfoStatus(info string) control.UserStatus {
+	return control.UserStatus{
+		ControllerId: c.id,
+		User:         c.user,
+		Code:         control.USER_STATUS_INFO,
+		Info:         info,
+		Err:          nil,
+	}
+}
+
+func (c *ClusterController) newErrorStatus(err error) control.UserStatus {
+	return control.UserStatus{
+		ControllerId: c.id,
+		User:         c.user,
+		Code:         control.USER_STATUS_ERROR,
+		Info:         "",
+		Err:          err,
+	}
+}

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -132,6 +132,7 @@ type User interface {
 	SetCurrentChannel(channel *model.Channel) error
 
 	// System console functionalities
+	
 	// GetLogs fetches the logs.
 	GetLogs(page, perPage int) error
 	// GetAnalytics fetches the system analytics.

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -5,6 +5,7 @@ package user
 
 import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
@@ -129,6 +130,18 @@ type User interface {
 	IsTeamAdmin() (bool, error)
 	SetCurrentTeam(team *model.Team) error
 	SetCurrentChannel(channel *model.Channel) error
+
+	// System console functionalities
+	// GetLogs fetches the logs.
+	GetLogs(page, perPage int) error
+	// GetAnalytics fetches the system analytics.
+	GetAnalytics() error
+	// GetClusterStatus fetches the cluster status.
+	GetClusterStatus() error
+	// GetPluginStatuses fetches the plugin statuses.
+	GetPluginStatuses() error
+	// UpdateConfig updates the config with cfg.
+	UpdateConfig(cfg *model.Config) error
 
 	// Clear clears the underlying UserStore
 	ClearUserData()

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -132,7 +132,7 @@ type User interface {
 	SetCurrentChannel(channel *model.Channel) error
 
 	// System console functionalities
-	
+
 	// GetLogs fetches the logs.
 	GetLogs(page, perPage int) error
 	// GetAnalytics fetches the system analytics.

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -5,7 +5,6 @@ package userentity
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -896,14 +895,7 @@ func (ue *UserEntity) GetLogs(page, perPage int) error {
 
 // GetAnalytics fetches the system analytics.
 func (ue *UserEntity) GetAnalytics() error {
-	teamIds, err := ue.GetTeamsForUser(ue.store.Id())
-	if err != nil {
-		return err
-	}
-	if len(teamIds) == 0 {
-		return fmt.Errorf("user does not have any teams")
-	}
-	_, resp := ue.client.GetAnalyticsOld("", teamIds[0])
+	_, resp := ue.client.GetAnalyticsOld("", "")
 	if resp.Error != nil {
 		return resp.Error
 	}


### PR DESCRIPTION
Just a basic smoke testing of the APIs that involve cluster communication.
It just iterates over all APIs serially, rolling over to the first API.


#### Ticket link

https://mattermost.atlassian.net/browse/MM-25049