### PR TITLE
MM-25850: fix rand usage to not panic

### DIFF
--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -62,14 +62,14 @@ func splitName(name string) (string, string) {
 
 func getCutoff(prefix, typed string, altRand *rand.Rand) int {
 	cutoff := len(prefix) + 2
-	if len(typed)/2 > 0 {
-		if altRand != nil {
-			cutoff += altRand.Intn(len(typed) / 2)
-		} else {
-			cutoff += rand.Intn(len(typed) / 2)
-		}
+	switch {
+	case len(typed)/2 > 0 && altRand != nil:
+		return cutoff + altRand.Intn(len(typed)/2)
+	case len(typed)/2 > 0:
+		return cutoff + rand.Intn(len(typed)/2)
+	default:
+		return cutoff
 	}
-	return cutoff
 }
 
 func emulateMention(teamId, channelId, name string, auto func(teamId, channelId, username string, limit int) (map[string]bool, error)) error {

--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -60,13 +60,14 @@ func splitName(name string) (string, string) {
 	return prefix, typed
 }
 
-func getCutoff(prefix, typed string, seed ...int64) int {
-	if len(seed) > 0 { // for deterministic test output
-		rand.Seed(seed[0])
-	}
+func getCutoff(prefix, typed string, altRand *rand.Rand) int {
 	cutoff := len(prefix) + 2
 	if len(typed)/2 > 0 {
-		cutoff += rand.Intn(len(typed) / 2)
+		if altRand != nil {
+			cutoff += altRand.Intn(len(typed) / 2)
+		} else {
+			cutoff += rand.Intn(len(typed) / 2)
+		}
 	}
 	return cutoff
 }
@@ -75,7 +76,7 @@ func emulateMention(teamId, channelId, name string, auto func(teamId, channelId,
 	found := errors.New("found") // will be used to halt emulate typing function
 
 	prefix, typed := splitName(name)
-	cutoff := getCutoff(prefix, typed)
+	cutoff := getCutoff(prefix, typed, nil)
 	resp := control.EmulateUserTyping(typed, func(term string) control.UserActionResponse {
 		term = prefix + term
 		users, err := auto(teamId, channelId, term, 100)

--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -60,11 +60,22 @@ func splitName(name string) (string, string) {
 	return prefix, typed
 }
 
+func getCutoff(prefix, typed string, seed ...int64) int {
+	if len(seed) > 0 { // for deterministic test output
+		rand.Seed(seed[0])
+	}
+	cutoff := len(prefix) + 2
+	if len(typed)/2 > 0 {
+		cutoff += rand.Intn(len(typed) / 2)
+	}
+	return cutoff
+}
+
 func emulateMention(teamId, channelId, name string, auto func(teamId, channelId, username string, limit int) (map[string]bool, error)) error {
 	found := errors.New("found") // will be used to halt emulate typing function
 
 	prefix, typed := splitName(name)
-	cutoff := len(prefix) + rand.Intn(len(typed)/2) + 2
+	cutoff := getCutoff(prefix, typed)
 	resp := control.EmulateUserTyping(typed, func(term string) control.UserActionResponse {
 		term = prefix + term
 		users, err := auto(teamId, channelId, term, 100)

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -147,3 +147,39 @@ func TestSplitName(t *testing.T) {
 		require.Equal(t, tc.typed, typed)
 	}
 }
+
+func TestGetCutoff(t *testing.T) {
+	testCases := []struct {
+		prefix, typed string
+		cutoff        int
+	}{
+		{
+			prefix: "testuser-",
+			typed:  "1",
+			cutoff: 11,
+		},
+		{
+			prefix: "testuser",
+			typed:  "999",
+			cutoff: 10,
+		},
+		{
+			prefix: "téstüser",
+			typed:  "999",
+			cutoff: 12,
+		},
+		{
+			prefix: "",
+			typed:  "testuser",
+			cutoff: 3,
+		},
+		{
+			prefix: "",
+			typed:  "testuser-100a",
+			cutoff: 7,
+		},
+	}
+	for _, tc := range testCases {
+		require.Equal(t, tc.cutoff, getCutoff(tc.prefix, tc.typed, 1)) // seed is constant for deterministic random numbers for tests
+	}
+}

--- a/loadtest/control/simulcontroller/utils_test.go
+++ b/loadtest/control/simulcontroller/utils_test.go
@@ -5,6 +5,7 @@ package simulcontroller
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -171,7 +172,7 @@ func TestGetCutoff(t *testing.T) {
 		{
 			prefix: "",
 			typed:  "testuser",
-			cutoff: 3,
+			cutoff: 5,
 		},
 		{
 			prefix: "",
@@ -179,7 +180,10 @@ func TestGetCutoff(t *testing.T) {
 			cutoff: 7,
 		},
 	}
+	// custom rand with fixed source for deterministic values
+	// without polluting global rand
+	newRand := rand.New(rand.NewSource(1))
 	for _, tc := range testCases {
-		require.Equal(t, tc.cutoff, getCutoff(tc.prefix, tc.typed, 1)) // seed is constant for deterministic random numbers for tests
+		require.Equal(t, tc.cutoff, getCutoff(tc.prefix, tc.typed, newRand))
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Fix usage of `rand.Intn` to stop panic. Refactored to make testable.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-25850
