### PR TITLE
MM-26421: calculate diff after rounding off

### DIFF
--- a/loadtest/report/compare.go
+++ b/loadtest/report/compare.go
@@ -5,15 +5,17 @@ package report
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"time"
 
 	"github.com/prometheus/common/model"
 )
 
 // diff contains the differences from a base measurement.
 type diff struct {
-	actual       float64
-	delta        float64
+	actual       time.Duration
+	delta        time.Duration
 	deltaPercent float64
 }
 
@@ -104,9 +106,12 @@ func calculateDeltas(reports ...Report) comp {
 		// XXX: This can be somewhat refactored but whether absolute metrics
 		// are useful or not needs to be seen.
 		for label, value := range base.AvgStoreTimes {
-			actual := roundTo3DecimalPlaces(float64(r.AvgStoreTimes[label]))
-			delta := actual - roundTo3DecimalPlaces(float64(value))
-			deltaP := (delta / actual) * 100
+			actual := getDuration(float64(r.AvgStoreTimes[label]))
+			delta := actual - getDuration(float64(value))
+			deltaP := (delta.Seconds() / actual.Seconds()) * 100
+			if math.IsNaN(deltaP) {
+				deltaP = 0
+			}
 
 			diffs := c.store[label]
 			diffs[0] = append(diffs[0], diff{
@@ -118,9 +123,12 @@ func calculateDeltas(reports ...Report) comp {
 		}
 
 		for label, value := range base.P99StoreTimes {
-			actual := roundTo3DecimalPlaces(float64(r.P99StoreTimes[label]))
-			delta := actual - roundTo3DecimalPlaces(float64(value))
-			deltaP := (delta / actual) * 100
+			actual := getDuration(float64(r.P99StoreTimes[label]))
+			delta := actual - getDuration(float64(value))
+			deltaP := (delta.Seconds() / actual.Seconds()) * 100
+			if math.IsNaN(deltaP) {
+				deltaP = 0
+			}
 
 			diffs := c.store[label]
 			diffs[1] = append(diffs[1], diff{
@@ -132,9 +140,12 @@ func calculateDeltas(reports ...Report) comp {
 		}
 
 		for label, value := range base.AvgAPITimes {
-			actual := roundTo3DecimalPlaces(float64(r.AvgAPITimes[label]))
-			delta := actual - roundTo3DecimalPlaces(float64(value))
-			deltaP := (delta / actual) * 100
+			actual := getDuration(float64(r.AvgAPITimes[label]))
+			delta := actual - getDuration(float64(value))
+			deltaP := (delta.Seconds() / actual.Seconds()) * 100
+			if math.IsNaN(deltaP) {
+				deltaP = 0
+			}
 
 			diffs := c.api[label]
 			diffs[0] = append(diffs[0], diff{
@@ -146,9 +157,12 @@ func calculateDeltas(reports ...Report) comp {
 		}
 
 		for label, value := range base.P99APITimes {
-			actual := roundTo3DecimalPlaces(float64(r.P99APITimes[label]))
-			delta := actual - roundTo3DecimalPlaces(float64(value))
-			deltaP := (delta / actual) * 100
+			actual := getDuration(float64(r.P99APITimes[label]))
+			delta := actual - getDuration(float64(value))
+			deltaP := (delta.Seconds() / actual.Seconds()) * 100
+			if math.IsNaN(deltaP) {
+				deltaP = 0
+			}
 
 			diffs := c.api[label]
 			diffs[1] = append(diffs[1], diff{

--- a/loadtest/report/compare.go
+++ b/loadtest/report/compare.go
@@ -104,8 +104,8 @@ func calculateDeltas(reports ...Report) comp {
 		// XXX: This can be somewhat refactored but whether absolute metrics
 		// are useful or not needs to be seen.
 		for label, value := range base.AvgStoreTimes {
-			actual := float64(r.AvgStoreTimes[label])
-			delta := actual - float64(value)
+			actual := roundTo3DecimalPlaces(float64(r.AvgStoreTimes[label]))
+			delta := actual - roundTo3DecimalPlaces(float64(value))
 			deltaP := (delta / actual) * 100
 
 			diffs := c.store[label]
@@ -118,8 +118,8 @@ func calculateDeltas(reports ...Report) comp {
 		}
 
 		for label, value := range base.P99StoreTimes {
-			actual := float64(r.P99StoreTimes[label])
-			delta := actual - float64(value)
+			actual := roundTo3DecimalPlaces(float64(r.P99StoreTimes[label]))
+			delta := actual - roundTo3DecimalPlaces(float64(value))
 			deltaP := (delta / actual) * 100
 
 			diffs := c.store[label]
@@ -132,8 +132,8 @@ func calculateDeltas(reports ...Report) comp {
 		}
 
 		for label, value := range base.AvgAPITimes {
-			actual := float64(r.AvgAPITimes[label])
-			delta := actual - float64(value)
+			actual := roundTo3DecimalPlaces(float64(r.AvgAPITimes[label]))
+			delta := actual - roundTo3DecimalPlaces(float64(value))
 			deltaP := (delta / actual) * 100
 
 			diffs := c.api[label]
@@ -146,8 +146,8 @@ func calculateDeltas(reports ...Report) comp {
 		}
 
 		for label, value := range base.P99APITimes {
-			actual := float64(r.P99APITimes[label])
-			delta := actual - float64(value)
+			actual := roundTo3DecimalPlaces(float64(r.P99APITimes[label]))
+			delta := actual - roundTo3DecimalPlaces(float64(value))
 			deltaP := (delta / actual) * 100
 
 			diffs := c.api[label]

--- a/loadtest/report/output.go
+++ b/loadtest/report/output.go
@@ -6,6 +6,7 @@ package report
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"os/exec"
 	"sort"
@@ -28,14 +29,14 @@ func displayMarkdown(c comp, target *os.File, base Report, cols int) {
 		p99 := measurement[1]
 
 		fmt.Fprint(target, " |  Avg")
-		fmt.Fprintf(target, "| %.3f", base.AvgStoreTimes[label])
+		fmt.Fprintf(target, "| %.3f", roundTo3DecimalPlaces(float64(base.AvgStoreTimes[label])))
 		for i := 0; i < len(avg); i++ {
 			fmt.Fprintf(target, "| %.3f | %.3f | %.3f", avg[i].actual, avg[i].delta, avg[i].deltaPercent)
 		}
 		fmt.Fprintln(target)
 
 		fmt.Fprint(target, "| |  P99")
-		fmt.Fprintf(target, "| %.3f", base.P99StoreTimes[label])
+		fmt.Fprintf(target, "| %.3f", roundTo3DecimalPlaces(float64(base.P99StoreTimes[label])))
 		for i := 0; i < len(p99); i++ {
 			fmt.Fprintf(target, "| %.3f | %.3f | %.3f", p99[i].actual, p99[i].delta, p99[i].deltaPercent)
 		}
@@ -53,14 +54,14 @@ func displayMarkdown(c comp, target *os.File, base Report, cols int) {
 		p99 := measurement[1]
 
 		fmt.Fprint(target, " | Avg")
-		fmt.Fprintf(target, "| %.3f", base.AvgAPITimes[label])
+		fmt.Fprintf(target, "| %.3f", roundTo3DecimalPlaces(float64(base.AvgAPITimes[label])))
 		for i := 0; i < len(avg); i++ {
 			fmt.Fprintf(target, "| %.3f | %.3f | %.3f", avg[i].actual, avg[i].delta, avg[i].deltaPercent)
 		}
 		fmt.Fprintln(target)
 
 		fmt.Fprint(target, "| | P99")
-		fmt.Fprintf(target, "| %.3f", base.P99APITimes[label])
+		fmt.Fprintf(target, "| %.3f", roundTo3DecimalPlaces(float64(base.P99APITimes[label])))
 		for i := 0; i < len(p99); i++ {
 			fmt.Fprintf(target, "| %.3f | %.3f | %.3f", p99[i].actual, p99[i].delta, p99[i].deltaPercent)
 		}
@@ -166,4 +167,8 @@ func sortKeys(m map[model.LabelValue]avgp99) []model.LabelValue {
 		return labels[i] < labels[j]
 	})
 	return labels
+}
+
+func roundTo3DecimalPlaces(f float64) float64 {
+	return math.Round(f*1000) / 1000
 }


### PR DESCRIPTION
Right now, we are calculating diff from the original value, but printing rounded off values.
That shows confusing output as the diff and the values don't match up.

This PR changes that to show proper time units in duration rounded off to ms.

This changes

```
ChannelStore.GetMembersForUser |  Avg| 0.002| 0.002 | 0.000 | 3.116
| |  P99| 0.008| 0.008 | 0.001 | 7.457
| ChannelStore.GetPinnedPostCount |  Avg| 0.000| 0.000 | -0.000 | -2.957
| |  P99| 0.005| 0.005 | -0.000 | -0.043
| ChannelStore.GetPublicChannelsForTeam |  Avg| 0.001| 0.001 | -0.000 | -2.145
| |  P99| 0.005| 0.005 | -0.000 | -0.246
```

to

```
| ChannelStore.GetMembersForUser |  Avg| 2ms| 14ms | 12ms | 85.714
| |  P99| 8ms| 340ms | 332ms | 97.647
| ChannelStore.GetPinnedPostCount |  Avg| 0s| 2ms | 2ms | 100.000
| |  P99| 5ms| 23ms | 18ms | 78.261
| ChannelStore.GetPublicChannelsForTeam |  Avg| 1ms| 11ms | 10ms | 90.909
| |  P99| 5ms| 216ms | 211ms | 97.685
```

#### Ticket link

https://mattermost.atlassian.net/browse/MM-26421