### PR TITLE
[MM-26561] Implement loadtest status command

### DIFF
--- a/cmd/ltctl/loadtest.go
+++ b/cmd/ltctl/loadtest.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator"
+	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
+
+	"github.com/spf13/cobra"
+)
+
+func RunLoadTestStartCmdF(cmd *cobra.Command, args []string) error {
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	t := terraform.New(config)
+	defer t.Cleanup()
+	return t.StartCoordinator()
+}
+
+func RunLoadTestStopCmdF(cmd *cobra.Command, args []string) error {
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	t := terraform.New(config)
+	defer t.Cleanup()
+	return t.StopCoordinator()
+}
+
+func printCoordinatorStatus(status *coordinator.Status) {
+	fmt.Println("==================================================")
+	fmt.Println("load-test status:")
+	fmt.Println("")
+	fmt.Println("State:", status.State)
+	fmt.Println("Start time:", status.StartTime.Format(time.UnixDate))
+	if status.State == coordinator.Done {
+		fmt.Println("Stop time:", status.StopTime.Format(time.UnixDate))
+		fmt.Println("Duration:", status.StopTime.Sub(status.StartTime).Round(time.Second))
+	}
+	fmt.Println("Active users:", status.ActiveUsers)
+	fmt.Println("Number of errors:", status.NumErrors)
+	if status.State == coordinator.Done {
+		fmt.Println("Supported users:", status.SupportedUsers)
+	}
+	fmt.Println("==================================================")
+}
+
+func RunLoadTestStatusCmdF(cmd *cobra.Command, args []string) error {
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	t := terraform.New(config)
+	defer t.Cleanup()
+
+	status, err := t.GetCoordinatorStatus()
+	if err != nil {
+		return err
+	}
+
+	printCoordinatorStatus(status)
+
+	return nil
+}

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -37,17 +37,6 @@ func RunDestroyCmdF(cmd *cobra.Command, args []string) error {
 	return t.Destroy()
 }
 
-func RunStartCmdF(cmd *cobra.Command, args []string) error {
-	config, err := getConfig(cmd)
-	if err != nil {
-		return err
-	}
-
-	t := terraform.New(config)
-	defer t.Cleanup()
-	return t.StartCoordinator()
-}
-
 func RunInfoCmdF(cmd *cobra.Command, args []string) error {
 	config, err := getConfig(cmd)
 	if err != nil {
@@ -56,17 +45,6 @@ func RunInfoCmdF(cmd *cobra.Command, args []string) error {
 
 	t := terraform.New(config)
 	return t.Info()
-}
-
-func RunStopCmdF(cmd *cobra.Command, args []string) error {
-	config, err := getConfig(cmd)
-	if err != nil {
-		return err
-	}
-
-	t := terraform.New(config)
-	defer t.Cleanup()
-	return t.StopCoordinator()
 }
 
 func RunSSHListCmdF(cmd *cobra.Command, args []string) error {
@@ -143,12 +121,17 @@ func main() {
 		{
 			Use:   "start",
 			Short: "Start the coordinator in the current load-test deployment",
-			RunE:  RunStartCmdF,
+			RunE:  RunLoadTestStartCmdF,
 		},
 		{
 			Use:   "stop",
 			Short: "Stop the coordinator in the current load-test deployment",
-			RunE:  RunStopCmdF,
+			RunE:  RunLoadTestStopCmdF,
+		},
+		{
+			Use:   "status",
+			Short: "Shows the status of the current load-test",
+			RunE:  RunLoadTestStatusCmdF,
 		},
 	}
 

--- a/coordinator/cluster/status.go
+++ b/coordinator/cluster/status.go
@@ -4,6 +4,6 @@
 package cluster
 
 type Status struct {
-	ActiveUsers int
-	NumErrors   int64
+	ActiveUsers int   // Total number of currently active users across the load-test agents cluster.
+	NumErrors   int64 // Total number of errors received from the load-test agents cluster.
 }

--- a/coordinator/status.go
+++ b/coordinator/status.go
@@ -53,10 +53,18 @@ func (s *State) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON returns a JSON representation from a State variable.
 func (s State) MarshalJSON() ([]byte, error) {
+	val, err := s.stateToString()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(val)
+}
+
+func (s State) stateToString() (string, error) {
 	var res string
 	switch s {
 	default:
-		return nil, ErrInvalidState
+		return "", ErrInvalidState
 	case Stopped:
 		res = "stopped"
 	case Running:
@@ -64,14 +72,20 @@ func (s State) MarshalJSON() ([]byte, error) {
 	case Done:
 		res = "done"
 	}
+	return res, nil
+}
 
-	return json.Marshal(res)
+func (s State) String() string {
+	res, _ := s.stateToString()
+	return res
 }
 
 // Status contains various information about Coordinator.
 type Status struct {
-	State       State     // State of Coordinator.
-	StartTime   time.Time // Time when Coordinator was started.
-	ActiveUsers int       // Total number of currently active users across the load-test agents cluster.
-	NumErrors   int64     // Total number of errors received from the load-test agents cluster.
+	State          State     // State of Coordinator.
+	StartTime      time.Time // Time when Coordinator has started.
+	StopTime       time.Time // Time when Coordinator has stopped.
+	ActiveUsers    int       // Total number of currently active users across the load-test agents cluster.
+	NumErrors      int64     // Total number of errors received from the load-test agents cluster.
+	SupportedUsers int       // Number of supported users.
 }

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -28,11 +29,11 @@ func (t *Terraform) StartCoordinator() error {
 	}
 
 	if len(output.Instances.Value) == 0 {
-		return fmt.Errorf("there are no app server instances to run the load-test")
+		return errors.New("there are no app server instances to run the load-test")
 	}
 
 	if len(output.Agents.Value) == 0 {
-		return fmt.Errorf("there are no agent instances to run the coordinator")
+		return errors.New("there are no agent instances to run the coordinator")
 	}
 	ip := output.Agents.Value[0].PublicIP
 
@@ -166,7 +167,7 @@ func (t *Terraform) StopCoordinator() error {
 	}
 
 	if len(output.Agents.Value) == 0 {
-		return fmt.Errorf("there are no agents to initialize load-test")
+		return errors.New("there are no agents to initialize load-test")
 	}
 	ip := output.Agents.Value[0].PublicIP
 
@@ -206,7 +207,7 @@ func (t *Terraform) GetCoordinatorStatus() (*coordinator.Status, error) {
 	}
 
 	if len(output.Agents.Value) == 0 {
-		return nil, fmt.Errorf("there are no agents to initialize load-test")
+		return nil, errors.New("there are no agents to initialize load-test")
 	}
 	ip := output.Agents.Value[0].PublicIP
 
@@ -226,7 +227,7 @@ func (t *Terraform) GetCoordinatorStatus() (*coordinator.Status, error) {
 	}
 
 	if res.Error != "" {
-		return nil, fmt.Errorf(res.Error)
+		return nil, errors.New(res.Error)
 	}
 
 	return res.Status, nil

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -195,7 +195,7 @@ func (t *Terraform) StopCoordinator() error {
 }
 
 // GetCoordinatorStatus returns information about the status of the
-// coordinatore in the current load-test deployment.
+// coordinator in the current load-test deployment.
 func (t *Terraform) GetCoordinatorStatus() (*coordinator.Status, error) {
 	if err := t.preFlightCheck(); err != nil {
 		return nil, err


### PR DESCRIPTION
#### Summary

PR adds a `ltctl loadtest status` command that shows the status of the current load-test, if any.
It essentially removes the need to go through coordinator's logs to figure out what's going on.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26561
