### PR TITLE
[MM-23496] Fix race conditions when creating/destroying API resources

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -96,11 +96,11 @@ func (a *api) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 	agentId := r.FormValue("id")
 	if val, ok := a.getResource(agentId); ok && val != nil {
 		if _, ok := val.(*loadtest.LoadTester); ok {
-			writeAgentResponse(w, http.StatusBadRequest, &client.AgentResponse{
+			writeAgentResponse(w, http.StatusConflict, &client.AgentResponse{
 				Error: fmt.Sprintf("load-test agent with id %s already exists", agentId),
 			})
 		} else {
-			writeAgentResponse(w, http.StatusBadRequest, &client.AgentResponse{
+			writeAgentResponse(w, http.StatusConflict, &client.AgentResponse{
 				Error: fmt.Sprintf("resource with id %s already exists", agentId),
 			})
 		}
@@ -117,7 +117,7 @@ func (a *api) createLoadAgentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if ok := a.setResource(agentId, lt); !ok {
-		writeAgentResponse(w, http.StatusBadRequest, &client.AgentResponse{
+		writeAgentResponse(w, http.StatusConflict, &client.AgentResponse{
 			Error: fmt.Sprintf("resource with id %s already exists", agentId),
 		})
 		return

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -77,7 +77,7 @@ func TestAgentAPI(t *testing.T) {
 			JSON().Object().NotContainsKey("error")
 
 		obj = e.POST("/create").WithQuery("id", ltId).WithJSON(rd).
-			Expect().Status(http.StatusBadRequest).
+			Expect().Status(http.StatusConflict).
 			JSON().Object().ContainsKey("error")
 		rawMsg = obj.Value("error").String().Raw()
 		require.Equal(t, fmt.Sprintf("load-test agent with id %s already exists", ltId), rawMsg)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	agentClient "github.com/mattermost/mattermost-load-test-ng/api/client/agent"
+	coordClient "github.com/mattermost/mattermost-load-test-ng/api/client/coordinator"
+	"github.com/mattermost/mattermost-load-test-ng/coordinator"
+	"github.com/mattermost/mattermost-load-test-ng/defaults"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
+
+	"github.com/stretchr/testify/require"
+)
+
+// concurrency level
+const n = 8
+
+func TestAgentClientConcurrency(t *testing.T) {
+	// create http.Handler
+	handler := SetupAPIRouter(logger.New(&logger.Settings{}), logger.New(&logger.Settings{}))
+
+	// run server using httptest
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	var wg sync.WaitGroup
+
+	t.Run("create", func(t *testing.T) {
+		wg.Add(n)
+		id := "test"
+		var success int
+		var ltConfig loadtest.Config
+		var ucConfig simulcontroller.Config
+		defaults.Set(&ltConfig)
+		defaults.Set(&ucConfig)
+		agent, err := agentClient.New(id, server.URL, nil)
+		require.NoError(t, err)
+		require.NotNil(t, agent)
+		for i := 0; i < n; i++ {
+			go func() {
+				if _, err := agent.Create(&ltConfig, &ucConfig); err == nil {
+					success += 1
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		// Only the one attempt should have succeeded.
+		require.Equal(t, 1, success)
+
+		_, err = agent.Run()
+		require.NoError(t, err)
+		_, err = agent.AddUsers(10)
+		require.NoError(t, err)
+
+		success = 0
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				_, err := agent.Destroy()
+				if err == nil {
+					success += 1
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		// Only the one attempt should have succeeded.
+		require.Equal(t, 1, success)
+	})
+
+	t.Run("create/destroy", func(t *testing.T) {
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func(id string) {
+				agent := createAgent(t, id, server.URL)
+				require.Equal(t, id, agent.Id())
+				_, err := agent.Destroy()
+				require.NoError(t, err)
+				wg.Done()
+			}(fmt.Sprintf("agent-%d", i))
+		}
+		wg.Wait()
+	})
+
+	t.Run("run/stop", func(t *testing.T) {
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func(id string) {
+				agent := createAgent(t, id, server.URL)
+				require.Equal(t, id, agent.Id())
+				st, err := agent.Run()
+				require.NoError(t, err)
+				require.Equal(t, loadtest.Running, st.State)
+				time.Sleep(100 * time.Millisecond)
+				st, err = agent.Stop()
+				require.NoError(t, err)
+				require.Equal(t, loadtest.Stopped, st.State)
+				st, err = agent.Run()
+				require.NoError(t, err)
+				require.Equal(t, loadtest.Running, st.State)
+				time.Sleep(100 * time.Millisecond)
+				st, err = agent.Stop()
+				require.NoError(t, err)
+				require.Equal(t, loadtest.Stopped, st.State)
+				wg.Done()
+			}(fmt.Sprintf("agent-%d", i))
+		}
+		wg.Wait()
+	})
+
+	t.Run("status", func(t *testing.T) {
+		id := "test"
+		agent := createAgent(t, id, server.URL)
+		require.Equal(t, id, agent.Id())
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				st, err := agent.Status()
+				require.NoError(t, err)
+				require.Empty(t, st)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		_, err := agent.Destroy()
+		require.NoError(t, err)
+	})
+
+	t.Run("add/rm users", func(t *testing.T) {
+		id := "test"
+		agent := createAgent(t, id, server.URL)
+		require.Equal(t, id, agent.Id())
+		st, err := agent.Run()
+		require.NoError(t, err)
+		require.Equal(t, loadtest.Running, st.State)
+		st, err = agent.AddUsers(n)
+		require.NoError(t, err)
+		require.Equal(t, int64(n), st.NumUsers)
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			if i%2 == 0 {
+				go func() {
+					st, err := agent.AddUsers(2)
+					require.NoError(t, err)
+					require.NotEmpty(t, st)
+					wg.Done()
+				}()
+			} else {
+				go func() {
+					st, err := agent.RemoveUsers(2)
+					require.NoError(t, err)
+					require.NotEmpty(t, st)
+					wg.Done()
+				}()
+			}
+		}
+		wg.Wait()
+		_, err = agent.Destroy()
+		require.NoError(t, err)
+	})
+}
+
+func TestCoordClientConcurrency(t *testing.T) {
+	// create http.Handler
+	handler := SetupAPIRouter(logger.New(&logger.Settings{}), logger.New(&logger.Settings{}))
+
+	// run server using httptest
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	var wg sync.WaitGroup
+
+	createClient := func(t *testing.T, i int) *coordClient.Coordinator {
+		t.Helper()
+		id := fmt.Sprintf("coord-%d", i)
+		coord, err := coordClient.New(id, server.URL, nil)
+		require.NoError(t, err)
+		require.NotNil(t, coord)
+		return coord
+	}
+
+	create := func(t *testing.T, i int) *coordClient.Coordinator {
+		t.Helper()
+		coord := createClient(t, i)
+		var coordConfig coordinator.Config
+		var ltConfig loadtest.Config
+		defaults.Set(&coordConfig)
+		defaults.Set(&ltConfig)
+		coordConfig.ClusterConfig.Agents[0].Id = coord.Id() + "-agent"
+		coordConfig.ClusterConfig.Agents[0].ApiURL = server.URL
+		coordConfig.MonitorConfig.Queries[0].Description = "Query"
+		coordConfig.MonitorConfig.Queries[0].Query = "query"
+		_, err := coord.Create(&coordConfig, &ltConfig)
+		require.NoError(t, err)
+		return coord
+	}
+
+	t.Run("create/destroy", func(t *testing.T) {
+		wg.Add(n)
+		coord := createClient(t, 0)
+		var coordConfig coordinator.Config
+		var ltConfig loadtest.Config
+		defaults.Set(&coordConfig)
+		defaults.Set(&ltConfig)
+		coordConfig.ClusterConfig.Agents[0].Id = coord.Id() + "-agent"
+		coordConfig.ClusterConfig.Agents[0].ApiURL = server.URL
+		coordConfig.MonitorConfig.Queries[0].Description = "Query"
+		coordConfig.MonitorConfig.Queries[0].Query = "query"
+		var success int
+		for i := 0; i < n; i++ {
+			go func() {
+				_, err := coord.Create(&coordConfig, &ltConfig)
+				if err == nil {
+					success += 1
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		// Only the one attempt should have succeeded.
+		require.Equal(t, 1, success)
+
+		_, err := coord.Run()
+		require.NoError(t, err)
+
+		success = 0
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			go func() {
+				_, err := coord.Destroy()
+				if err == nil {
+					success += 1
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		// Only the one attempt should have succeeded.
+		require.Equal(t, 1, success)
+	})
+
+	t.Run("run/status/stop", func(t *testing.T) {
+		wg.Add(n)
+		for i := 0; i < n; i++ {
+			id := fmt.Sprintf("coord-%d", i)
+			coord := create(t, i)
+			require.Equal(t, id, coord.Id())
+			go func() {
+				st, err := coord.Run()
+				require.NoError(t, err)
+				require.Equal(t, coordinator.Running, st.State)
+				time.Sleep(100 * time.Millisecond)
+				st, err = coord.Status()
+				require.NoError(t, err)
+				require.NotEmpty(t, st)
+				st, err = coord.Stop()
+				require.NoError(t, err)
+				require.Equal(t, coordinator.Done, st.State)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -71,11 +71,11 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 	id := r.FormValue("id")
 	if val, ok := a.getResource(id); ok && val != nil {
 		if _, ok := val.(*coordinator.Coordinator); ok {
-			writeCoordinatorResponse(w, http.StatusBadRequest, &client.CoordinatorResponse{
+			writeCoordinatorResponse(w, http.StatusConflict, &client.CoordinatorResponse{
 				Error: fmt.Sprintf("load-test coordinator with id %s already exists", id),
 			})
 		} else {
-			writeCoordinatorResponse(w, http.StatusBadRequest, &client.CoordinatorResponse{
+			writeCoordinatorResponse(w, http.StatusConflict, &client.CoordinatorResponse{
 				Error: fmt.Sprintf("resource with id %s already exists", id),
 			})
 		}
@@ -93,7 +93,7 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if ok := a.setResource(id, c); !ok {
-		writeCoordinatorResponse(w, http.StatusBadRequest, &client.CoordinatorResponse{
+		writeCoordinatorResponse(w, http.StatusConflict, &client.CoordinatorResponse{
 			Error: fmt.Sprintf("resource with id %s already exists", id),
 		})
 		return

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -92,7 +92,12 @@ func (a *api) createCoordinatorHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.setResource(id, c)
+	if ok := a.setResource(id, c); !ok {
+		writeCoordinatorResponse(w, http.StatusBadRequest, &client.CoordinatorResponse{
+			Error: fmt.Sprintf("resource with id %s already exists", id),
+		})
+		return
+	}
 
 	status, err := c.Status()
 	if err != nil {
@@ -117,7 +122,14 @@ func (a *api) destroyCoordinatorHandler(w http.ResponseWriter, r *http.Request) 
 
 	_ = c.Stop() // we are ignoring the error here in case the coordinator was previously stopped
 
-	a.deleteResource(mux.Vars(r)["id"])
+	id := mux.Vars(r)["id"]
+	if ok := a.deleteResource(id); !ok {
+		writeCoordinatorResponse(w, http.StatusNotFound, &client.CoordinatorResponse{
+			Error: fmt.Sprintf("load-test coordinator with id %s not found", id),
+		})
+		return
+	}
+
 	status, err := c.Status()
 	if err != nil {
 		writeCoordinatorResponse(w, http.StatusInternalServerError, &client.CoordinatorResponse{

--- a/api/coordinator_test.go
+++ b/api/coordinator_test.go
@@ -64,7 +64,7 @@ func TestCoordinatorAPI(t *testing.T) {
 		require.Equal(t, "load-test coordinator created", rawMsg)
 
 		obj = e.POST("/create").WithQuery("id", id).WithJSON(data).
-			Expect().Status(http.StatusBadRequest).
+			Expect().Status(http.StatusConflict).
 			JSON().Object().ContainsKey("error")
 		rawMsg = obj.Value("error").String().Raw()
 		require.Equal(t, "load-test coordinator with id ltc0 already exists", rawMsg)

--- a/api/server.go
+++ b/api/server.go
@@ -30,16 +30,24 @@ func (a *api) getResource(id string) (interface{}, bool) {
 	return val, ok
 }
 
-func (a *api) setResource(id string, res interface{}) {
+func (a *api) setResource(id string, res interface{}) bool {
 	a.mut.Lock()
 	defer a.mut.Unlock()
-	a.resources[id] = res
+	if _, ok := a.resources[id]; !ok {
+		a.resources[id] = res
+		return true
+	}
+	return false
 }
 
-func (a *api) deleteResource(id string) {
+func (a *api) deleteResource(id string) bool {
 	a.mut.Lock()
 	defer a.mut.Unlock()
-	delete(a.resources, id)
+	if _, ok := a.resources[id]; ok {
+		delete(a.resources, id)
+		return true
+	}
+	return false
 }
 
 func (a *api) pprofIndexHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Summary

PR fixes a couple of high level race conditions with creating/destroying API resources:
Trying to create a resource with the same id concurrently could cause more than one to be created.

This should be the last known race condition hence closing the investigation ticket with it.

#### Example

```sh
curl -d "{\"CoordinatorConfig\": $(cat config/coordinator.json),\"LoadTestConfig\": $(cat config/config.json)}" http://localhost:4000/coordinator/create\?id\=ltc0 &
curl -d "{\"CoordinatorConfig\": $(cat config/coordinator.json),\"LoadTestConfig\": $(cat config/config.json)}" http://localhost:4000/coordinator/create\?id\=ltc0 &
curl -d "{\"CoordinatorConfig\": $(cat config/coordinator.json),\"LoadTestConfig\": $(cat config/config.json)}" http://localhost:4000/coordinator/create\?id\=ltc0 &
curl -d "{\"CoordinatorConfig\": $(cat config/coordinator.json),\"LoadTestConfig\": $(cat config/config.json)}" http://localhost:4000/coordinator/create\?id\=ltc0 &


{"id":"ltc0","message":"load-test coordinator creation failed","error":"could not create coordinator: coordinator: failed to create cluster: cluster: failed to create agent: agent: load-test agent api request error: load-test agent with id lt0 already exists"}
{"id":"ltc0","message":"load-test coordinator created","status":{"State":"stopped","StartTime":"0001-01-01T00:00:00Z","StopTime":"0001-01-01T00:00:00Z","ActiveUsers":0,"NumErrors":0,"SupportedUsers":0}}
{"id":"ltc0","message":"load-test coordinator creation failed","error":"could not create coordinator: coordinator: failed to create cluster: cluster: failed to create agent: agent: load-test agent api request error: load-test agent with id lt0 already exists"}
{"id":"ltc0","message":"load-test coordinator created","status":{"State":"stopped","StartTime":"0001-01-01T00:00:00Z","StopTime":"0001-01-01T00:00:00Z","ActiveUsers":0,"NumErrors":0,"SupportedUsers":0}}
```

#### Ticket

https://mattermost.atlassian.net/browse/MM-23496