### PR TITLE
[MM-26178] Improve coordinator's feedback loop

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -101,6 +101,10 @@ func (c *Coordinator) Run() error {
 				mlog.Info(fmt.Sprintf("estimated number of supported users is %f", math.Round(avg(latest))))
 				return nil
 			}
+			// We truncate to remove older samples which are not needed anymore.
+			if len(samples) >= 2*len(latest) {
+				samples = latest
+			}
 		}
 
 		// We give the feedback loop some rest time in case of performance

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -101,9 +101,10 @@ func (c *Coordinator) Run() error {
 				mlog.Info(fmt.Sprintf("estimated number of supported users is %f", math.Round(avg(latest))))
 				return nil
 			}
-			// We truncate to remove older samples which are not needed anymore.
+			// We replace older samples which are not needed anymore.
 			if len(samples) >= 2*len(latest) {
-				samples = latest
+				copy(samples, latest)
+				samples = samples[:len(latest)]
 			}
 		}
 

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -5,6 +5,7 @@ package coordinator
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"syscall"
@@ -42,7 +43,6 @@ func (c *Coordinator) Run() error {
 	defer c.monitor.Stop()
 
 	var lastActionTime, lastAlertTime time.Time
-	var supportedUsers int
 
 	// For now we are keeping all these values constant but in the future they
 	// might change based on the state of the feedback loop.
@@ -58,6 +58,20 @@ func (c *Coordinator) Run() error {
 	// The timespan to wait after a performance degradation alert before
 	// incrementing or decrementing users again.
 	restTime := time.Duration(c.config.RestTimeSec) * time.Second
+
+	// TODO: considering making the following values configurable.
+
+	// The threshold at which we consider the load-test done and we are ready to
+	// give an answer. The value represent the slope of the best fine line for
+	// the gathered samples. This value approaching zero means we have found
+	// an equilibrium point.
+	stopThreshold := 0.1
+	// The timespan to consider when calculating the best fit line. A higher
+	// value means considering a higher number of samples which improves the precision of
+	// the final result.
+	samplesTimeRange := 30 * time.Minute
+
+	var samples []point
 
 	for {
 		var perfStatus performance.Status
@@ -76,14 +90,18 @@ func (c *Coordinator) Run() error {
 		status := c.cluster.Status()
 		mlog.Info("coordinator: cluster status:", mlog.Int("active_users", status.ActiveUsers), mlog.Int64("errors", status.NumErrors))
 
-		// TODO: supportedUsers should be estimated in a more clever way in the future.
-		// For now we say that the supported number of users is the number of active users that ran
-		// for the defined timespan without causing any performance degradation alert.
-		if !lastAlertTime.IsZero() && !perfStatus.Alert && hasPassed(lastAlertTime, restTime) && hasPassed(lastActionTime, restTime) {
-			supportedUsers = status.ActiveUsers
+		if !lastAlertTime.IsZero() {
+			samples = append(samples, point{
+				x: time.Now(),
+				y: status.ActiveUsers,
+			})
+			latest := getLatestSamples(samples, samplesTimeRange)
+			if len(latest) > 0 && len(latest) < len(samples) && math.Abs(slope(latest)) < stopThreshold {
+				mlog.Info("coordinator done!")
+				mlog.Info(fmt.Sprintf("estimated number of supported users is %f", math.Round(avg(latest))))
+				return nil
+			}
 		}
-
-		mlog.Info("coordinator: supported users", mlog.Int("supported_users", supportedUsers))
 
 		// We give the feedback loop some rest time in case of performance
 		// degradation alerts. We want metrics to stabilize before incrementing/decrementing users again.

--- a/coordinator/math.go
+++ b/coordinator/math.go
@@ -1,0 +1,39 @@
+package coordinator
+
+import (
+	"time"
+)
+
+type point struct {
+	x time.Time
+	y int
+}
+
+// slope calculates the slope of the best fit line using simple linear
+// regression (least squares method).
+func slope(points []point) float64 {
+	n := float64(len(points))
+	var sumXY float64
+	var sumX float64
+	var sumY float64
+	var sumXX float64
+
+	for _, p := range points {
+		x := float64(p.x.Unix() - points[0].x.Unix())
+		y := float64(p.y)
+		sumXY += x * y
+		sumX += x
+		sumY += y
+		sumXX += x * x
+	}
+
+	return ((n * sumXY) - (sumX * sumY)) / ((n * sumXX) - (sumX * sumX))
+}
+
+func avg(points []point) float64 {
+	var total int
+	for _, p := range points {
+		total += p.y
+	}
+	return float64(total) / float64(len(points))
+}

--- a/coordinator/math_test.go
+++ b/coordinator/math_test.go
@@ -1,0 +1,80 @@
+package coordinator
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlope(t *testing.T) {
+	var samples []point
+	require.True(t, math.IsNaN(slope(samples)))
+
+	samples = []point{
+		{time.Unix(0, 0), 0},
+	}
+	require.True(t, math.IsNaN(slope(samples)))
+
+	samples = []point{
+		{time.Unix(0, 0), 0},
+		{time.Unix(1, 0), 4},
+	}
+	require.Equal(t, float64(4), slope(samples))
+
+	samples = []point{
+		{time.Unix(0, 0), 0},
+		{time.Unix(1, 0), 4},
+		{time.Unix(2, 0), 8},
+	}
+	require.Equal(t, float64(4), slope(samples))
+
+	samples = []point{
+		{time.Unix(0, 0), 10},
+		{time.Unix(1, 0), 8},
+		{time.Unix(2, 0), 6},
+		{time.Unix(3, 0), 4},
+		{time.Unix(4, 0), 2},
+	}
+	require.Equal(t, float64(-2), slope(samples))
+
+	samples = []point{
+		{time.Unix(0, 0), 8},
+		{time.Unix(2, 0), 4},
+		{time.Unix(8, 0), 8},
+		{time.Unix(10, 0), 4},
+		{time.Unix(20, 0), 8},
+	}
+	s := slope(samples)
+	require.Equal(t, float64(0.065), math.Round(s*1000)/1000)
+
+	samples = []point{
+		{time.Unix(0, 0), 0},
+		{time.Unix(1, 0), 4},
+		{time.Unix(2, 0), 8},
+		{time.Unix(3, 0), 12},
+		{time.Unix(4, 0), 16},
+		{time.Unix(5, 0), 12},
+		{time.Unix(6, 0), 8},
+		{time.Unix(7, 0), 12},
+		{time.Unix(8, 0), 16},
+		{time.Unix(9, 0), 12},
+	}
+	s = slope(samples)
+	require.Equal(t, float64(1.1879), math.Round(s*10000)/10000)
+}
+
+func BenchmarkSlope(b *testing.B) {
+	samples := make([]point, 10000)
+	for i := 0; i < len(samples); i++ {
+		samples[i].x = time.Unix(int64(i), 0)
+		if i > 0 {
+			samples[i].y = samples[i-1].y + 4
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = slope(samples)
+	}
+}

--- a/coordinator/math_test.go
+++ b/coordinator/math_test.go
@@ -65,6 +65,8 @@ func TestSlope(t *testing.T) {
 	require.Equal(t, float64(1.1879), math.Round(s*10000)/10000)
 }
 
+var slopeSink float64
+
 func BenchmarkSlope(b *testing.B) {
 	samples := make([]point, 10000)
 	for i := 0; i < len(samples); i++ {
@@ -75,6 +77,6 @@ func BenchmarkSlope(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = slope(samples)
+		slopeSink = slope(samples)
 	}
 }

--- a/coordinator/utils.go
+++ b/coordinator/utils.go
@@ -20,3 +20,20 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// getLatestSamples returns all the samples in the time range
+// [lastSampleTime-d, lastSampleTime].
+func getLatestSamples(samples []point, d time.Duration) []point {
+	var k int
+	if len(samples) == 0 {
+		return samples
+	}
+	last := samples[len(samples)-1]
+	for i := len(samples) - 1; i >= 0; i-- {
+		if last.x.Sub(samples[i].x) >= d {
+			k = i
+			break
+		}
+	}
+	return samples[k:]
+}

--- a/coordinator/utils_test.go
+++ b/coordinator/utils_test.go
@@ -26,3 +26,42 @@ func TestMin(t *testing.T) {
 	require.Equal(t, 50, min(80, 50))
 	require.Equal(t, 30, min(100, 30))
 }
+
+func TestGetLatestSamples(t *testing.T) {
+	samples := []point{}
+	require.Empty(t, getLatestSamples(samples, 1*time.Minute))
+
+	samples = []point{
+		{time.Unix(0, 0), 0},
+		{time.Unix(1, 0), 4},
+		{time.Unix(2, 0), 8},
+	}
+	expected := []point{
+		{time.Unix(1, 0), 4},
+		{time.Unix(2, 0), 8},
+	}
+	require.Equal(t, expected, getLatestSamples(samples, 1*time.Second))
+
+	samples = []point{
+		{time.Unix(0, 0), 0},
+		{time.Unix(10, 0), 1},
+		{time.Unix(20, 0), 2},
+		{time.Unix(30, 0), 3},
+		{time.Unix(40, 0), 4},
+	}
+	require.Equal(t, samples, getLatestSamples(samples, 40*time.Second))
+
+	samples = []point{
+		{time.Unix(0, 0), 0},
+		{time.Unix(10, 0), 1},
+		{time.Unix(20, 0), 2},
+		{time.Unix(30, 0), 3},
+		{time.Unix(40, 0), 4},
+	}
+	expected = []point{
+		{time.Unix(20, 0), 2},
+		{time.Unix(30, 0), 3},
+		{time.Unix(40, 0), 4},
+	}
+	require.Equal(t, expected, getLatestSamples(samples, 20*time.Second))
+}


### PR DESCRIPTION
#### Summary

PR improves coordinator's feedback loop by finding an equilibrium point through simple linear regression. 
The idea is to check when the slope of the number of active users' graph flattens out.
When this value goes under a defined threshold we stop the coordinator and calculate an estimate (simple average) of the number of supported users.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26178