### PR TITLE
MM-25437: Shutdown agents in parallel

### DIFF
--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -6,6 +6,7 @@ package cluster
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
 
@@ -75,11 +76,17 @@ func (c *LoadAgentCluster) Stop() error {
 // It differs from Stop() as it won't return early in case of an error.
 // It makes sure agent.Stop() is called once for every agent in the cluster.
 func (c *LoadAgentCluster) Shutdown() {
-	for _, agent := range c.agents {
-		if err := agent.Stop(); err != nil {
-			mlog.Error("cluster: failed to stop agent", mlog.Err(err))
-		}
+	var wg sync.WaitGroup
+	wg.Add(len(c.agents))
+	for _, ag := range c.agents {
+		go func(ag *agent.LoadAgent) {
+			defer wg.Done()
+			if err := ag.Stop(); err != nil {
+				mlog.Error("cluster: failed to stop agent", mlog.Err(err))
+			}
+		}(ag)
 	}
+	wg.Wait()
 }
 
 // IncrementUsers increments the total number of active users in the load-test


### PR DESCRIPTION
While shutting down a huge cluster of more than 10k users,
the stopping of the coordinator service will time out, leading
to the service being forcibly killed but the agents would still
be running.

We shutdown in parallel to reduce the time.

The DefaultTimeoutStopSec is 90 seconds, so we can keep that as is.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-25437