### PR TITLE
[MM-26694] loadtest: remove idle users after loadtester has stopped

### DIFF
--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -214,6 +214,7 @@ func (lt *LoadTester) Stop() error {
 
 	lt.wg.Wait()
 	close(lt.statusChan)
+	lt.idleControllers = make([]control.UserController, 0)
 	lt.status.NumUsers = 0
 	lt.status.State = Stopped
 	return nil


### PR DESCRIPTION
#### Summary
This PR adds a reset to idle controllers after stopping the `LoadTester`. My initial idea was to keep them for reuse at re-running but it was going to add too much of complexity to keep alive the `statusChan`. If it is required I probably have a branch for that :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26694

