### PR TITLE
[MM-26218] Make HTTP API resources safe for concurrent access

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -103,9 +103,15 @@ func (a *api) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 
 	agentId := r.FormValue("id")
 	if val, ok := a.resources.Load(agentId); ok && val != nil {
-		writeAgentResponse(w, http.StatusBadRequest, &agentResponse{
-			Error: fmt.Sprintf("load-test agent with id %s already exists", agentId),
-		})
+		if _, ok := val.(*loadtest.LoadTester); ok {
+			writeAgentResponse(w, http.StatusBadRequest, &agentResponse{
+				Error: fmt.Sprintf("load-test agent with id %s already exists", agentId),
+			})
+		} else {
+			writeAgentResponse(w, http.StatusBadRequest, &agentResponse{
+				Error: fmt.Sprintf("resource with id %s already exists", agentId),
+			})
+		}
 		return
 	}
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -102,7 +102,7 @@ func (a *api) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	agentId := r.FormValue("id")
-	if val, ok := a.resources.Load(agentId); ok && val != nil {
+	if val, ok := a.getResource(agentId); ok && val != nil {
 		if _, ok := val.(*loadtest.LoadTester); ok {
 			writeAgentResponse(w, http.StatusBadRequest, &agentResponse{
 				Error: fmt.Sprintf("load-test agent with id %s already exists", agentId),
@@ -124,7 +124,7 @@ func (a *api) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	a.resources.Store(agentId, lt)
+	a.setResource(agentId, lt)
 
 	writeAgentResponse(w, http.StatusCreated, &agentResponse{
 		Id:      agentId,
@@ -136,7 +136,7 @@ func (a *api) getLoadAgentById(w http.ResponseWriter, r *http.Request) (*loadtes
 	vars := mux.Vars(r)
 	id := vars["id"]
 
-	val, ok := a.resources.Load(id)
+	val, ok := a.getResource(id)
 	if !ok || val == nil {
 		err := fmt.Errorf("load-test agent with id %s not found", id)
 		writeAgentResponse(w, http.StatusNotFound, &agentResponse{
@@ -199,7 +199,7 @@ func (a *api) destroyLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 
 	_ = lt.Stop() // we are ignoring the error here in case the load test was previously stopped
 
-	a.resources.Delete(mux.Vars(r)["id"])
+	a.deleteResource(mux.Vars(r)["id"])
 	writeAgentResponse(w, http.StatusOK, &agentResponse{
 		Message: "load-test agent destroyed",
 		Status:  lt.Status(),

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -77,9 +77,15 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 
 	id := r.FormValue("id")
 	if val, ok := a.resources.Load(id); ok && val != nil {
-		writeCoordinatorResponse(w, http.StatusBadRequest, &coordinatorResponse{
-			Error: fmt.Sprintf("load-test coordinator with id %s already exists", id),
-		})
+		if _, ok := val.(*coordinator.Coordinator); ok {
+			writeCoordinatorResponse(w, http.StatusBadRequest, &coordinatorResponse{
+				Error: fmt.Sprintf("load-test coordinator with id %s already exists", id),
+			})
+		} else {
+			writeCoordinatorResponse(w, http.StatusBadRequest, &coordinatorResponse{
+				Error: fmt.Sprintf("resource with id %s already exists", id),
+			})
+		}
 		return
 	}
 

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -32,7 +32,7 @@ func writeCoordinatorResponse(w http.ResponseWriter, status int, resp *coordinat
 func (a *api) getCoordinatorById(w http.ResponseWriter, r *http.Request) (*coordinator.Coordinator, error) {
 	vars := mux.Vars(r)
 	id := vars["id"]
-	val, ok := a.resources.Load(id)
+	val, ok := a.getResource(id)
 	if !ok || val == nil {
 		err := fmt.Errorf("load-test coordinator with id %s not found", id)
 		writeCoordinatorResponse(w, http.StatusNotFound, &coordinatorResponse{
@@ -76,7 +76,7 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 	config := data.CoordinatorConfig
 
 	id := r.FormValue("id")
-	if val, ok := a.resources.Load(id); ok && val != nil {
+	if val, ok := a.getResource(id); ok && val != nil {
 		if _, ok := val.(*coordinator.Coordinator); ok {
 			writeCoordinatorResponse(w, http.StatusBadRequest, &coordinatorResponse{
 				Error: fmt.Sprintf("load-test coordinator with id %s already exists", id),
@@ -99,7 +99,7 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.resources.Store(id, c)
+	a.setResource(id, c)
 
 	writeCoordinatorResponse(w, http.StatusCreated, &coordinatorResponse{
 		Message: "load-test coordinator created",
@@ -114,7 +114,7 @@ func (a *api) destroyCoordinatorHandler(w http.ResponseWriter, r *http.Request) 
 
 	_ = c.Stop() // we are ignoring the error here in case the coordinator was previously stopped
 
-	a.resources.Delete(mux.Vars(r)["id"])
+	a.deleteResource(mux.Vars(r)["id"])
 	writeCoordinatorResponse(w, http.StatusOK, &coordinatorResponse{
 		Message: "load-test coordinator destroyed",
 	})

--- a/api/coordinator_test.go
+++ b/api/coordinator_test.go
@@ -68,6 +68,12 @@ func TestCoordinatorAPI(t *testing.T) {
 		rawMsg = obj.Value("error").String().Raw()
 		require.Equal(t, "load-test coordinator with id ltc0 already exists", rawMsg)
 
+		eAgent := httpexpect.New(t, server.URL+"/loadagent")
+		obj = eAgent.GET(id).Expect().Status(http.StatusBadRequest).
+			JSON().Object().ContainsKey("error")
+		rawMsg = obj.Value("error").String().Raw()
+		require.Equal(t, "resource with id ltc0 is not a load-test agent", rawMsg)
+
 		obj = e.DELETE(id).
 			Expect().Status(http.StatusOK).
 			JSON().Object().ContainsKey("message")

--- a/api/server.go
+++ b/api/server.go
@@ -16,10 +16,30 @@ import (
 
 // api keeps track of the load-test API server state.
 type api struct {
-	resources sync.Map
+	mut       sync.RWMutex
+	resources map[string]interface{}
 	metrics   *performance.Metrics
 	coordLog  *mlog.Logger
 	agentLog  *mlog.Logger
+}
+
+func (a *api) getResource(id string) (interface{}, bool) {
+	a.mut.RLock()
+	defer a.mut.RUnlock()
+	val, ok := a.resources[id]
+	return val, ok
+}
+
+func (a *api) setResource(id string, res interface{}) {
+	a.mut.Lock()
+	defer a.mut.Unlock()
+	a.resources[id] = res
+}
+
+func (a *api) deleteResource(id string) {
+	a.mut.Lock()
+	defer a.mut.Unlock()
+	delete(a.resources, id)
 }
 
 func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
@@ -40,9 +60,10 @@ func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
 // Custom loggers for coordinator and agent are given.
 func SetupAPIRouter(coordLog, agentLog *mlog.Logger) *mux.Router {
 	a := api{
-		metrics:  performance.NewMetrics(),
-		coordLog: coordLog,
-		agentLog: agentLog,
+		resources: make(map[string]interface{}),
+		metrics:   performance.NewMetrics(),
+		coordLog:  coordLog,
+		agentLog:  agentLog,
 	}
 
 	router := mux.NewRouter()

--- a/api/server.go
+++ b/api/server.go
@@ -6,9 +6,8 @@ package api
 import (
 	"net/http"
 	"net/http/pprof"
+	"sync"
 
-	"github.com/mattermost/mattermost-load-test-ng/coordinator"
-	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 	"github.com/mattermost/mattermost-load-test-ng/performance"
 
 	"github.com/gorilla/mux"
@@ -17,11 +16,10 @@ import (
 
 // api keeps track of the load-test API server state.
 type api struct {
-	agents       map[string]*loadtest.LoadTester
-	coordinators map[string]*coordinator.Coordinator
-	metrics      *performance.Metrics
-	coordLog     *mlog.Logger
-	agentLog     *mlog.Logger
+	resources sync.Map
+	metrics   *performance.Metrics
+	coordLog  *mlog.Logger
+	agentLog  *mlog.Logger
 }
 
 func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
@@ -42,11 +40,9 @@ func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {
 // Custom loggers for coordinator and agent are given.
 func SetupAPIRouter(coordLog, agentLog *mlog.Logger) *mux.Router {
 	a := api{
-		agents:       make(map[string]*loadtest.LoadTester),
-		coordinators: make(map[string]*coordinator.Coordinator),
-		metrics:      performance.NewMetrics(),
-		coordLog:     coordLog,
-		agentLog:     agentLog,
+		metrics:  performance.NewMetrics(),
+		coordLog: coordLog,
+		agentLog: agentLog,
 	}
 
 	router := mux.NewRouter()


### PR DESCRIPTION
#### Summary

PR makes concurrent access to API server's resources safe by storing them in a `sync.Map`.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26218