### PR TITLE
[MM-23914] Prefer errors.New over fmt.Errorf for simple strings

### DIFF
--- a/cmd/ltctl/collect.go
+++ b/cmd/ltctl/collect.go
@@ -136,7 +136,7 @@ func createClients(output *terraform.Output) (map[string]*ssh.Client, error) {
 
 func RunCollectCmdF(cmd *cobra.Command, args []string) error {
 	if os.Getenv("SSH_AUTH_SOCK") == "" {
-		return fmt.Errorf("ssh agent not running. Please run eval \"$(ssh-agent -s)\" and then ssh-add")
+		return errors.New("ssh agent not running. Please run eval \"$(ssh-agent -s)\" and then ssh-add")
 	}
 
 	config, err := getConfig(cmd)

--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -33,7 +33,7 @@ type errorTrack struct {
 // An error is returned if the initialization fails.
 func New(config LoadAgentClusterConfig, ltConfig loadtest.Config, log *mlog.Logger) (*LoadAgentCluster, error) {
 	if log == nil {
-		return nil, fmt.Errorf("logger should not be nil")
+		return nil, errors.New("logger should not be nil")
 	}
 	if err := defaults.Validate(config); err != nil {
 		return nil, fmt.Errorf("could not validate configuration: %w", err)

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -4,6 +4,7 @@
 package coordinator
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -210,10 +211,10 @@ func (c *Coordinator) Status() Status {
 // An error is returned if the initialization fails.
 func New(config *Config, ltConfig loadtest.Config, log *mlog.Logger) (*Coordinator, error) {
 	if config == nil {
-		return nil, fmt.Errorf("coordinator: config should not be nil")
+		return nil, errors.New("coordinator: config should not be nil")
 	}
 	if log == nil {
-		return nil, fmt.Errorf("coordinator: logger should not be nil")
+		return nil, errors.New("coordinator: logger should not be nil")
 	}
 	if err := defaults.Validate(config); err != nil {
 		return nil, fmt.Errorf("could not validate configuration: %w", err)

--- a/coordinator/performance/config.go
+++ b/coordinator/performance/config.go
@@ -4,7 +4,7 @@
 package performance
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
 )
@@ -23,13 +23,13 @@ type MonitorConfig struct {
 // Returns an error if the validation fails.
 func (c MonitorConfig) IsValid() error {
 	if c.PrometheusURL == "" {
-		return fmt.Errorf("PrometheusURL cannot be empty")
+		return errors.New("PrometheusURL cannot be empty")
 	}
 	if c.UpdateIntervalMs < 1000 {
-		return fmt.Errorf("UpdateInterval cannot be less than 1000")
+		return errors.New("UpdateInterval cannot be less than 1000")
 	}
 	if len(c.Queries) == 0 {
-		return fmt.Errorf("Queries cannot be empty")
+		return errors.New("Queries cannot be empty")
 	}
 	return nil
 }

--- a/coordinator/performance/monitor.go
+++ b/coordinator/performance/monitor.go
@@ -4,6 +4,7 @@
 package performance
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -23,7 +24,7 @@ type Monitor struct {
 // NewMonitor creates and initializes a new Monitor.
 func NewMonitor(config MonitorConfig, log *mlog.Logger) (*Monitor, error) {
 	if log == nil {
-		return nil, fmt.Errorf("logger should not be nil")
+		return nil, errors.New("logger should not be nil")
 	}
 	if err := config.IsValid(); err != nil {
 		return nil, fmt.Errorf("could not validate configuration: %w", err)

--- a/defaults/validate.go
+++ b/defaults/validate.go
@@ -240,7 +240,7 @@ func validateFromOneofValues(value reflect.Value, values []string) error {
 	default:
 		return errors.New("unsupported field type for oneof validation")
 	}
-	return fmt.Errorf("value is not one of valid values")
+	return errors.New("value is not one of valid values")
 }
 
 func isAlphanumeric(s string) bool {

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -4,6 +4,7 @@
 package deployment
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -108,11 +109,11 @@ func checkPrefix(str string) bool {
 func (c *Config) validateElasticSearchConfig() error {
 	if (c.ElasticSearchSettings != ElasticSearchSettings{}) {
 		if c.ElasticSearchSettings.InstanceCount > 1 {
-			return fmt.Errorf("it is not possible to create more than 1 instance of Elasticsearch")
+			return errors.New("it is not possible to create more than 1 instance of Elasticsearch")
 		}
 
 		if c.ElasticSearchSettings.InstanceCount > 0 && c.ElasticSearchSettings.VpcID == "" {
-			return fmt.Errorf("VpcID must be set in order to create an Elasticsearch instance")
+			return errors.New("VpcID must be set in order to create an Elasticsearch instance")
 		}
 
 		domainName := c.ClusterName + "-es"

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -108,7 +109,7 @@ func (t *Terraform) configureAndRunAgents(extAgent *ssh.ExtAgent, output *Output
 
 func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, output *Output) error {
 	if len(output.Agents.Value) == 0 {
-		return fmt.Errorf("there are no agents to initialize load-test")
+		return errors.New("there are no agents to initialize load-test")
 	}
 	ip := output.Agents.Value[0].PublicIP
 	sshc, err := extAgent.NewClient(ip)

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -6,6 +6,7 @@ package terraform
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -380,7 +381,7 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 
 func (t *Terraform) preFlightCheck() error {
 	if os.Getenv("SSH_AUTH_SOCK") == "" {
-		return fmt.Errorf("ssh agent not running. Please run eval \"$(ssh-agent -s)\" and then ssh-add")
+		return errors.New("ssh agent not running. Please run eval \"$(ssh-agent -s)\" and then ssh-add")
 	}
 
 	if err := checkTerraformVersion(); err != nil {
@@ -443,7 +444,7 @@ func pingServer(addr string) error {
 	for {
 		select {
 		case <-timeout:
-			return fmt.Errorf("timeout after 30 seconds, server is not responding")
+			return errors.New("timeout after 30 seconds, server is not responding")
 		case <-time.After(3 * time.Second):
 			_, resp := client.GetPingWithServerStatus()
 			if resp.Error != nil {

--- a/deployment/terraform/ssh/ssh.go
+++ b/deployment/terraform/ssh/ssh.go
@@ -99,7 +99,7 @@ func (sshc *Client) Upload(src io.Reader, dst string, sudo bool) ([]byte, error)
 	if strings.ContainsAny(dst, `'\`) {
 		// TODO: copied from load-test repo. Need to be improved
 		// by using an actual sftp library.
-		return nil, fmt.Errorf("shell quoting not actually implemented. don't use weird paths")
+		return nil, errors.New("shell quoting not actually implemented. don't use weird paths")
 	}
 
 	sess, err := sshc.client.NewSession()
@@ -132,7 +132,7 @@ func (sshc *Client) Download(src string, dst io.Writer, sudo bool) error {
 	if strings.ContainsAny(src, `'\`) {
 		// TODO: copied from load-test repo. Need to be improved
 		// by using an actual sftp library.
-		return fmt.Errorf("shell quoting not actually implemented. don't use weird paths")
+		return errors.New("shell quoting not actually implemented. don't use weird paths")
 	}
 
 	sess, err := sshc.client.NewSession()

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -110,7 +110,7 @@ func openBrowser(url string) (err error) {
 	case "darwin":
 		err = exec.Command("open", url).Start()
 	default:
-		err = fmt.Errorf("unsupported platform")
+		err = errors.New("unsupported platform")
 	}
 	return
 }

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -239,7 +239,7 @@ func (c *SimulController) joinChannel(u user.User) control.UserActionResponse {
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	} else if team == nil {
-		return control.UserActionResponse{Err: control.NewUserError(fmt.Errorf("current team should be set"))}
+		return control.UserActionResponse{Err: control.NewUserError(errors.New("current team should be set"))}
 	}
 
 	if err := u.GetPublicChannelsForTeam(team.Id, 0, 100); err != nil {
@@ -390,7 +390,7 @@ func switchChannel(u user.User) control.UserActionResponse {
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	} else if team == nil {
-		return control.UserActionResponse{Err: control.NewUserError(fmt.Errorf("current team should be set"))}
+		return control.UserActionResponse{Err: control.NewUserError(errors.New("current team should be set"))}
 	}
 
 	channel, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf|store.SelectNotCurrent|store.SelectNotDirect|store.SelectNotGroup)
@@ -762,7 +762,7 @@ func openDirectOrGroupChannel(u user.User) control.UserActionResponse {
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	} else if team == nil {
-		return control.UserActionResponse{Err: control.NewUserError(fmt.Errorf("current team should be set"))}
+		return control.UserActionResponse{Err: control.NewUserError(errors.New("current team should be set"))}
 	}
 
 	channel, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf|store.SelectNotCurrent|store.SelectNotPublic|store.SelectNotPrivate)
@@ -819,7 +819,7 @@ func unreadCheck(u user.User) control.UserActionResponse {
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	} else if team == nil {
-		return control.UserActionResponse{Err: control.NewUserError(fmt.Errorf("current team should be set"))}
+		return control.UserActionResponse{Err: control.NewUserError(errors.New("current team should be set"))}
 	}
 
 	channel, err := u.Store().CurrentChannel()
@@ -847,7 +847,7 @@ func searchChannels(u user.User) control.UserActionResponse {
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	} else if team == nil {
-		return control.UserActionResponse{Err: control.NewUserError(fmt.Errorf("current team should be set"))}
+		return control.UserActionResponse{Err: control.NewUserError(errors.New("current team should be set"))}
 	}
 
 	channel, err := u.Store().RandomChannel(team.Id, store.SelectAny)

--- a/loadtest/control/simulcontroller/websocket.go
+++ b/loadtest/control/simulcontroller/websocket.go
@@ -32,7 +32,7 @@ func (c *SimulController) wsEventHandler(wg *sync.WaitGroup) {
 		case model.WEBSOCKET_EVENT_TYPING:
 			userId, ok := ev.GetData()["user_id"].(string)
 			if !ok || userId == "" {
-				c.status <- c.newErrorStatus(fmt.Errorf("simulcontroller: invalid data found in event data"))
+				c.status <- c.newErrorStatus(errors.New("simulcontroller: invalid data found in event data"))
 				break
 			}
 			user, err := c.user.Store().GetUser(userId)

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -25,7 +25,7 @@ const (
 func (ue *UserEntity) handleReactionEvent(ev *model.WebSocketEvent) error {
 	var data string
 	if el, ok := ev.Data["reaction"]; !ok {
-		return fmt.Errorf("reaction data is missing")
+		return errors.New("reaction data is missing")
 	} else if data, ok = el.(string); !ok {
 		return fmt.Errorf("type of the reaction data should be a string, but it is %T", el)
 	}
@@ -57,7 +57,7 @@ func (ue *UserEntity) handleReactionEvent(ev *model.WebSocketEvent) error {
 		if ok, err := ue.store.DeleteReaction(reaction); err != nil {
 			return err
 		} else if !ok {
-			return fmt.Errorf("could not find reaction in the store")
+			return errors.New("could not find reaction in the store")
 		}
 	}
 
@@ -67,7 +67,7 @@ func (ue *UserEntity) handleReactionEvent(ev *model.WebSocketEvent) error {
 func (ue *UserEntity) handlePostEvent(ev *model.WebSocketEvent) error {
 	var data string
 	if el, ok := ev.Data["post"]; !ok {
-		return fmt.Errorf("post data is missing")
+		return errors.New("post data is missing")
 	} else if data, ok = el.(string); !ok {
 		return fmt.Errorf("type of the post data should be a string, but it is %T", el)
 	}
@@ -195,7 +195,7 @@ func getWaitTime(failCount int) time.Duration {
 // who are in the specified channel.
 func (ue *UserEntity) SendTypingEvent(channelId, parentId string) error {
 	if !ue.connected {
-		return fmt.Errorf("user is not connected")
+		return errors.New("user is not connected")
 	}
 	ue.wsTyping <- userTypingMsg{
 		channelId,


### PR DESCRIPTION
#### Summary

Courtesy of:

```sh
for file in $(rg "fmt.Errorf\(\".+\"\)" -l); do sed -r -i "s/fmt.Errorf\((\".+\")\)/errors.New(\1)/g" $file; done;
```

#### Ticket

https://mattermost.atlassian.net/browse/MM-23914

