### PR TITLE
[MM-26395] Simplify coordinator's config

### DIFF
--- a/cmd/ltcoordinator/main.go
+++ b/cmd/ltcoordinator/main.go
@@ -34,11 +34,7 @@ func RunCoordinatorCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for i := 0; i < len(cfg.ClusterConfig.Agents); i++ {
-		cfg.ClusterConfig.Agents[i].LoadTestConfig = *ltConfig
-	}
-
-	c, err := coordinator.New(cfg)
+	c, err := coordinator.New(cfg, *ltConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create coordinator: %w", err)
 	}

--- a/coordinator/agent/agent.go
+++ b/coordinator/agent/agent.go
@@ -22,7 +22,7 @@ import (
 // LoadAgent is the object acting as a client to the load-test agent
 // HTTP API.
 type LoadAgent struct {
-	config LoadAgentConfig
+	config Config
 	status *loadtest.Status
 	client *http.Client
 }
@@ -31,7 +31,7 @@ var ErrAgentNotFound = errors.New("agent: not found")
 
 // New creates and initializes a new LoadAgent for the given config.
 // An error is returned if the initialization fails.
-func New(config LoadAgentConfig) (*LoadAgent, error) {
+func New(config Config) (*LoadAgent, error) {
 	if err := defaults.Validate(config); err != nil {
 		return nil, fmt.Errorf("could not validate configartion: %w", err)
 	}

--- a/coordinator/agent/config.go
+++ b/coordinator/agent/config.go
@@ -7,8 +7,8 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 )
 
-// LoadAgentConfig holds information about the load-test agent instance.
-type LoadAgentConfig struct {
+// Config holds information about the load-test agent instance.
+type Config struct {
 	// A sring that identifies the load-test agent instance.
 	Id string `default:"lt0" validate:"notempty"`
 	// The API URL used to control the specified load-test instance.

--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
@@ -29,14 +30,19 @@ type errorTrack struct {
 
 // New creates and initializes a new LoadAgentCluster for the given config.
 // An error is returned if the initialization fails.
-func New(config LoadAgentClusterConfig) (*LoadAgentCluster, error) {
+func New(config LoadAgentClusterConfig, ltConfig loadtest.Config) (*LoadAgentCluster, error) {
 	if err := defaults.Validate(config); err != nil {
 		return nil, fmt.Errorf("could not validate configuration: %w", err)
 	}
 	agents := make([]*agent.LoadAgent, len(config.Agents))
 	errMap := make(map[*agent.LoadAgent]errorTrack)
 	for i := 0; i < len(agents); i++ {
-		agent, err := agent.New(config.Agents[i])
+		agentConfig := agent.Config{
+			Id:             config.Agents[i].Id,
+			ApiURL:         config.Agents[i].ApiURL,
+			LoadTestConfig: ltConfig,
+		}
+		agent, err := agent.New(agentConfig)
 		if err != nil {
 			return nil, fmt.Errorf("cluster: failed to create agent: %w", err)
 		}

--- a/coordinator/cluster/config.go
+++ b/coordinator/cluster/config.go
@@ -3,9 +3,13 @@
 
 package cluster
 
-import (
-	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
-)
+// LoadAgentConfig holds information about the load-test agent instance.
+type LoadAgentConfig struct {
+	// A sring that identifies the load-test agent instance.
+	Id string `default:"lt0" validate:"notempty"`
+	// The API URL used to control the specified load-test instance.
+	ApiURL string `default:"http://localhost:4000" validate:"url"`
+}
 
 // LoadAgentClusterConfig holds information regarding the cluster of load-test
 // agents.
@@ -13,7 +17,7 @@ type LoadAgentClusterConfig struct {
 	// Agents is a list of the load-test agents API endpoints to be used during
 	// the load-test. It's length defines the number of load-test instances
 	// used during a load-test.
-	Agents []agent.LoadAgentConfig `default_size:"1"`
+	Agents []LoadAgentConfig `default_size:"1"`
 	// MaxActiveUsers defines the upper limit of concurrently active users to run across
 	// the whole cluster.
 	MaxActiveUsers int `default:"1000" validate:"range:(0,]"`

--- a/coordinator/cluster/utils_test.go
+++ b/coordinator/cluster/utils_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func createMockAgents(t *testing.T) []*agent.LoadAgent {
-	cfg := agent.LoadAgentConfig{
+	cfg := agent.Config{
 		ApiURL: "localhost:8065",
 		Id:     "id",
 	}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -137,6 +137,7 @@ func (c *Coordinator) Run() error {
 }
 
 // New creates and initializes a new Coordinator for the given config.
+// The ltConfig parameter is used to create and configure load-test agents.
 // An error is returned if the initialization fails.
 func New(config *Config, ltConfig loadtest.Config) (*Coordinator, error) {
 	if config == nil {

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
@@ -137,7 +138,7 @@ func (c *Coordinator) Run() error {
 
 // New creates and initializes a new Coordinator for the given config.
 // An error is returned if the initialization fails.
-func New(config *Config) (*Coordinator, error) {
+func New(config *Config, ltConfig loadtest.Config) (*Coordinator, error) {
 	if config == nil {
 		return nil, fmt.Errorf("coordinator: config should not be nil")
 	}
@@ -145,7 +146,7 @@ func New(config *Config) (*Coordinator, error) {
 		return nil, fmt.Errorf("could not validate configuration: %w", err)
 	}
 
-	cluster, err := cluster.New(config.ClusterConfig)
+	cluster, err := cluster.New(config.ClusterConfig, ltConfig)
 	if err != nil {
 		return nil, fmt.Errorf("coordinator: failed to create cluster: %w", err)
 	}

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
-	"github.com/mattermost/mattermost-load-test-ng/coordinator/agent"
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/cluster"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
@@ -29,9 +29,9 @@ func (t *Terraform) StartCoordinator() error {
 	}
 	ip := output.Agents.Value[0].PublicIP
 
-	var loadAgentConfigs []agent.LoadAgentConfig
+	var loadAgentConfigs []cluster.LoadAgentConfig
 	for _, val := range output.Agents.Value {
-		loadAgentConfigs = append(loadAgentConfigs, agent.LoadAgentConfig{
+		loadAgentConfigs = append(loadAgentConfigs, cluster.LoadAgentConfig{
 			Id:     val.Tags.Name,
 			ApiURL: "http://" + val.PrivateIP + ":4000",
 		})

--- a/docs/coordinator_config.md
+++ b/docs/coordinator_config.md
@@ -6,7 +6,7 @@
 
 ### Agents
 
-*[]agent.LoadAgentConfig*
+*[]cluster.LoadAgentConfig*
 
 #### Id
 


### PR DESCRIPTION
#### Summary

PR simplifies `coordinator`'s config by removing the `loadtest.Config` from the `LoadAgentClusterConfig`.
The config is instead passed once when creating a new coordinator.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26395