### PR TITLE
MM-25935: validate the scheme prefix of download URLs

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -6,6 +6,7 @@ package deployment
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
@@ -82,10 +83,24 @@ type ElasticSearchSettings struct {
 
 // IsValid reports whether a given deployment config is valid or not.
 func (c *Config) IsValid() error {
+	if !checkPrefix(c.MattermostDownloadURL) {
+		return fmt.Errorf("mattermost download url is not in correct format: %q", c.MattermostDownloadURL)
+	}
+
+	if !checkPrefix(c.LoadTestDownloadURL) {
+		return fmt.Errorf("load-test download url is not in correct format: %q", c.LoadTestDownloadURL)
+	}
+
 	if err := c.validateElasticSearchConfig(); err != nil {
 		return err
 	}
 	return nil
+}
+
+func checkPrefix(str string) bool {
+	return strings.HasPrefix(str, "https://") ||
+		strings.HasPrefix(str, "http://") ||
+		strings.HasPrefix(str, "file://")
 }
 
 func (c *Config) validateElasticSearchConfig() error {

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -65,6 +65,11 @@ func (t *Terraform) Create() error {
 		if err != nil {
 			return err
 		}
+
+		if info.Mode().Perm() != 0775 {
+			return fmt.Errorf("file %s has to be an executable", binaryPath)
+		}
+
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("binary path %s has to be a regular file", binaryPath)
 		}


### PR DESCRIPTION
- We validate whether an URL starts with the proper scheme.
- And we also raise an error if the mattermost download URL is not a binary
if it's a file. This fixes a common confusion where people pass paths to the entire
mattermost .tar.gz package.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-25935