### PR TITLE
Remove everything with mattermost-load-test-ng in agent creation

### DIFF
--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -60,7 +60,7 @@ func (t *Terraform) configureAndRunAgents(extAgent *ssh.ExtAgent, output *Output
 				return fmt.Errorf("error uploading file %q, output: %q: %w", packagePath, out, err)
 			}
 			commands := []string{
-				"rm -rf mattermost-load-test-ng",
+				"rm -rf mattermost-load-test-ng*",
 				"tar xzf tmp.tar.gz",
 				"mv mattermost-load-test-ng* mattermost-load-test-ng",
 				"rm tmp.tar.gz",


### PR DESCRIPTION
If there is already a .tar.gz file present, then this throws an error
while trying to move the directory. We therefore delete everything with that name.
