### PR TITLE
[MM-27906] Fix inconsistencies when querying metrics

### DIFF
--- a/config/coordinator.sample.json
+++ b/config/coordinator.sample.json
@@ -16,30 +16,35 @@
         "Description": "Percentage of HTTP 5xx server errors",
         "Query": "(sum(rate(mattermost_api_time_count{status_code=~\"5..\"}[1m]))/sum(rate(mattermost_api_time_count[1m])))*100",
         "Threshold": 0.025,
+        "MinIntervalSec": 60,
         "Alert": true
       },
       {
         "Description": "Average client request duration",
         "Query": "sum(rate(loadtest_http_request_time_sum[1m]))/sum(rate(loadtest_http_request_time_count[1m]))",
         "Threshold": 0.1,
+        "MinIntervalSec": 60,
         "Alert": true
       },
       {
         "Description": "99th percentile of client request duration",
         "Query": "histogram_quantile(0.99, sum(rate(loadtest_http_request_time_bucket[1m])) by (le))",
         "Threshold": 2.0,
+        "MinIntervalSec": 60,
         "Alert": true
       },
       {
         "Description": "Percentage of HTTP 5xx client errors",
         "Query": "(sum(rate(loadtest_http_errors_total{status_code=~\"5..\"}[1m]))/sum(rate(loadtest_http_request_time_count[1m])))*100",
         "Threshold": 0.025,
+        "MinIntervalSec": 60,
         "Alert": true
       },
       {
         "Description": "Percentage of client timeouts",
         "Query": "(sum(rate(loadtest_http_timeouts_total[1m]))/sum(rate(loadtest_http_request_time_count[1m]))) * 100",
         "Threshold": 0.025,
+        "MinIntervalSec": 60,
         "Alert": true
       }
     ]

--- a/coordinator/performance/prometheus/config.go
+++ b/coordinator/performance/prometheus/config.go
@@ -9,9 +9,18 @@ type Configuration struct {
 	HealthcheckUpdateIntervalInMS int    `default:"60000" validate:"range:[0,]"`
 }
 
+// Query contains the needed information to perform a query.
 type Query struct {
-	Description string  `validate:"notempty"`
-	Query       string  `validate:"notempty"`
-	Threshold   float64 `validate:"range:[0,]"`
-	Alert       bool
+	// The description for the query.
+	Description string `validate:"notempty"`
+	// The PromQL query to be run.
+	Query string `validate:"notempty"`
+	// The value over which the performance monitor will fire an alert
+	// to the coordinator's feedback loop.
+	Threshold float64 `validate:"range:[0,]"`
+	// The minimum amount of time (in seconds) that needs to have passed
+	// since the start of the monitoring process before the query can be run.
+	MinIntervalSec int `validate:"range:[0,]"`
+	// The value indicating whether or not to fire an alert.
+	Alert bool
 }


### PR DESCRIPTION
#### Summary

PR is an alternative approach to fix the issue that https://github.com/mattermost/mattermost-load-test-ng/pull/377 was addressing.

We introduce a new query specific config value `MinIntervalSec` that defines the minimum amount of time (in seconds) that needs to have passed before attempting to run the query.

#### Ticket

https://mattermost.atlassian.net/browse/MM-27906

