### PR TITLE
MM-25424: skip common prefix when considering mentioning username

### DIFF
--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
@@ -49,11 +50,15 @@ func genMessage(isReply bool) string {
 }
 
 func splitName(name string) (string, string) {
+	reSplit := regexp.MustCompile(`\d+$`)
+	typed := reSplit.FindString(name)
 	var prefix string
-	if strings.HasPrefix(name, "testuser-") {
-		prefix = "testuser-"
+	if typed == "" {
+		typed = name
+	} else {
+		prefix = strings.TrimSuffix(name, typed)
 	}
-	return prefix, strings.TrimPrefix(name, prefix)
+	return prefix, typed
 }
 
 func emulateMention(teamId, channelId, name string, auto func(teamId, channelId, username string, limit int) (map[string]bool, error)) error {

--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 	"math"
 	"math/rand"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 )
 
 // pickAction randomly selects an action from a slice of userAction with
@@ -50,8 +50,7 @@ func genMessage(isReply bool) string {
 }
 
 func splitName(name string) (string, string) {
-	reSplit := regexp.MustCompile(`\d+$`)
-	typed := reSplit.FindString(name)
+	typed := user.TestUserSuffixRegexp.FindString(name)
 	var prefix string
 	if typed == "" {
 		typed = name

--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -61,10 +61,10 @@ func splitName(name string) (string, string) {
 }
 
 func emulateMention(teamId, channelId, name string, auto func(teamId, channelId, username string, limit int) (map[string]bool, error)) error {
-	cutoff := 2 + rand.Intn(len(name)/2)
 	found := errors.New("found") // will be used to halt emulate typing function
 
 	prefix, typed := splitName(name)
+	cutoff := len(prefix) + rand.Intn(len(typed)/2) + 2
 	resp := control.EmulateUserTyping(typed, func(term string) control.UserActionResponse {
 		term = prefix + term
 		users, err := auto(teamId, channelId, term, 100)

--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"math"
 	"math/rand"
-	"regexp"
 	"strings"
 	"time"
 
@@ -50,15 +49,11 @@ func genMessage(isReply bool) string {
 }
 
 func splitName(name string) (string, string) {
-	reSplit := regexp.MustCompile(`\d+$`)
-	typed := reSplit.FindString(name)
 	var prefix string
-	if typed == "" {
-		typed = name
-	} else {
-		prefix = strings.TrimSuffix(name, typed)
+	if strings.HasPrefix(name, "testuser-") {
+		prefix = "testuser-"
 	}
-	return prefix, typed
+	return prefix, strings.TrimPrefix(name, prefix)
 }
 
 func emulateMention(teamId, channelId, name string, auto func(teamId, channelId, username string, limit int) (map[string]bool, error)) error {

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -122,13 +122,13 @@ func TestSplitName(t *testing.T) {
 		},
 		{
 			input:  "testuser999",
-			prefix: "",
-			typed:  "testuser999",
+			prefix: "testuser",
+			typed:  "999",
 		},
 		{
-			input:  "téstüser-999",
-			prefix: "",
-			typed:  "téstüser-999",
+			input:  "téstüser999",
+			prefix: "téstüser",
+			typed:  "999",
 		},
 		{
 			input:  "testuser",
@@ -137,8 +137,8 @@ func TestSplitName(t *testing.T) {
 		},
 		{
 			input:  "testuser-100a",
-			prefix: "testuser-",
-			typed:  "100a",
+			prefix: "",
+			typed:  "testuser-100a",
 		},
 	}
 	for _, tc := range testCases {

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -110,3 +110,40 @@ func TestPickAction(t *testing.T) {
 		require.Greater(t, res[1], res[3])
 	})
 }
+
+func TestSplitName(t *testing.T) {
+	testCases := []struct {
+		input, prefix, typed string
+	}{
+		{
+			input:  "testuser-1",
+			prefix: "testuser-",
+			typed:  "1",
+		},
+		{
+			input:  "testuser999",
+			prefix: "testuser",
+			typed:  "999",
+		},
+		{
+			input:  "téstüser999",
+			prefix: "téstüser",
+			typed:  "999",
+		},
+		{
+			input:  "testuser",
+			prefix: "",
+			typed:  "testuser",
+		},
+		{
+			input:  "testuser-100a",
+			prefix: "",
+			typed:  "testuser-100a",
+		},
+	}
+	for _, tc := range testCases {
+		ePrefix, eTyped := splitName(tc.input)
+		require.Equal(t, tc.prefix, ePrefix)
+		require.Equal(t, tc.typed, eTyped)
+	}
+}

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -142,8 +142,8 @@ func TestSplitName(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		ePrefix, eTyped := splitName(tc.input)
-		require.Equal(t, tc.prefix, ePrefix)
-		require.Equal(t, tc.typed, eTyped)
+		prefix, typed := splitName(tc.input)
+		require.Equal(t, tc.prefix, prefix)
+		require.Equal(t, tc.typed, typed)
 	}
 }

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -122,13 +122,13 @@ func TestSplitName(t *testing.T) {
 		},
 		{
 			input:  "testuser999",
-			prefix: "testuser",
-			typed:  "999",
+			prefix: "",
+			typed:  "testuser999",
 		},
 		{
-			input:  "téstüser999",
-			prefix: "téstüser",
-			typed:  "999",
+			input:  "téstüser-999",
+			prefix: "",
+			typed:  "téstüser-999",
 		},
 		{
 			input:  "testuser",
@@ -137,8 +137,8 @@ func TestSplitName(t *testing.T) {
 		},
 		{
 			input:  "testuser-100a",
-			prefix: "",
-			typed:  "testuser-100a",
+			prefix: "testuser-",
+			typed:  "100a",
 		},
 	}
 	for _, tc := range testCases {

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
+// TestUserSuffixRegexp matches the numerical suffix of test usernames,
+// which are assumed to be in this format.
 var TestUserSuffixRegexp = regexp.MustCompile(`\d+$`)
 
 // User provides a wrapper interface to interact with the Mattermost server

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -4,10 +4,14 @@
 package user
 
 import (
+	"regexp"
+
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 )
+
+var TestUserSuffixRegexp = regexp.MustCompile(`\d+$`)
 
 // User provides a wrapper interface to interact with the Mattermost server
 // through its client APIs. It persists the data to its UserStore for later use.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Skip common username prefix when loadtesting typed mentions. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-25424
