### PR TITLE
[MM-26034] Review docs and fix some config defaults

### DIFF
--- a/config/coordinator.sample.json
+++ b/config/coordinator.sample.json
@@ -25,7 +25,7 @@
   "RestTimeSec": 10,
   "LogSettings": {
     "EnableConsole": true,
-    "ConsoleLevel": "ERROR",
+    "ConsoleLevel": "INFO",
     "ConsoleJson": false,
     "EnableFile": true,
     "FileLevel": "INFO",

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -27,7 +27,7 @@
   "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v0.6.0-alpha/mattermost-load-test-ng-v0.6.0-alpha-linux-amd64.tar.gz",
   "LogSettings": {
     "EnableConsole": true,
-    "ConsoleLevel": "ERROR",
+    "ConsoleLevel": "INFO",
     "ConsoleJson": false,
     "EnableFile": true,
     "FileLevel": "INFO",

--- a/docs/local_loadtest.md
+++ b/docs/local_loadtest.md
@@ -53,10 +53,14 @@ Running this command will create initial teams and channels for the users to joi
 A new load-test can be started with the following command:
 
 ```sh
-go run ./cmd/ltagent -c config/config.json --controller-config config/simplecontroller.json -d 60
+go run ./cmd/ltagent -n 10 -d 60
 ```
 
-This will run a load-test with the given configs for 60 seconds.
+This will start a load-test running the specified number of users (10) for 60 seconds.
+
+#### Note
+
+Command line arguments take precedence over configuration settings.
 
 ## Running a load-test through the load-test agent API server
 
@@ -159,7 +163,7 @@ Its documentation can be found [here](coordinator_config.md).
 From a different terminal we can then run the [`coordinator`](coordinator.md).
 
 ```sh
-go run ./cmd/ltcoordinator -c config/coordinator.json -l config/config.json
+go run ./cmd/ltcoordinator
 ```
 
 This will start running a load-test across the configured cluster of load-test agents.

--- a/docs/terraform_loadtest.md
+++ b/docs/terraform_loadtest.md
@@ -91,7 +91,7 @@ cp config/config.sample.json config/config.json
 
 Its documentation can be found [here](loadtest_config.md).
 
-### Run the coordinator
+### Start a load-test
 
 ```sh
 go run ./cmd/ltctl loadtest start

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -74,7 +74,7 @@ type InstanceConfiguration struct {
 
 type UsersConfiguration struct {
 	InitialActiveUsers int `default:"0" validate:"range:[0,$MaxActiveUsers]"`
-	MaxActiveUsers     int `default:"1000" validate:"range:(0,]"`
+	MaxActiveUsers     int `default:"2000" validate:"range:(0,]"`
 	AvgSessionsPerUser int `default:"1" validate:"range:[1,]"`
 }
 


### PR DESCRIPTION
#### Summary

PR reviews the documentation, adds missing `-n` flag when running load-test manually and simplifies a bit the commands (no need to explicitly pass configs).
PR also fixes a couple of config defaults.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26034
