### PR TITLE
[MM-24654] Make docs more explicit

### DIFF
--- a/docs/deployer_config.md
+++ b/docs/deployer_config.md
@@ -119,7 +119,9 @@ The password to connect to the database.
 
 *string*
 
-The URL from where to download Mattermost release. This can also point to a local binary path if the user wants to run a load-test on a custom server build. The path should be prefixed with `file://` and point to the binary of the server (e.g. `file:///home/user/go/src/github.com/mattermost/mattermost-server/bin/mattermost`). Only the binary gets replaced, and the rest of the build comes from the latest stable release.
+The URL from where to download Mattermost release. This can also point to a local binary path if the user wants to run a load-test on a custom server build.  
+The path should be prefixed with `file://` and point to the binary of the server (e.g. `file:///home/user/go/src/github.com/mattermost/mattermost-server/bin/mattermost`).  
+Only the binary gets replaced, and the rest of the build comes from the latest stable release.
 
 ## MattermostLicenseFile
 

--- a/docs/deployer_config.md
+++ b/docs/deployer_config.md
@@ -119,7 +119,7 @@ The password to connect to the database.
 
 *string*
 
-The URL from where to download Mattermost release. This can also point to a local binary path if the user wants to run a load-test on a custom build. The path should be prefixed with `file://`. In that case, only the binary gets replaced, and the rest of the build comes from the latest stable release.
+The URL from where to download Mattermost release. This can also point to a local binary path if the user wants to run a load-test on a custom server build. The path should be prefixed with `file://` and point to the binary of the server (e.g. `file:///home/user/go/src/github.com/mattermost/mattermost-server/bin/mattermost`). Only the binary gets replaced, and the rest of the build comes from the latest stable release.
 
 ## MattermostLicenseFile
 


### PR DESCRIPTION
#### Summary

PR makes more explicit the fact that when using `file://` we only replace the server's binary and not the full build.

#### Ticket

https://mattermost.atlassian.net/browse/MM-24654