### PR TITLE
[MM-28497] Avoid failing if user mention cannot be autocompleted

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -803,7 +803,7 @@ func createMessage(u user.User, channel *model.Channel, isReply bool) (string, e
 		if err != nil {
 			return "", err
 		}
-		if err := emulateMention(channel.TeamId, channel.Id, user.Username, u.AutocompleteUsersInChannel); err != nil {
+		if err := emulateMention(channel.TeamId, channel.Id, user.Username, u.AutocompleteUsersInChannel); err != nil && !errors.Is(err, errNoMatch) {
 			return "", err
 		}
 		message = "@" + user.Username + " "

--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -14,6 +14,8 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 )
 
+var errNoMatch = errors.New("could not match username")
+
 // pickAction randomly selects an action from a slice of userAction with
 // probability proportional to the action's frequency.
 func pickAction(actions []userAction) (*userAction, error) {
@@ -101,7 +103,7 @@ func emulateMention(teamId, channelId, name string, auto func(teamId, channelId,
 		return resp.Err
 	}
 
-	return errors.New("could not match username")
+	return errNoMatch
 }
 
 func pickIdleTimeMs(minIdleTimeMs, avgIdleTimeMs int, rate float64) time.Duration {


### PR DESCRIPTION
#### Summary

PR fixes `SimulController.createMessage()` so that it won't fail if user mention could not be constructed.
We should still support posts with mentions of users not in the channel.

#### Ticket

https://mattermost.atlassian.net/browse/MM-28497
