### PR TITLE
Improve executable file check

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -67,6 +67,7 @@ func (t *Terraform) Create() error {
 			return err
 		}
 
+		// We make sure the file is executable by both the owner and group.
 		if info.Mode()&0110 != 0110 {
 			return fmt.Errorf("file %s has to be an executable", binaryPath)
 		}

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -67,7 +67,7 @@ func (t *Terraform) Create() error {
 			return err
 		}
 
-		if info.Mode().Perm() != 0775 {
+		if info.Mode()&0110 != 0110 {
 			return fmt.Errorf("file %s has to be an executable", binaryPath)
 		}
 


### PR DESCRIPTION
#### Summary

Executable file check suddenly failed today. My `mattermost` binary was `0755` instead of the required `0775`.
PR makes it so that we only require executable bit for owner and group to be present.