### PR TITLE
MM-26416: move Prometheus queries to load from config

### DIFF
--- a/cmd/ltctl/report.go
+++ b/cmd/ltctl/report.go
@@ -25,6 +25,11 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
 	const layout = "2006-01-02 15:04:05"
 	startTime, err := time.Parse(layout, args[0])
 	if err != nil {
@@ -76,7 +81,7 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create prometheus.Helper: %w", err)
 	}
 
-	g := report.New(label, helper)
+	g := report.New(label, helper, config.Report)
 	data, err := g.Generate(startTime, endTime)
 	if err != nil {
 		return fmt.Errorf("error while generating report: %w", err)

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -33,5 +33,30 @@
     "FileLevel": "INFO",
     "FileJson": true,
     "FileLocation": "deployer.log"
+  },
+  "Report": {
+    "Label": "{instance=~\"app.*\"}",
+    "GraphQueries": [
+      {
+        "Name":  "CPU Utilization",
+        "Query": "avg(irate(mattermost_process_cpu_seconds_total{instance=~\"app.*\"}[1m])* 100)"
+      },
+      {
+        "Name":  "Heap In Use",
+        "Query": "avg(go_memstats_heap_inuse_bytes{instance=~\"app.*:8067\"})"
+      },
+      {
+        "Name":  "Stack In Use",
+        "Query": "avg(go_memstats_stack_inuse_bytes{instance=~\"app.*:8067\"})"
+      },
+      {
+        "Name":  "RPS",
+        "Query": "sum(rate(mattermost_http_requests_total{instance=~\"app.*:8067\"}[1m]))"
+      },
+      {
+        "Name":  "Avg Store times",
+        "Query": "sum(increase(mattermost_db_store_time_sum{instance=~\"app.*:8067\"}[1m])) / sum(increase(mattermost_db_store_time_count{instance=~\"app.*:8067\"}[1m]))"
+      }
+    ]
   }
 }

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -55,7 +55,7 @@
       },
       {
         "Name":  "Avg Store times",
-        "Query": "sum(increase(mattermost_db_store_time_sum{instance=~\"app.*:8067\"}[1m])) / sum(increase(mattermost_db_store_time_count{instance=~\"app.*:8067\"}[1m]))"
+        "Query": "sum(rate(mattermost_db_store_time_sum{instance=~\"app.*:8067\"}[1m])) / sum(rate(mattermost_db_store_time_count{instance=~\"app.*:8067\"}[1m]))"
       }
     ]
   }

