### PR TITLE
[MM-27024] Fix some remaining flakiness

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -117,6 +117,13 @@ func main() {
 		Short: "Manage the load-test",
 	}
 
+	resetCmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset and re-initialize target instance database",
+		RunE:  RunResetCmdF,
+	}
+	resetCmd.Flags().Bool("confirm", false, "Confirm you really want to reset the database and re-initialize it.")
+
 	loadtestComands := []*cobra.Command{
 		{
 			Use:   "start",
@@ -133,11 +140,7 @@ func main() {
 			Short: "Shows the status of the current load-test",
 			RunE:  RunLoadTestStatusCmdF,
 		},
-		{
-			Use:   "reset",
-			Short: "Reset and re-initialize target instance database",
-			RunE:  RunResetCmdF,
-		},
+		resetCmd,
 	}
 
 	loadtestCmd.AddCommand(loadtestComands...)

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -28,12 +28,9 @@ The results.txt will be a markdown formatted table comparing the average and p99
 
 - Always use the same cluster setup to compare different tests.
 - Calculate the number of users required to reach an average time of at least 10ms. And then compare the tests using that number of users. Anything less than that means the DB is not being stressed well enough and can introduce a lot of noise in the results.
-- While starting another test, it is recommended to reset the DB and initialize it again to start with the exact same state as the previous test. Follow these steps to accomplish that.
+- While starting another test, it is recommended to reset the DB and initialize it again to start with the exact same state as the previous test. This can be done by running the following command:
 
-On the app server's instance, run:
-- `/opt/mattermost$ echo YES | ./bin/mattermost reset`
-- `/opt/mattermost$ ./bin/mattermost user create --email sysadmin@sample.mattermost.com --username sysadmin --password Sys@dmin-sample1 --system_admin`
-- `sudo service mattermost restart`
+```sh
+go run ./cmd/ltctl loadtest reset
+```
 
-Then on the coordinator's instance, run:
-- `/home/ubuntu/mattermost-load-test-ng$ ./bin/ltagent init`


### PR DESCRIPTION
#### Summary

PR addresses a couple of remaining issues causing sporadic errors.

- Checking for Grafana to be up before updating the preferences.
- Restarting all the MM app servers after a DB reset and wait until they are up before continuing.

As a bonus feature, PR also adds `--confirm` flag to the `reset` command.

#### Ticket

https://mattermost.atlassian.net/browse/MM-27024
