### PR TITLE
Releasing v1.0.0

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -24,7 +24,7 @@
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",
-  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v0.7.0-alpha/mattermost-load-test-ng-v0.7.0-alpha-linux-amd64.tar.gz",
+  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.0.0/mattermost-load-test-ng-v1.0.0-linux-amd64.tar.gz",
   "LogSettings": {
     "EnableConsole": true,
     "ConsoleLevel": "INFO",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	// URL from where to download load-test-ng binaries and configuration files.
 	// The configuration files provided in the package will be overridden in
 	// the deployment process.
-	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v0.5.0-alpha/mattermost-load-test-ng-v0.5.0-alpha-linux-amd64.tar.gz" validate:"url"`
+	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.0.0/mattermost-load-test-ng-v1.0.0-linux-amd64.tar.gz" validate:"url"`
 	ElasticSearchSettings ElasticSearchSettings
 	LogSettings           logger.Settings
 	Report                report.Config

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -25,7 +25,7 @@ const cmdExecTimeoutMinutes = 30
 
 const (
 	latestReleaseURL           = "https://latest.mattermost.com/mattermost-enterprise-linux"
-	defaultLoadTestDownloadURL = "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v0.7.0-alpha/mattermost-load-test-ng-v0.7.0-alpha-linux-amd64.tar.gz"
+	defaultLoadTestDownloadURL = "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.0.0/mattermost-load-test-ng-v1.0.0-linux-amd64.tar.gz"
 	filePrefix                 = "file://"
 	minSupportedVersion        = 0.12
 	maxSupportedVersion        = 0.12


### PR DESCRIPTION
#### Summary

Release **1.0.0** is up at https://github.com/mattermost/mattermost-load-test-ng/releases/tag/v1.0.0
PR updates related code references.