--- a/defaults/json.go
+++ b/defaults/json.go
@@ -34,6 +34,7 @@ func readJSON(path string, value interface{}) error {
 	if err != nil {
 		return fmt.Errorf("could not open file: %w", err)
 	}
+	defer file.Close()
 
 	err = json.NewDecoder(file).Decode(&value)
 	if err != nil {

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/report"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 )
 
@@ -63,6 +64,7 @@ type Config struct {
 	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v0.5.0-alpha/mattermost-load-test-ng-v0.5.0-alpha-linux-amd64.tar.gz" validate:"url"`
 	ElasticSearchSettings ElasticSearchSettings
 	LogSettings           logger.Settings
+	Report                report.Config
 }
 
 // ElasticSearchSettings contains the necessary data

--- a/docs/deployer_config.md
+++ b/docs/deployer_config.md
@@ -202,13 +202,19 @@ The location of the log file.
 
 The label to filter Prometheus queries.
 
-### GraphQueries.Name
+### GraphQueries
+
+*[]GraphQuery*
+
+GraphQuery contains the query to be executed against a Prometheus instance to gather data for reports.
+
+#### Name
 
 *string*
 
 A friendly name for the graph.
 
-### GraphQueries.Query
+#### Query
 
 *string*
 

--- a/docs/deployer_config.md
+++ b/docs/deployer_config.md
@@ -193,3 +193,23 @@ When true, logged events are written in a machine-readable JSON format. Otherwis
 *string*
 
 The location of the log file.
+
+## Report
+
+### Label
+
+*string*
+
+The label to filter Prometheus queries.
+
+### GraphQueries.Name
+
+*string*
+
+A friendly name for the graph.
+
+### GraphQueries.Query
+
+*string*
+
+The Prometheus query to run.

--- a/loadtest/report/generate.go
+++ b/loadtest/report/generate.go
@@ -86,7 +86,7 @@ func (g *Generator) Generate(startTime, endTime time.Time) (Report, error) {
 	sec := int(diff.Seconds())
 
 	// Avg store times.
-	tmpl := `sum(increase(mattermost_db_store_time_sum%s[%ds])) by (method) / sum(increase(mattermost_db_store_time_count%s[%ds])) by (method)`
+	tmpl := `sum(rate(mattermost_db_store_time_sum%s[%ds])) by (method) / sum(rate(mattermost_db_store_time_count%s[%ds])) by (method)`
 	query := fmt.Sprintf(tmpl, g.cfg.Label, sec, g.cfg.Label, sec)
 	data.AvgStoreTimes, err = g.getValue(endTime, query, "method")
 	if err != nil {
@@ -102,7 +102,7 @@ func (g *Generator) Generate(startTime, endTime time.Time) (Report, error) {
 	}
 
 	// Avg API times.
-	tmpl = `sum(increase(mattermost_api_time_sum%s[%ds])) by (handler) / sum(increase(mattermost_api_time_count%s[%ds])) by (handler)`
+	tmpl = `sum(rate(mattermost_api_time_sum%s[%ds])) by (handler) / sum(rate(mattermost_api_time_count%s[%ds])) by (handler)`
 	query = fmt.Sprintf(tmpl, g.cfg.Label, sec, g.cfg.Label, sec)
 	data.AvgAPITimes, err = g.getValue(endTime, query, "handler")
 	if err != nil {

--- a/loadtest/report/generate.go
+++ b/loadtest/report/generate.go
@@ -11,13 +11,28 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
+
 	"github.com/prometheus/common/model"
 )
+
+// Config contains information needed to generate reports.
+type Config struct {
+	Label        string // Label to be used when querying Prometheus
+	GraphQueries []GraphQuery
+}
+
+// GraphQuery contains the query to be executed against a Prometheus instance
+// to gather data for reports.
+type GraphQuery struct {
+	Name  string // A friendly name for the query.
+	Query string // The actual Prometheus query to be executed.
+}
 
 // Generator is used to generate load test reports.
 type Generator struct {
 	label  string
 	helper *prometheus.Helper
+	cfg    Config
 }
 
 // Report contains the entire report data comprising of several metrics
@@ -38,10 +53,11 @@ type graph struct {
 }
 
 // New returns a new instance of a generator.
-func New(label string, helper *prometheus.Helper) *Generator {
+func New(label string, helper *prometheus.Helper, cfg Config) *Generator {
 	return &Generator{
 		label:  label,
 		helper: helper,
+		cfg:    cfg,
 	}
 }
 
@@ -69,69 +85,39 @@ func (g *Generator) Generate(startTime, endTime time.Time) (Report, error) {
 	diff := endTime.Sub(startTime)
 	sec := int(diff.Seconds())
 
-	// TODO: ability to filter the instances by a given label for cases
-	// when a single Prometheus instance runs multiple clusters.
-
 	// Avg store times.
-	tmpl := `sum(increase(mattermost_db_store_time_sum[%ds])) by (method) / sum(increase(mattermost_db_store_time_count[%ds])) by (method)`
-	query := fmt.Sprintf(tmpl, sec, sec)
+	tmpl := `sum(increase(mattermost_db_store_time_sum%s[%ds])) by (method) / sum(increase(mattermost_db_store_time_count%s[%ds])) by (method)`
+	query := fmt.Sprintf(tmpl, g.cfg.Label, sec, g.cfg.Label, sec)
 	data.AvgStoreTimes, err = g.getValue(endTime, query, "method")
 	if err != nil {
 		return data, fmt.Errorf("error while getting avg store times: %w", err)
 	}
 
 	// P99 store times.
-	tmpl = `histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket[%ds])) by (le,method))`
-	query = fmt.Sprintf(tmpl, sec)
+	tmpl = `histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket%s[%ds])) by (le,method))`
+	query = fmt.Sprintf(tmpl, g.cfg.Label, sec)
 	data.P99StoreTimes, err = g.getValue(endTime, query, "method")
 	if err != nil {
 		return data, fmt.Errorf("error while getting p99 store times: %w", err)
 	}
 
 	// Avg API times.
-	tmpl = `sum(increase(mattermost_api_time_sum[%ds])) by (handler) / sum(increase(mattermost_api_time_count[%ds])) by (handler)`
-	query = fmt.Sprintf(tmpl, sec, sec)
+	tmpl = `sum(increase(mattermost_api_time_sum%s[%ds])) by (handler) / sum(increase(mattermost_api_time_count%s[%ds])) by (handler)`
+	query = fmt.Sprintf(tmpl, g.cfg.Label, sec, g.cfg.Label, sec)
 	data.AvgAPITimes, err = g.getValue(endTime, query, "handler")
 	if err != nil {
 		return data, fmt.Errorf("error while getting avg API times: %w", err)
 	}
 
 	// P99 API times.
-	tmpl = `histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket[%ds])) by (handler,le))`
-	query = fmt.Sprintf(tmpl, sec)
+	tmpl = `histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket%s[%ds])) by (handler,le))`
+	query = fmt.Sprintf(tmpl, g.cfg.Label, sec)
 	data.P99APITimes, err = g.getValue(endTime, query, "handler")
 	if err != nil {
 		return data, fmt.Errorf("error while getting p99 API times: %w", err)
 	}
 
-	// TODO: move them to be loadable from config so that more queries can be easily added later.
-	graphQueries := []struct {
-		Name  string
-		Query string
-	}{
-		{
-			Name:  "CPU Utilization",
-			Query: `avg(irate(mattermost_process_cpu_seconds_total{instance=~"app.*"}[1m])* 100)`,
-		},
-		{
-			Name:  "Heap In Use",
-			Query: `avg(go_memstats_heap_inuse_bytes{instance=~"app.*:8067"})`,
-		},
-		{
-			Name:  "Stack In Use",
-			Query: `avg(go_memstats_stack_inuse_bytes{instance=~"app.*:8067"})`,
-		},
-		{
-			Name:  "RPS",
-			Query: `sum(rate(mattermost_http_requests_total{instance=~"app.*:8067"}[1m]))`,
-		},
-		{
-			Name:  "Avg Store times",
-			Query: `sum(increase(mattermost_db_store_time_sum{instance=~"app.*:8067"}[1m])) / sum(increase(mattermost_db_store_time_count{instance=~"app.*:8067"}[1m]))`,
-		},
-	}
-
-	for _, gq := range graphQueries {
+	for _, gq := range g.cfg.GraphQueries {
 		res, err := g.helper.Matrix(gq.Query, startTime, endTime)
 		if err != nil {
 			return data, fmt.Errorf("error while getting %s: %w", gq.Name, err)

--- a/loadtest/report/generate.go
+++ b/loadtest/report/generate.go
@@ -17,7 +17,7 @@ import (
 
 // Config contains information needed to generate reports.
 type Config struct {
-	Label        string // Label to be used when querying Prometheus
+	Label        string // Label to be used when querying Prometheus.
 	GraphQueries []GraphQuery
 }
 

--- a/loadtest/report/generate_test.go
+++ b/loadtest/report/generate_test.go
@@ -170,7 +170,7 @@ func TestGenerate(t *testing.T) {
 				Values: values,
 			},
 		},
-		`sum(increase(mattermost_db_store_time_sum{instance=~"app.*:8067"}[1m])) / sum(increase(mattermost_db_store_time_count{instance=~"app.*:8067"}[1m]))`: {
+		`sum(rate(mattermost_db_store_time_sum{instance=~"app.*:8067"}[1m])) / sum(rate(mattermost_db_store_time_count{instance=~"app.*:8067"}[1m]))`: {
 			&model.SampleStream{
 				Metric: model.Metric{},
 				Values: values,
@@ -199,7 +199,7 @@ func TestGenerate(t *testing.T) {
 			},
 			{
 				Name:  "Avg Store times",
-				Query: "sum(increase(mattermost_db_store_time_sum{instance=~\"app.*:8067\"}[1m])) / sum(increase(mattermost_db_store_time_count{instance=~\"app.*:8067\"}[1m]))",
+				Query: "sum(rate(mattermost_db_store_time_sum{instance=~\"app.*:8067\"}[1m])) / sum(rate(mattermost_db_store_time_count{instance=~\"app.*:8067\"}[1m]))",
 			},
 		},
 	}

--- a/loadtest/report/generate_test.go
+++ b/loadtest/report/generate_test.go
@@ -50,7 +50,7 @@ func TestGenerate(t *testing.T) {
 	}
 
 	var input = map[string]model.Matrix{
-		"sum(increase(mattermost_db_store_time_sum[10s])) by (method) / sum(increase(mattermost_db_store_time_count[10s])) by (method)": {
+		"sum(rate(mattermost_db_store_time_sum[10s])) by (method) / sum(rate(mattermost_db_store_time_count[10s])) by (method)": {
 			&model.SampleStream{
 				Metric: model.Metric{
 					"method": "method1",
@@ -98,7 +98,7 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 		},
-		"sum(increase(mattermost_api_time_sum[10s])) by (handler) / sum(increase(mattermost_api_time_count[10s])) by (handler)": {
+		"sum(rate(mattermost_api_time_sum[10s])) by (handler) / sum(rate(mattermost_api_time_count[10s])) by (handler)": {
 			&model.SampleStream{
 				Metric: model.Metric{
 					"handler": "handler1",

--- a/loadtest/report/generate_test.go
+++ b/loadtest/report/generate_test.go
@@ -178,6 +178,32 @@ func TestGenerate(t *testing.T) {
 		},
 	}
 
+	cfg := Config{
+		Label: "",
+		GraphQueries: []GraphQuery{
+			{
+				Name:  "CPU Utilization",
+				Query: "avg(irate(mattermost_process_cpu_seconds_total{instance=~\"app.*\"}[1m])* 100)",
+			},
+			{
+				Name:  "Heap In Use",
+				Query: "avg(go_memstats_heap_inuse_bytes{instance=~\"app.*:8067\"})",
+			},
+			{
+				Name:  "Stack In Use",
+				Query: "avg(go_memstats_stack_inuse_bytes{instance=~\"app.*:8067\"})",
+			},
+			{
+				Name:  "RPS",
+				Query: "sum(rate(mattermost_http_requests_total{instance=~\"app.*:8067\"}[1m]))",
+			},
+			{
+				Name:  "Avg Store times",
+				Query: "sum(increase(mattermost_db_store_time_sum{instance=~\"app.*:8067\"}[1m])) / sum(increase(mattermost_db_store_time_count{instance=~\"app.*:8067\"}[1m]))",
+			},
+		},
+	}
+
 	label := "base"
 	var output = Report{
 		Label:         label,
@@ -214,7 +240,7 @@ func TestGenerate(t *testing.T) {
 		dataMap: input,
 	})
 
-	g := New(label, helper)
+	g := New(label, helper, cfg)
 	now := time.Now()
 	r, err := g.Generate(now.Add(-10*time.Second), now)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR changes the graph queries from being hardcoded
to being loadable from config. This takes care of using custom labels
for the queries and at the same time, use any custom query that the user
wants to run.

We also add a Label field for the Avg and P99 queries.

While here, we fix an unrelated bug that did not close the file.

Docs are updated and sample config file is also changed.

### Ticket link

https://mattermost.atlassian.net/browse/MM-26416
