### PR TITLE
[MM-26459] Split logs for agent and coordinator

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -109,7 +109,7 @@ func (a *api) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lt, err := loadtest.New(&ltConfig, NewControllerWrapper(&ltConfig, ucConfig, 0, agentId, a.metrics), a.alog)
+	lt, err := loadtest.New(&ltConfig, NewControllerWrapper(&ltConfig, ucConfig, 0, agentId, a.metrics), a.agentLog)
 	if err != nil {
 		writeAgentResponse(w, http.StatusBadRequest, &agentResponse{
 			Id:      agentId,

--- a/api/agent.go
+++ b/api/agent.go
@@ -109,7 +109,7 @@ func (a *api) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lt, err := loadtest.New(&ltConfig, NewControllerWrapper(&ltConfig, ucConfig, 0, agentId, a.metrics))
+	lt, err := loadtest.New(&ltConfig, NewControllerWrapper(&ltConfig, ucConfig, 0, agentId, a.metrics), a.alog)
 	if err != nil {
 		writeAgentResponse(w, http.StatusBadRequest, &agentResponse{
 			Id:      agentId,

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/gavv/httpexpect"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,7 @@ type requestData struct {
 
 func TestAgentAPI(t *testing.T) {
 	// create http.Handler
-	handler := SetupAPIRouter()
+	handler := SetupAPIRouter(logger.New(&logger.Settings{}), logger.New(&logger.Settings{}))
 
 	// run server using httptest
 	server := httptest.NewServer(handler)

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -76,7 +76,7 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c, err := coordinator.New(&config, a.clog)
+	c, err := coordinator.New(&config, a.coordLog)
 	if err != nil {
 		writeCoordinatorResponse(w, http.StatusBadRequest, &coordinatorResponse{
 			Id:      id,

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -76,7 +76,7 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c, err := coordinator.New(&config)
+	c, err := coordinator.New(&config, a.clog)
 	if err != nil {
 		writeCoordinatorResponse(w, http.StatusBadRequest, &coordinatorResponse{
 			Id:      id,

--- a/api/coordinator_test.go
+++ b/api/coordinator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/gavv/httpexpect"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ import (
 
 func TestCoordinatorAPI(t *testing.T) {
 	// create http.Handler
-	handler := SetupAPIRouter()
+	handler := SetupAPIRouter(logger.New(&logger.Settings{}), logger.New(&logger.Settings{}))
 
 	// run server using httptest
 	server := httptest.NewServer(handler)

--- a/api/server.go
+++ b/api/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/performance"
 
 	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
 // api keeps track of the load-test API server state.
@@ -19,6 +20,8 @@ type api struct {
 	agents       map[string]*loadtest.LoadTester
 	coordinators map[string]*coordinator.Coordinator
 	metrics      *performance.Metrics
+	clog         *mlog.Logger
+	alog         *mlog.Logger
 }
 
 func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
@@ -36,11 +39,13 @@ func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // SetupAPIRouter creates a router to handle load test API requests.
-func SetupAPIRouter() *mux.Router {
+func SetupAPIRouter(clog, alog *mlog.Logger) *mux.Router {
 	a := api{
 		agents:       make(map[string]*loadtest.LoadTester),
 		coordinators: make(map[string]*coordinator.Coordinator),
 		metrics:      performance.NewMetrics(),
+		clog:         clog,
+		alog:         alog,
 	}
 
 	router := mux.NewRouter()

--- a/api/server.go
+++ b/api/server.go
@@ -20,8 +20,8 @@ type api struct {
 	agents       map[string]*loadtest.LoadTester
 	coordinators map[string]*coordinator.Coordinator
 	metrics      *performance.Metrics
-	clog         *mlog.Logger
-	alog         *mlog.Logger
+	coordLog     *mlog.Logger
+	agentLog     *mlog.Logger
 }
 
 func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
@@ -39,13 +39,14 @@ func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // SetupAPIRouter creates a router to handle load test API requests.
-func SetupAPIRouter(clog, alog *mlog.Logger) *mux.Router {
+// Custom loggers for coordinator and agent are given.
+func SetupAPIRouter(coordLog, agentLog *mlog.Logger) *mux.Router {
 	a := api{
 		agents:       make(map[string]*loadtest.LoadTester),
 		coordinators: make(map[string]*coordinator.Coordinator),
 		metrics:      performance.NewMetrics(),
-		clog:         clog,
-		alog:         alog,
+		coordLog:     coordLog,
+		agentLog:     agentLog,
 	}
 
 	router := mux.NewRouter()

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -79,6 +79,8 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not validate configuration: %w", err)
 	}
 
+	log := logger.New(&config.LogSettings)
+
 	userPrefix, err := cmd.Flags().GetString("user-prefix")
 	if err != nil {
 		return err
@@ -115,7 +117,7 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	lt, err := loadtest.New(config, api.NewControllerWrapper(config, &genConfig, 0, userPrefix, nil))
+	lt, err := loadtest.New(config, api.NewControllerWrapper(config, &genConfig, 0, userPrefix, nil), log)
 	if err != nil {
 		return fmt.Errorf("error while initializing loadtest: %w", err)
 	}

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/spf13/cobra"
@@ -49,6 +50,8 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 	if err := defaults.Validate(*config); err != nil {
 		return fmt.Errorf("could not validate configuration: %w", err)
 	}
+
+	log := logger.New(&config.LogSettings)
 
 	controllerType := config.UserControllerConfiguration.Type
 
@@ -105,7 +108,7 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	lt, err := loadtest.New(config, api.NewControllerWrapper(config, ucConfig, userOffset, userPrefix, nil))
+	lt, err := loadtest.New(config, api.NewControllerWrapper(config, ucConfig, userOffset, userPrefix, nil), log)
 	if err != nil {
 		return fmt.Errorf("error while initializing loadtest: %w", err)
 	}

--- a/cmd/ltapi/main.go
+++ b/cmd/ltapi/main.go
@@ -18,6 +18,7 @@ import (
 func RunServerCmdF(cmd *cobra.Command, args []string) error {
 	port, _ := cmd.Flags().GetInt("port")
 
+	// TODO: add a config file for the API server.
 	logger.Init(&logger.Settings{
 		EnableConsole: true,
 		ConsoleLevel:  "ERROR",
@@ -28,8 +29,28 @@ func RunServerCmdF(cmd *cobra.Command, args []string) error {
 		FileLocation:  "ltapi.log",
 	})
 
+	clog := logger.New(&logger.Settings{
+		EnableConsole: false,
+		ConsoleLevel:  "ERROR",
+		ConsoleJson:   false,
+		EnableFile:    true,
+		FileLevel:     "INFO",
+		FileJson:      true,
+		FileLocation:  "ltcoordinator.log",
+	})
+
+	alog := logger.New(&logger.Settings{
+		EnableConsole: false,
+		ConsoleLevel:  "ERROR",
+		ConsoleJson:   false,
+		EnableFile:    true,
+		FileLevel:     "INFO",
+		FileJson:      true,
+		FileLocation:  "ltagent.log",
+	})
+
 	mlog.Info("API server started, listening on", mlog.Int("port", port))
-	return http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), api.SetupAPIRouter())
+	return http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), api.SetupAPIRouter(clog, alog))
 }
 
 func main() {

--- a/cmd/ltcoordinator/main.go
+++ b/cmd/ltcoordinator/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/spf13/cobra"
@@ -27,6 +28,8 @@ func RunCoordinatorCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	log := logger.New(&cfg.LogSettings)
+
 	ltConfigFilePath, err := cmd.Flags().GetString("ltagent-config")
 	if err != nil {
 		return err
@@ -40,7 +43,7 @@ func RunCoordinatorCmdF(cmd *cobra.Command, args []string) error {
 		cfg.ClusterConfig.Agents[i].LoadTestConfig = *ltConfig
 	}
 
-	c, err := coordinator.New(cfg)
+	c, err := coordinator.New(cfg, log)
 	if err != nil {
 		return fmt.Errorf("failed to create coordinator: %w", err)
 	}

--- a/coordinator/agent/agent.go
+++ b/coordinator/agent/agent.go
@@ -24,6 +24,7 @@ type LoadAgent struct {
 	config LoadAgentConfig
 	status *loadtest.Status
 	client *http.Client
+	log    *mlog.Logger
 }
 
 // TODO: maybe move this into a shared model package.
@@ -39,7 +40,10 @@ var ErrAgentNotFound = errors.New("agent: not found")
 
 // New creates and initializes a new LoadAgent for the given config.
 // An error is returned if the initialization fails.
-func New(config LoadAgentConfig) (*LoadAgent, error) {
+func New(config LoadAgentConfig, log *mlog.Logger) (*LoadAgent, error) {
+	if log == nil {
+		return nil, errors.New("logger should not be nil")
+	}
 	if err := defaults.Validate(config); err != nil {
 		return nil, fmt.Errorf("could not validate configartion: %w", err)
 	}
@@ -47,6 +51,7 @@ func New(config LoadAgentConfig) (*LoadAgent, error) {
 		config: config,
 		status: &loadtest.Status{},
 		client: &http.Client{},
+		log:    log,
 	}, nil
 }
 
@@ -139,7 +144,7 @@ func (a *LoadAgent) Start() error {
 		return err
 	}
 
-	mlog.Info("agent: agent created", mlog.String("agent_id", a.config.Id))
+	a.log.Info("agent: agent created", mlog.String("agent_id", a.config.Id))
 
 	return nil
 }
@@ -154,7 +159,7 @@ func (a *LoadAgent) Stop() error {
 		return err
 	}
 
-	mlog.Info("agent: agent destroyed", mlog.String("agent_id", a.config.Id))
+	a.log.Info("agent: agent destroyed", mlog.String("agent_id", a.config.Id))
 
 	return nil
 }

--- a/coordinator/cluster/utils_test.go
+++ b/coordinator/cluster/utils_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,11 +18,11 @@ func createMockAgents(t *testing.T) []*agent.LoadAgent {
 	}
 	defaults.Set(&cfg)
 
-	agent1, err := agent.New(cfg)
+	agent1, err := agent.New(cfg, logger.New(&logger.Settings{}))
 	require.NoError(t, err)
-	agent2, err := agent.New(cfg)
+	agent2, err := agent.New(cfg, logger.New(&logger.Settings{}))
 	require.NoError(t, err)
-	agent3, err := agent.New(cfg)
+	agent3, err := agent.New(cfg, logger.New(&logger.Settings{}))
 	require.NoError(t, err)
 
 	agents := []*agent.LoadAgent{

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/stretchr/testify/require"
 )
@@ -45,11 +46,15 @@ func setupAPIServer(t *testing.T) *httptest.Server {
 }
 
 func TestNew(t *testing.T) {
-	c, err := New(nil)
+	c, err := New(nil, logger.New(&logger.Settings{}))
 	require.Error(t, err)
 	require.Nil(t, c)
 
-	c, err = New(newConfig(t))
+	c, err = New(newConfig(t), nil)
+	require.Error(t, err)
+	require.Nil(t, c)
+
+	c, err = New(newConfig(t), logger.New(&logger.Settings{}))
 	require.NoError(t, err)
 	require.NotNil(t, c)
 }
@@ -61,7 +66,7 @@ func TestRun(t *testing.T) {
 	cfg := newConfig(t)
 	cfg.ClusterConfig.Agents[0].ApiURL = srv.URL
 
-	c, err := New(cfg)
+	c, err := New(cfg, logger.New(&logger.Settings{}))
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
@@ -93,7 +98,7 @@ func TestStop(t *testing.T) {
 	cfg := newConfig(t)
 	cfg.ClusterConfig.Agents[0].ApiURL = srv.URL
 
-	c, err := New(cfg)
+	c, err := New(cfg, logger.New(&logger.Settings{}))
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	require.Equal(t, c.status.State, Stopped)
@@ -122,7 +127,7 @@ func TestStatus(t *testing.T) {
 	cfg := newConfig(t)
 	cfg.ClusterConfig.Agents[0].ApiURL = srv.URL
 
-	c, err := New(cfg)
+	c, err := New(cfg, logger.New(&logger.Settings{}))
 	require.NoError(t, err)
 	require.NotNil(t, c)
 

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -68,20 +68,29 @@ func newController(id int, status chan<- control.UserStatus) (control.UserContro
 }
 
 func TestNew(t *testing.T) {
-	// ignore lt structs if there is an error.
-	_, err := New(nil, newController)
-	require.NotNil(t, err)
+	log := logger.New(&ltConfig.LogSettings)
 
-	_, err = New(&ltConfig, nil)
+	lt, err := New(nil, newController, log)
 	require.NotNil(t, err)
+	require.Nil(t, lt)
 
-	lt, err := New(&ltConfig, newController)
-	require.Nil(t, err)
+	lt, err = New(&ltConfig, nil, log)
+	require.Error(t, err)
+	require.Nil(t, lt)
+
+	lt, err = New(&ltConfig, newController, nil)
+	require.Error(t, err)
+	require.Nil(t, lt)
+
+	lt, err = New(&ltConfig, newController, log)
+	require.NoError(t, err)
 	require.NotNil(t, lt)
 }
 
 func TestAddUsers(t *testing.T) {
-	lt, err := New(&ltConfig, newController)
+	log := logger.New(&ltConfig.LogSettings)
+
+	lt, err := New(&ltConfig, newController, log)
 	require.Nil(t, err)
 
 	n, err := lt.AddUsers(0)
@@ -109,7 +118,8 @@ func TestAddUsers(t *testing.T) {
 }
 
 func TestRemoveUsers(t *testing.T) {
-	lt, err := New(&ltConfig, newController)
+	log := logger.New(&ltConfig.LogSettings)
+	lt, err := New(&ltConfig, newController, log)
 	defer close(lt.statusChan)
 	require.Nil(t, err)
 
@@ -161,7 +171,8 @@ func TestRemoveUsers(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	lt, err := New(&ltConfig, newController)
+	log := logger.New(&ltConfig.LogSettings)
+	lt, err := New(&ltConfig, newController, log)
 	require.Nil(t, err)
 	err = lt.Run()
 	require.NoError(t, err)
@@ -176,7 +187,8 @@ func TestRun(t *testing.T) {
 }
 
 func TestRerun(t *testing.T) {
-	lt, err := New(&ltConfig, newController)
+	log := logger.New(&ltConfig.LogSettings)
+	lt, err := New(&ltConfig, newController, log)
 	require.Nil(t, err)
 	err = lt.Run()
 	require.NoError(t, err)
@@ -192,7 +204,8 @@ func TestRerun(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	lt, err := New(&ltConfig, newController)
+	log := logger.New(&ltConfig.LogSettings)
+	lt, err := New(&ltConfig, newController, log)
 	require.Nil(t, err)
 	err = lt.Stop()
 	require.Equal(t, ErrNotRunning, err)
@@ -213,7 +226,8 @@ func TestStop(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
-	lt, err := New(&ltConfig, newController)
+	log := logger.New(&ltConfig.LogSettings)
+	lt, err := New(&ltConfig, newController, log)
 	require.NotNil(t, lt)
 	require.Nil(t, err)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
+// Settings holds information used to initialize a new logger.
 type Settings struct {
 	EnableConsole bool   `default:"true"`
 	ConsoleJson   bool   `default:"false"`
@@ -19,6 +20,7 @@ type Settings struct {
 	FileLocation  string `default:"loadtest.log"`
 }
 
+// New returns a newly created and initialized logger with the given settings.
 func New(logSettings *Settings) *mlog.Logger {
 	return mlog.NewLogger(&mlog.LoggerConfiguration{
 		EnableConsole: logSettings.EnableConsole,
@@ -31,6 +33,7 @@ func New(logSettings *Settings) *mlog.Logger {
 	})
 }
 
+// Init initializes the global logger with the given settings.
 func Init(logSettings *Settings) {
 	log := mlog.NewLogger(&mlog.LoggerConfiguration{
 		EnableConsole: logSettings.EnableConsole,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -19,6 +19,18 @@ type Settings struct {
 	FileLocation  string `default:"loadtest.log"`
 }
 
+func New(logSettings *Settings) *mlog.Logger {
+	return mlog.NewLogger(&mlog.LoggerConfiguration{
+		EnableConsole: logSettings.EnableConsole,
+		ConsoleJson:   logSettings.ConsoleJson,
+		ConsoleLevel:  strings.ToLower(logSettings.ConsoleLevel),
+		EnableFile:    logSettings.EnableFile,
+		FileJson:      logSettings.FileJson,
+		FileLevel:     strings.ToLower(logSettings.FileLevel),
+		FileLocation:  logSettings.FileLocation,
+	})
+}
+
 func Init(logSettings *Settings) {
 	log := mlog.NewLogger(&mlog.LoggerConfiguration{
 		EnableConsole: logSettings.EnableConsole,


### PR DESCRIPTION
#### Summary

PR splits logging for the two main components. 
This is needed to avoid having a single `ltapi.log` file with everything inside.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26459