### PR TITLE
[MM-25899] Use gencontroller to improve init process

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -128,8 +128,8 @@ func (a *API) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		ueConfig := userentity.Config{
 			ServerURL:    ltConfig.ConnectionConfiguration.ServerURL,
 			WebSocketURL: ltConfig.ConnectionConfiguration.WebSocketURL,
-			Username:     fmt.Sprintf("%s-user%d", agentId, id),
-			Email:        fmt.Sprintf("%s-user%d@example.com", agentId, id),
+			Username:     fmt.Sprintf("%s-%d", agentId, id),
+			Email:        fmt.Sprintf("%s-%d@example.com", agentId, id),
 			Password:     "testPass123$",
 		}
 		store, err := memstore.New(&memstore.Config{

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -112,7 +112,17 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
-	genConfig := config.InstanceConfiguration
+	genConfig := gencontroller.Config{
+		NumTeams:               config.InstanceConfiguration.NumTeams,
+		NumChannels:            config.InstanceConfiguration.NumChannels,
+		NumPosts:               config.InstanceConfiguration.NumPosts,
+		NumReactions:           config.InstanceConfiguration.NumReactions,
+		PercentReplies:         config.InstanceConfiguration.PercentReplies,
+		PercentPublicChannels:  config.InstanceConfiguration.PercentPublicChannels,
+		PercentPrivateChannels: config.InstanceConfiguration.PercentPrivateChannels,
+		PercentDirectChannels:  config.InstanceConfiguration.PercentDirectChannels,
+		PercentGroupChannels:   config.InstanceConfiguration.PercentGroupChannels,
+	}
 
 	newControllerFn := func(id int, status chan<- control.UserStatus) (control.UserController, error) {
 		ueConfig := userentity.Config{

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -50,7 +50,9 @@ func genData(lt *loadtest.LoadTester, numUsers int64) error {
 	}(time.Now())
 
 	for lt.Status().NumUsersAdded != numUsers {
-		lt.AddUsers(10)
+		if _, err := lt.AddUsers(10); err != nil {
+			return fmt.Errorf("failed to add users %w", err)
+		}
 		time.Sleep(5 * time.Second)
 	}
 

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -5,93 +5,59 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
+	"net"
+	"net/http"
 	"os"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
-	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/spf13/cobra"
 )
 
-func createTeams(admin *userentity.UserEntity, numTeams int) error {
-	team := &model.Team{
-		AllowOpenInvite: true,
-		Type:            "O",
+func initDone(serverURL, userPrefix string) (bool, error) {
+	ueConfig := userentity.Config{
+		ServerURL: serverURL,
+		Username:  userPrefix + "-1",
+		Email:     userPrefix + "-1@example.com",
+		Password:  "testPass123$",
 	}
-	for i := 0; i < numTeams; i++ {
-		team.Name = fmt.Sprintf("team%d", i)
-		team.DisplayName = team.Name
-		id, err := admin.CreateTeam(team)
-		if err != nil {
-			return err
-		}
-		mlog.Info("team created", mlog.String("team_id", id))
-		err = admin.GetTeam(id)
-		if err != nil {
-			return err
-		}
+	store, err := memstore.New(nil)
+	if err != nil {
+		return false, err
 	}
-	return nil
+	ueSetup := userentity.Setup{
+		Store:     store,
+		Transport: http.DefaultTransport,
+	}
+	return userentity.New(ueSetup, ueConfig).Login() == nil, nil
 }
 
-func createChannels(admin *userentity.UserEntity, numChannels int) error {
-	channelTypes := []string{"O", "P"}
-
-	for i := 0; i < numChannels; i++ {
-		team, err := admin.Store().RandomTeam(store.SelectAny)
-		if err != nil {
-			return err
-		}
-
-		id, err := admin.CreateChannel(&model.Channel{
-			Name:        model.NewId(),
-			DisplayName: fmt.Sprintf("ch-%d", i),
-			TeamId:      team.Id,
-			Type:        channelTypes[rand.Intn(len(channelTypes))],
-		})
-		if err != nil {
-			return err
-		}
-		mlog.Info("channel created", mlog.String("channel_id", id))
+func genData(lt *loadtest.LoadTester, numUsers int64) error {
+	if err := lt.Run(); err != nil {
+		return err
 	}
-	return nil
-}
 
-func createTeamAdmins(admin *userentity.UserEntity, numUsers int, config *loadtest.Config) error {
-	for i := 0; i < numUsers; i++ {
-		index := i * config.InstanceConfiguration.TeamAdminInterval
-		ueConfig := userentity.Config{
-			ServerURL:    config.ConnectionConfiguration.ServerURL,
-			WebSocketURL: config.ConnectionConfiguration.WebSocketURL,
-			Username:     fmt.Sprintf("testuser-%d", index),
-			Email:        fmt.Sprintf("testuser-%d@example.com", index),
-			Password:     "testPass123$",
-		}
-		store, err := memstore.New(nil)
-		if err != nil {
-			return err
-		}
-		u := userentity.New(userentity.Setup{Store: store}, ueConfig)
+	defer func(start time.Time) {
+		mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))
+	}(time.Now())
 
-		if err := u.SignUp(ueConfig.Email, ueConfig.Username, ueConfig.Password); err != nil {
-			mlog.Warn("error while signing up", mlog.Err(err)) // Possibly, user already exists.
-			continue
-		}
-		id := u.Store().Id()
-
-		if err := admin.UpdateUserRoles(id, model.SYSTEM_USER_ROLE_ID+" "+model.TEAM_ADMIN_ROLE_ID); err != nil {
-			return err
-		}
-		mlog.Info("user created", mlog.String("user_id", id))
+	for lt.Status().NumUsersAdded != numUsers {
+		lt.AddUsers(10)
+		time.Sleep(5 * time.Second)
 	}
-	return nil
+
+	for lt.Status().NumUsersStopped != numUsers {
+		time.Sleep(1 * time.Second)
+	}
+
+	return lt.Stop()
 }
 
 func RunInitCmdF(cmd *cobra.Command, args []string) error {
@@ -107,63 +73,98 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	numTeams := config.InstanceConfiguration.NumTeams
-	numChannels := config.InstanceConfiguration.NumChannels
-	numTeamAdmins := config.InstanceConfiguration.NumTeamAdmins
+	if err := config.IsValid(); err != nil {
+		return fmt.Errorf("could not validate configuration: %w", err)
+	}
 
-	ueConfig := userentity.Config{
-		ServerURL:    config.ConnectionConfiguration.ServerURL,
-		WebSocketURL: config.ConnectionConfiguration.WebSocketURL,
-	}
-	store, err := memstore.New(nil)
-	if err != nil {
-		return err
-	}
-	err = store.SetUser(&model.User{
-		Email:    config.ConnectionConfiguration.AdminEmail,
-		Password: config.ConnectionConfiguration.AdminPassword,
-	})
+	userPrefix, err := cmd.Flags().GetString("user-prefix")
 	if err != nil {
 		return err
 	}
 
-	admin := userentity.New(userentity.Setup{Store: store}, ueConfig)
-
-	start := time.Now()
-
-	if err = admin.Login(); err != nil {
+	if ok, err := initDone(config.ConnectionConfiguration.ServerURL, userPrefix); err != nil {
 		return err
+	} else if ok {
+		mlog.Warn("init already done")
+		return nil
 	}
 
-	if err = createTeams(admin, numTeams); err != nil {
-		return err
+	seed := memstore.SetRandomSeed()
+	mlog.Info(fmt.Sprintf("random seed value is: %d", seed))
+
+	// http.Transport to be shared amongst all clients.
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   1 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxConnsPerHost:       100,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		ResponseHeaderTimeout: 10 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   1 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
 
-	if err = createChannels(admin, numChannels); err != nil {
-		return err
+	genConfig := config.InstanceConfiguration
+
+	newControllerFn := func(id int, status chan<- control.UserStatus) (control.UserController, error) {
+		ueConfig := userentity.Config{
+			ServerURL:    config.ConnectionConfiguration.ServerURL,
+			WebSocketURL: config.ConnectionConfiguration.WebSocketURL,
+			Username:     fmt.Sprintf("%s-%d", userPrefix, id),
+			Email:        fmt.Sprintf("%s-%d@example.com", userPrefix, id),
+			Password:     "testPass123$",
+		}
+		store, err := memstore.New(&memstore.Config{
+			MaxStoredPosts:          500,
+			MaxStoredUsers:          1000,
+			MaxStoredChannelMembers: 1000,
+			MaxStoredStatuses:       1000,
+		})
+		if err != nil {
+			return nil, err
+		}
+		ueSetup := userentity.Setup{
+			Store:     store,
+			Transport: transport,
+		}
+		ue := userentity.New(ueSetup, ueConfig)
+		return gencontroller.New(id, ue, &genConfig, status)
 	}
 
-	if err = createTeamAdmins(admin, numTeamAdmins, config); err != nil {
-		return err
+	config.UsersConfiguration.InitialActiveUsers = 0
+	config.UserControllerConfiguration.RatesDistribution = []struct {
+		Rate       float64
+		Percentage float64
+	}{
+		{
+			Rate:       0.2,
+			Percentage: 1.0,
+		},
 	}
 
-	if _, err = admin.Logout(); err != nil {
-		return err
+	lt, err := loadtest.New(config, newControllerFn)
+	if err != nil {
+		return fmt.Errorf("error while initializing loadtest: %w", err)
 	}
 
-	mlog.Info("done", mlog.String("elapsed", time.Since(start).String()))
-
-	return nil
+	return genData(lt, 50)
 }
 
 func MakeInitCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:          "init",
 		Short:        "Initialize instance",
 		SilenceUsage: true,
 		RunE:         RunInitCmdF,
 		PreRun:       SetupLoadTest,
 	}
+	cmd.PersistentFlags().StringP("user-prefix", "", "testuser", "prefix used when generating usernames and emails")
+	return cmd
 }
 
 func SetupLoadTest(cmd *cobra.Command, args []string) {

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
@@ -73,7 +74,7 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := config.IsValid(); err != nil {
+	if err := defaults.Validate(*config); err != nil {
 		return fmt.Errorf("could not validate configuration: %w", err)
 	}
 
@@ -137,10 +138,7 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	config.UsersConfiguration.InitialActiveUsers = 0
-	config.UserControllerConfiguration.RatesDistribution = []struct {
-		Rate       float64
-		Percentage float64
-	}{
+	config.UserControllerConfiguration.RatesDistribution = []loadtest.RatesDistribution{
 		{
 			Rate:       0.2,
 			Percentage: 1.0,

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func initDone(serverURL, userPrefix string) (bool, error) {
+func isInitDone(serverURL, userPrefix string) (bool, error) {
 	ueConfig := userentity.Config{
 		ServerURL: serverURL,
 		Username:  userPrefix + "-1",
@@ -85,7 +85,7 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if ok, err := initDone(config.ConnectionConfiguration.ServerURL, userPrefix); err != nil {
+	if ok, err := isInitDone(config.ConnectionConfiguration.ServerURL, userPrefix); err != nil {
 		return err
 	} else if ok {
 		mlog.Warn("init already done")

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -208,11 +208,11 @@ func MakeLoadTestCommand() *cobra.Command {
 		SilenceUsage: true,
 		PreRun:       SetupLoadTest,
 	}
-	cmd.PersistentFlags().StringP("controller-config", "", "", "path to the controller configuration file to use")
 	cmd.PersistentFlags().StringP("config", "c", "", "path to the configuration file to use")
-	cmd.PersistentFlags().IntP("duration", "d", 60, "number of seconds to pass before stopping the load-test")
-	cmd.PersistentFlags().IntP("num-users", "n", 0, "number of users to run, setting this value will override the config setting")
-	cmd.PersistentFlags().Float64P("rate", "r", 1.0, "rate value for the controller")
+	cmd.Flags().StringP("controller-config", "", "", "path to the controller configuration file to use")
+	cmd.Flags().IntP("duration", "d", 60, "number of seconds to pass before stopping the load-test")
+	cmd.Flags().IntP("num-users", "n", 0, "number of users to run, setting this value will override the config setting")
+	cmd.Flags().Float64P("rate", "r", 1.0, "rate value for the controller")
 	cmd.PersistentFlags().StringP("user-prefix", "", "testuser", "prefix used when generating usernames and emails")
 	cmd.PersistentFlags().IntP("user-offset", "", 0, "numerical offset applied to user ids")
 	return cmd

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
@@ -26,30 +25,19 @@ import (
 )
 
 func runGenLoadtest(lt *loadtest.LoadTester, numUsers int) error {
-	start := time.Now()
 	if err := lt.Run(); err != nil {
 		return err
 	}
-	mlog.Info("loadtest started")
 
-	var err error
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for {
-			if status := lt.Status(); status.NumUsersStopped == int64(numUsers) {
-				err = lt.Stop()
-				return
-			}
-			time.Sleep(1 * time.Second)
-		}
-	}()
-	wg.Wait()
+	defer func(start time.Time) {
+		mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))
+	}(time.Now())
 
-	mlog.Info("loadtest done", mlog.String("elapsed", time.Since(start).String()))
+	for lt.Status().NumUsersStopped != int64(numUsers) {
+		time.Sleep(1 * time.Second)
+	}
 
-	return err
+	return lt.Stop()
 }
 
 func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -29,8 +29,13 @@
   "InstanceConfiguration": {
     "NumTeams": 2,
     "NumChannels": 10,
-    "NumTeamAdmins": 2,
-    "TeamAdminInterval": 10
+    "NumPosts": 0,
+    "NumReactions": 0,
+    "PercentReplies": 0.5,
+    "PercentPublicChannels": 0.2,
+    "PercentPrivateChannels": 0.1,
+    "PercentDirectChannels": 0.6,
+    "PercentGroupChannels": 0.1
   },
   "UsersConfiguration": {
     "InitialActiveUsers": 0,

--- a/coordinator/cluster/utils_test.go
+++ b/coordinator/cluster/utils_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func createMockAgents(t *testing.T) []*agent.LoadAgent {
 				InitialActiveUsers: 0,
 				AvgSessionsPerUser: 1,
 			},
-			InstanceConfiguration: loadtest.InstanceConfiguration{
+			InstanceConfiguration: gencontroller.Config{
 				NumTeams: 1,
 			},
 			LogSettings: logger.Settings{

--- a/coordinator/cluster/utils_test.go
+++ b/coordinator/cluster/utils_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
-	"github.com/mattermost/mattermost-load-test-ng/logger"
+	"github.com/mattermost/mattermost-load-test-ng/defaults"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,31 +14,9 @@ func createMockAgents(t *testing.T) []*agent.LoadAgent {
 	cfg := agent.LoadAgentConfig{
 		ApiURL: "localhost:8065",
 		Id:     "id",
-
-		LoadTestConfig: loadtest.Config{
-			ConnectionConfiguration: loadtest.ConnectionConfiguration{
-				ServerURL:     "localhost:8065",
-				WebSocketURL:  "localhost:4000",
-				AdminEmail:    "user@example.com",
-				AdminPassword: "str0ngPassword##",
-			},
-			UserControllerConfiguration: loadtest.UserControllerConfiguration{
-				Type: "simple",
-			},
-			UsersConfiguration: loadtest.UsersConfiguration{
-				MaxActiveUsers:     8,
-				InitialActiveUsers: 0,
-				AvgSessionsPerUser: 1,
-			},
-			InstanceConfiguration: gencontroller.Config{
-				NumTeams: 1,
-			},
-			LogSettings: logger.Settings{
-				ConsoleLevel: "ERROR",
-				FileLevel:    "ERROR",
-			},
-		},
 	}
+	defaults.Set(&cfg)
+
 	agent1, err := agent.New(cfg)
 	require.NoError(t, err)
 	agent2, err := agent.New(cfg)

--- a/defaults/set.go
+++ b/defaults/set.go
@@ -81,7 +81,7 @@ func structDefaults(value interface{}) error {
 				return fmt.Errorf("could not create map: %w", err)
 			}
 			field.Set(m)
-		case reflect.Bool, reflect.Int, reflect.Float64, reflect.String:
+		case reflect.Bool, reflect.Int, reflect.Int64, reflect.Float64, reflect.String:
 			tag, ok := t.Field(i).Tag.Lookup("default")
 			if !ok {
 				continue
@@ -112,7 +112,7 @@ func setValue(t reflect.Type, data string) (reflect.Value, error) {
 		v.SetBool(b)
 	case reflect.String:
 		v.SetString(data)
-	case reflect.Int:
+	case reflect.Int, reflect.Int64:
 		i, err := strconv.Atoi(data)
 		if err != nil {
 			return reflect.Zero(t), err

--- a/defaults/validate.go
+++ b/defaults/validate.go
@@ -34,6 +34,7 @@ func Validate(value interface{}) error {
 
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
+
 		switch field.Type().Kind() {
 		case reflect.Struct:
 			dv := field.Interface()
@@ -47,7 +48,7 @@ func Validate(value interface{}) error {
 					return err
 				}
 			}
-		case reflect.Bool, reflect.Int, reflect.Float64, reflect.String:
+		case reflect.Bool, reflect.Int, reflect.Int64, reflect.Float64, reflect.String:
 			tag, ok := t.Field(i).Tag.Lookup("validate")
 			if !ok {
 				continue
@@ -129,7 +130,7 @@ func validateFromRange(value reflect.Value, mins, maxs, minInterval, maxInterval
 	var min, max, val float64
 	var err error
 	switch value.Type().Kind() {
-	case reflect.Int:
+	case reflect.Int, reflect.Int64:
 		if mins != "" {
 			min, err = strconv.ParseFloat(mins, 64)
 		}
@@ -194,7 +195,7 @@ func validateFromField(value reflect.Value, valuestr string) (string, error) {
 		}
 
 		switch v.Type().Kind() {
-		case reflect.Int:
+		case reflect.Int, reflect.Int64:
 			return fmt.Sprintf("%d", v.Int()), nil
 		case reflect.Float64:
 			return fmt.Sprintf("%f", v.Float()), nil

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -132,7 +132,7 @@ func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, output *Output) error {
 	}
 
 	mlog.Info("Populating initial data for load-test", mlog.String("agent", ip))
-	cmd := "cd mattermost-load-test-ng && ./bin/ltagent init"
+	cmd := fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s'", output.Agents.Value[0].Tags.Name)
 	if out, err := sshc.RunCommand(cmd); err != nil {
 		// TODO: make this fully atomic. See MM-23998.
 		// ltagent init should drop teams and channels before creating them.

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -5,9 +5,9 @@ package loadtest
 
 import (
 	"errors"
+	"math"
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 )
 
@@ -66,6 +66,45 @@ func (ucc *UserControllerConfiguration) IsValid() error {
 	return nil
 }
 
+// InstanceConfiguration holds information about the data to be populated
+// during the init process.
+type InstanceConfiguration struct {
+	// The target number of teams to be created.
+	NumTeams int64 `default:"2" validate:"range:[0,]"`
+	// The target number of channels to be created.
+	NumChannels int64 `default:"10" validate:"range:[0,]"`
+	// The target number of posts to be created.
+	NumPosts int64 `default:"0" validate:"range:[0,]"`
+	// The target number of reactions to be created.
+	NumReactions int64 `default:"0" validate:"range:[0,]"`
+
+	// The percentage of replies to be created.
+	PercentReplies float64 `default:"0.5" validate:"range:[0,1]"`
+
+	// Percentages of channels to be created, grouped by type.
+	// The total sum of these values must be equal to 1.
+
+	// The percentage of public channels to be created.
+	PercentPublicChannels float64 `default:"0.2" validate:"range:[0,1]"`
+	// The percentage of private channels to be created.
+	PercentPrivateChannels float64 `default:"0.1" validate:"range:[0,1]"`
+	// The percentage of direct channels to be created.
+	PercentDirectChannels float64 `default:"0.6" validate:"range:[0,1]"`
+	// The percentage of group channels to be created.
+	PercentGroupChannels float64 `default:"0.1" validate:"range:[0,1]"`
+}
+
+// IsValid reports whether a given InstanceConfiguration is valid or not.
+// Returns an error if the validation fails.
+func (c *InstanceConfiguration) IsValid() error {
+	percentChannels := c.PercentPublicChannels + c.PercentPrivateChannels + c.PercentDirectChannels + c.PercentGroupChannels
+	if (math.Round(percentChannels*100) / 100) != 1 {
+		return errors.New("sum of percentages for channels should be equal to 1")
+	}
+
+	return nil
+}
+
 type UsersConfiguration struct {
 	InitialActiveUsers int `default:"0" validate:"range:[0,$MaxActiveUsers]"`
 	MaxActiveUsers     int `default:"2000" validate:"range:(0,]"`
@@ -75,7 +114,7 @@ type UsersConfiguration struct {
 type Config struct {
 	ConnectionConfiguration     ConnectionConfiguration
 	UserControllerConfiguration UserControllerConfiguration
-	InstanceConfiguration       gencontroller.Config
+	InstanceConfiguration       InstanceConfiguration
 	UsersConfiguration          UsersConfiguration
 	LogSettings                 logger.Settings
 }

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -6,7 +6,6 @@ package loadtest
 import (
 	"errors"
 
-	"github.com/mattermost/mattermost-load-test-ng/config"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
 	"github.com/mattermost/mattermost-load-test-ng/logger"

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -6,7 +6,9 @@ package loadtest
 import (
 	"errors"
 
+	"github.com/mattermost/mattermost-load-test-ng/config"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 )
 
@@ -65,13 +67,6 @@ func (ucc *UserControllerConfiguration) IsValid() error {
 	return nil
 }
 
-type InstanceConfiguration struct {
-	NumTeams          int `default:"2" validate:"range:(0,]"`
-	NumChannels       int `default:"10"`
-	NumTeamAdmins     int `default:"2"`
-	TeamAdminInterval int `default:"10"`
-}
-
 type UsersConfiguration struct {
 	InitialActiveUsers int `default:"0" validate:"range:[0,$MaxActiveUsers]"`
 	MaxActiveUsers     int `default:"2000" validate:"range:(0,]"`
@@ -81,7 +76,7 @@ type UsersConfiguration struct {
 type Config struct {
 	ConnectionConfiguration     ConnectionConfiguration
 	UserControllerConfiguration UserControllerConfiguration
-	InstanceConfiguration       InstanceConfiguration
+	InstanceConfiguration       gencontroller.Config
 	UsersConfiguration          UsersConfiguration
 	LogSettings                 logger.Settings
 }

--- a/loadtest/control/gencontroller/config.go
+++ b/loadtest/control/gencontroller/config.go
@@ -14,13 +14,13 @@ import (
 // GenController.
 type Config struct {
 	// The target number of teams to be created.
-	NumTeams int64 `default:"2" validate:"range:(0,]"`
+	NumTeams int64 `default:"2" validate:"range:[0,]"`
 	// The target number of channels to be created.
-	NumChannels int64 `default:"20" validate:"range:(0,]"`
+	NumChannels int64 `default:"20" validate:"range:[0,]"`
 	// The target number of posts to be created.
-	NumPosts int64 `default:"1000" validate:"range:(0,]"`
+	NumPosts int64 `default:"1000" validate:"range:[0,]"`
 	// The target number of reactions to be created.
-	NumReactions int64 `default:"200" validate:"range:(0,]"`
+	NumReactions int64 `default:"200" validate:"range:[0,]"`
 
 	// The percentage of replies to be created.
 	PercentReplies float64 `default:"0.5" validate:"range:[0,1]"`

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
@@ -33,7 +32,7 @@ var ltConfig = Config{
 		InitialActiveUsers: 0,
 		AvgSessionsPerUser: 1,
 	},
-	InstanceConfiguration: gencontroller.Config{
+	InstanceConfiguration: InstanceConfiguration{
 		NumTeams:               1,
 		NumChannels:            10,
 		NumPosts:               100,

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
@@ -32,8 +33,16 @@ var ltConfig = Config{
 		InitialActiveUsers: 0,
 		AvgSessionsPerUser: 1,
 	},
-	InstanceConfiguration: InstanceConfiguration{
-		NumTeams: 1,
+	InstanceConfiguration: gencontroller.Config{
+		NumTeams:               1,
+		NumChannels:            10,
+		NumPosts:               100,
+		NumReactions:           50,
+		PercentReplies:         0.5,
+		PercentPublicChannels:  0.2,
+		PercentPrivateChannels: 0.1,
+		PercentDirectChannels:  0.6,
+		PercentGroupChannels:   0.1,
 	},
 	LogSettings: logger.Settings{
 		ConsoleLevel: "ERROR",


### PR DESCRIPTION
#### Summary

PR improves current `init` process by leveraging `GenController`.
This will give us more control on the initial data to populate when creating a deployment.

#### Ticket

https://mattermost.atlassian.net/browse/MM-25899