### PR TITLE
[MM-25532] Make Prometheus targets human friendly

### DIFF
--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -31,25 +31,35 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent, output *Output) error {
 		return err
 	}
 
-	var mmEndpoint, nodeExporterEndpoint []string
-	for _, val := range output.Instances.Value {
-		mmEndpoint = append(mmEndpoint, "'"+val.PrivateIP+":8067'")
-		nodeExporterEndpoint = append(nodeExporterEndpoint, "'"+val.PrivateIP+":9100'")
+	var hosts string
+	var mmTargets, nodeTargets []string
+	for i, val := range output.Instances.Value {
+		host := fmt.Sprintf("app%d", i)
+		mmTargets = append(mmTargets, fmt.Sprintf("'%s:8067'", host))
+		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
+		hosts += fmt.Sprintf("%s %s\n", val.PrivateIP, host)
 	}
-	for _, val := range output.Agents.Value {
-		nodeExporterEndpoint = append(nodeExporterEndpoint, "'"+val.PrivateIP+":9100'")
+	for i, val := range output.Agents.Value {
+		host := fmt.Sprintf("agent%d", i)
+		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
+		hosts += fmt.Sprintf("%s %s\n", val.PrivateIP, host)
 	}
 	if output.HasProxy() {
-		nodeExporterEndpoint = append(nodeExporterEndpoint, "'"+output.Proxy.Value[0].PrivateIP+":9100'")
+		host := "proxy"
+		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
+		hosts += fmt.Sprintf("%s %s\n", output.Proxy.Value[0].PrivateIP, host)
 	}
-	mmConfig := strings.Join(mmEndpoint, ",")
-	nodeExporterConfig := strings.Join(nodeExporterEndpoint, ",")
 
-	prometheusConfigFile := fmt.Sprintf(prometheusConfig, mmConfig, nodeExporterConfig)
-	rdr := strings.NewReader(prometheusConfigFile)
 	mlog.Info("Updating Prometheus config", mlog.String("host", output.MetricsServer.Value.PublicIP))
+	prometheusConfigFile := fmt.Sprintf(prometheusConfig, strings.Join(nodeTargets, ","), strings.Join(mmTargets, ","))
+	rdr := strings.NewReader(prometheusConfigFile)
 	if out, err := sshc.Upload(rdr, "/etc/prometheus/prometheus.yml", true); err != nil {
 		return fmt.Errorf("error upload prometheus config: output: %s, error: %w", out, err)
+	}
+	metricsHostsFile := fmt.Sprintf(metricsHosts, hosts)
+	rdr = strings.NewReader(metricsHostsFile)
+	if out, err := sshc.Upload(rdr, "/etc/hosts", true); err != nil {
+		return fmt.Errorf("error upload metrics hosts file: output: %s, error: %w", out, err)
 	}
 
 	mlog.Info("Starting Prometheus", mlog.String("host", output.MetricsServer.Value.PublicIP))

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -34,13 +34,13 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent, output *Output) error {
 	var hosts string
 	var mmTargets, nodeTargets []string
 	for i, val := range output.Instances.Value {
-		host := fmt.Sprintf("app%d", i)
+		host := fmt.Sprintf("app-%d", i)
 		mmTargets = append(mmTargets, fmt.Sprintf("'%s:8067'", host))
 		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
 		hosts += fmt.Sprintf("%s %s\n", val.PrivateIP, host)
 	}
 	for i, val := range output.Agents.Value {
-		host := fmt.Sprintf("agent%d", i)
+		host := fmt.Sprintf("agent-%d", i)
 		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
 		hosts += fmt.Sprintf("%s %s\n", val.PrivateIP, host)
 	}

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -24,22 +24,36 @@ WantedBy=multi-user.target
 
 const prometheusConfig = `
 global:
-  scrape_interval:     15s # By default, scrape targets every 15 seconds.
-  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  scrape_interval:     5s
+  evaluation_interval: 5s
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  - job_name: 'prometheus'
-    scrape_interval: 5s
-    scrape_timeout: 5s
-
+  - job_name: prometheus
     static_configs:
-        - targets: ['localhost:9090', %s]
-
+        - targets: ['metrics:9090']
   - job_name: node
     static_configs:
-        - targets: ['localhost:9100', %s]
+        - targets: ['metrics:9100',%s]
+  - job_name: mattermost
+    static_configs:
+        - targets: [%s]
+`
+
+const metricsHosts = `
+127.0.0.1 localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1 ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts
+
+127.0.0.1 metrics
+%s
 `
 
 const nginxConfig = `


### PR DESCRIPTION
#### Summary

PR reworks a bit how we group and name Prometheus targets. This is to facilitate certain queries and at the same time make it easier to manually filter data in Grafana.
For example, I couldn't find a way to query node-exporter data coming only from app instances.
Now it's possible with a simple regexp on the `instance` label.

#### Ticket

https://mattermost.atlassian.net/browse/MM-25532