### PR TITLE
[MM-25410] Re-try failed init actions in SimulController

### DIFF
--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -88,15 +88,16 @@ func (c *SimulController) Run() {
 		},
 	}
 
-	for _, action := range initActions {
+	for i := 0; i < len(initActions); i++ {
 		select {
 		case <-c.stopChan:
 			return
 		case <-time.After(pickIdleTimeMs(c.config.MinIdleTimeMs, c.config.AvgIdleTimeMs, 1.0)):
 		}
 
-		if resp := action.run(c.user); resp.Err != nil {
+		if resp := initActions[i].run(c.user); resp.Err != nil {
 			c.status <- c.newErrorStatus(resp.Err)
+			i--
 		} else {
 			c.status <- c.newInfoStatus(resp.Info)
 		}

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -329,6 +329,11 @@ func (s *MemStore) SetPost(post *model.Post) error {
 		return errors.New("memstore: post id should not be empty")
 	}
 
+	// Avoid storing deleted posts.
+	if post.DeleteAt > 0 {
+		return nil
+	}
+
 	// We get an element from the queue and check if we have it in the map and
 	// if it points to the same memory location. If so, we delete it since it means the queue is full.
 	// This is done to keep the data pointed by the map consistent with the data stored in the queue.

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -201,27 +201,36 @@ func (ue *UserEntity) SearchPosts(teamId, terms string, isOrSearch bool) (*model
 }
 
 func (ue *UserEntity) GetPostsForChannel(channelId string, page, perPage int) error {
-	postlist, resp := ue.client.GetPostsForChannel(channelId, page, perPage, "")
+	postList, resp := ue.client.GetPostsForChannel(channelId, page, perPage, "")
 	if resp.Error != nil {
 		return resp.Error
 	}
-	return ue.store.SetPosts(postsMapToSlice(postlist.Posts))
+	if postList == nil || len(postList.Posts) == 0 {
+		return nil
+	}
+	return ue.store.SetPosts(postsMapToSlice(postList.Posts))
 }
 
 func (ue *UserEntity) GetPostsBefore(channelId, postId string, page, perPage int) error {
-	postlist, resp := ue.client.GetPostsBefore(channelId, postId, page, perPage, "")
+	postList, resp := ue.client.GetPostsBefore(channelId, postId, page, perPage, "")
 	if resp.Error != nil {
 		return resp.Error
 	}
-	return ue.store.SetPosts(postsMapToSlice(postlist.Posts))
+	if postList == nil || len(postList.Posts) == 0 {
+		return nil
+	}
+	return ue.store.SetPosts(postsMapToSlice(postList.Posts))
 }
 
 func (ue *UserEntity) GetPostsAfter(channelId, postId string, page, perPage int) error {
-	postlist, resp := ue.client.GetPostsAfter(channelId, postId, page, perPage, "")
+	postList, resp := ue.client.GetPostsAfter(channelId, postId, page, perPage, "")
 	if resp.Error != nil {
 		return resp.Error
 	}
-	return ue.store.SetPosts(postsMapToSlice(postlist.Posts))
+	if postList == nil || len(postList.Posts) == 0 {
+		return nil
+	}
+	return ue.store.SetPosts(postsMapToSlice(postList.Posts))
 }
 
 func (ue *UserEntity) GetPostsSince(channelId string, time int64) ([]string, error) {
@@ -229,7 +238,7 @@ func (ue *UserEntity) GetPostsSince(channelId string, time int64) ([]string, err
 	if resp.Error != nil {
 		return nil, resp.Error
 	}
-	if len(postList.Posts) == 0 {
+	if postList == nil || len(postList.Posts) == 0 {
 		return nil, nil
 	}
 
@@ -255,7 +264,7 @@ func (ue *UserEntity) GetPostsAroundLastUnread(channelId string, limitBefore, li
 	if resp.Error != nil {
 		return nil, resp.Error
 	}
-	if len(postList.Posts) == 0 {
+	if postList == nil || len(postList.Posts) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
#### Summary

PR implements a simple re-try mechanism for SimulController's init actions. If an action fails we'll run it again until it does.

Sometimes it would happen than an init action failed for some user and the controller would keep running with an inconsistent state (no sufficient data) which meant that while the user was considered active it would not apply the desired load and instead return errors.

Included in the PR are also other bug fixes which caused either crashes (nil dereferencing panics) or state errors (e.g. current team not set).

#### Ticket

https://mattermost.atlassian.net/browse/MM-25410