### PR TITLE
[MM-26443] Implement loadtest reset command

### DIFF
--- a/cmd/ltctl/collect.go
+++ b/cmd/ltctl/collect.go
@@ -151,7 +151,7 @@ func RunCollectCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if output.HasAppServers() {
+	if !output.HasAppServers() {
 		return errors.New("no active deployment found")
 	}
 

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -133,6 +133,11 @@ func main() {
 			Short: "Shows the status of the current load-test",
 			RunE:  RunLoadTestStatusCmdF,
 		},
+		{
+			Use:   "reset",
+			Short: "Reset and re-initialize target instance database",
+			RunE:  RunResetCmdF,
+		},
 	}
 
 	loadtestCmd.AddCommand(loadtestComands...)

--- a/cmd/ltctl/report.go
+++ b/cmd/ltctl/report.go
@@ -60,7 +60,7 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 		var confirm string
 		fmt.Scanln(&confirm)
 		if !regexp.MustCompile(`(?i)^(y|yes)?$`).MatchString(confirm) {
-			return errors.New("incorrect response")
+			return nil
 		}
 	}
 

--- a/cmd/ltctl/reset.go
+++ b/cmd/ltctl/reset.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
+	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
+
+	"github.com/spf13/cobra"
+)
+
+func RunResetCmdF(cmd *cobra.Command, args []string) error {
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		return errors.New("ssh agent not running. Please run eval \"$(ssh-agent -s)\" and then ssh-add")
+	}
+
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	output, err := terraform.New(config).Output()
+	if err != nil {
+		return fmt.Errorf("could not parse output: %w", err)
+	}
+
+	if !output.HasAppServers() {
+		return errors.New("no active deployment found")
+	}
+
+	extAgent, err := ssh.NewAgent()
+	if err != nil {
+		return err
+	}
+
+	appClient, err := extAgent.NewClient(output.Instances.Value[0].PublicIP)
+	if err != nil {
+		return fmt.Errorf("error in getting ssh connection %w", err)
+	}
+
+	agentClient, err := extAgent.NewClient(output.Agents.Value[0].PublicIP)
+	if err != nil {
+		return fmt.Errorf("error in getting ssh connection %w", err)
+	}
+
+	fmt.Println("Are you sure you want to delete everything? All data will be permanently deleted? [y/N]")
+	var confirm string
+	fmt.Scanln(&confirm)
+	if !regexp.MustCompile(`(?i)^(y|yes){1}?$`).MatchString(confirm) {
+		return nil
+	}
+
+	binaryPath := "/opt/mattermost/bin/mattermost"
+
+	cmds := []struct {
+		msg    string
+		value  string
+		client *ssh.Client
+	}{
+		{
+			msg:    "Resetting database",
+			value:  fmt.Sprintf("%s reset --confirm", binaryPath),
+			client: appClient,
+		},
+		{
+			msg: "Creating sysadmin",
+			value: fmt.Sprintf("%s user create --email %s --username %s --password '%s' --system_admin",
+				binaryPath, config.AdminEmail, config.AdminUsername, config.AdminPassword),
+			client: appClient,
+		},
+		{
+			msg:    "Initializing data",
+			value:  fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s'", output.Agents.Value[0].Tags.Name),
+			client: agentClient,
+		},
+	}
+
+	for _, c := range cmds {
+		fmt.Printf(c.msg)
+		if _, err := c.client.RunCommand(c.value); err != nil {
+			return fmt.Errorf("failed to run cmd %q: %w", c.value, err)
+		}
+		fmt.Println(" done")
+	}
+
+	return nil
+}

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -6,7 +6,6 @@ package terraform
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -113,7 +112,7 @@ Do you want to proceed ? (Y/n).`, maxSupportedVersion, version))
 		var confirm string
 		fmt.Scanln(&confirm)
 		if !regexp.MustCompile(`(?i)^(y|yes)?$`).MatchString(confirm) {
-			return errors.New("incorrect response")
+			return nil
 		}
 	}
 

--- a/docs/terraform_loadtest.md
+++ b/docs/terraform_loadtest.md
@@ -107,6 +107,14 @@ go run ./cmd/ltctl loadtest stop
 
 This will stop the currently running load-test.
 
+### Re-initialize a load-test
+
+```sh
+go run ./cmd/ltctl loadtest reset
+```
+
+This will completely erase data on the target instance's database and will run again the init process.
+
 ### Destroy the current deployment
 
 When done with a deployment, it's suggested to run:
@@ -116,3 +124,4 @@ go run ./cmd/ltctl deployment destroy
 ```
 
 This will permanently destroy all resources for the current deployment.
+


### PR DESCRIPTION
#### Summary

PR adds a `loadtest reset` command to `ltctl` to help resetting the target instance's db and re-initialize the data.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26443
