### PR TITLE
MM-25511: Improve nginx keepalive connections

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -235,7 +235,7 @@ func (t *Terraform) setupProxyServer(output *Output, extAgent *ssh.ExtAgent) {
 
 		backends := ""
 		for _, addr := range output.Instances.Value {
-			backends += "server " + addr.PrivateIP + ":8065;\n"
+			backends += "server " + addr.PrivateIP + ":8065; max_fails=3\n"
 		}
 
 		batch := []uploadInfo{

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -79,7 +79,7 @@ http {
 const nginxSiteConfig = `
 upstream backend {
 %s
-        keepalive 1024;
+        keepalive 64;
 }
 
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_size=3g inactive=120m use_temp_path=off;


### PR DESCRIPTION
1024 is too high a number for it. I misunderstood the directive to be something
where nginx would only keep connections alive when the client wouid be done with them.
But this is a different set of connections than "active" ones. And it is specifically mentioned in the docs.

> It should be particularly noted that the keepalive directive does not limit the total number
of connections to upstream servers that an nginx worker process can open.
The connections parameter should be set to a number small enough to let upstream servers
process new incoming connections as well.

https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive

After some trial and error, I found 64 to be a decent number.

Previously timeout errors would start to appear at 1k connections, now it comes at around 5k.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-25511
