### PR TITLE
[MM-26690] Fix deadlock in SendTypingEvent

### DIFF
--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -119,6 +119,8 @@ func (ue *UserEntity) listen(errChan chan error) {
 			errChan <- fmt.Errorf("userentity: websocketClient creation error: %w", err)
 			connectionFailCount++
 			select {
+			// Draining the channel to avoid blocking the sender.
+			case <-ue.wsTyping:
 			case <-ue.wsClosing:
 				// Explicit disconnect. Return.
 				close(ue.wsClosed)
@@ -168,6 +170,8 @@ func (ue *UserEntity) listen(errChan chan error) {
 
 		connectionFailCount++
 		select {
+		// Draining the channel to avoid blocking the sender.
+		case <-ue.wsTyping:
 		case <-ue.wsClosing:
 			// Explicit disconnect. Return.
 			close(ue.wsClosed)


### PR DESCRIPTION
#### Summary

PR fixes a deadlock in which `userentity.SendTypingEvent()` would block until a websocket connection was established.
It's not a new one but simply required ws connections to fail in order to trigger. I've reproduced it by using a wrong ws connection URL. 
I believe this is what happened during our recent Cloud test when I had to forcefully restart the API server.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26690
