### PR TITLE
MM-25605: Add timeout to the HTTP client

### DIFF
--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -6,6 +6,7 @@ package userentity
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
@@ -58,7 +59,10 @@ func New(store store.MutableUserStore, rt http.RoundTripper, config Config) *Use
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
-	ue.client.HttpClient = &http.Client{Transport: rt}
+	ue.client.HttpClient = &http.Client{
+		Transport: rt,
+		Timeout:   5 * time.Second,
+	}
 	err := store.SetUser(&model.User{
 		Username: config.Username,
 		Email:    config.Email,


### PR DESCRIPTION
Without a timeout in the HTTP request, the underlying TCP dialer
timeouts were also not working. And basically the entire network
stack would be dysfunctional.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-25605