### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Code specific documentation can be found on [GoDoc](https://godoc.org/github.com
 
 ## Development
 
-A sample implementation can be found in the [example](example/) folder.
+A sample implementation can be found in the [examples](examples/) folder.
 
 ## Help
 


### PR DESCRIPTION
#### Summary

Fixes a broken link to the `examples` folder.
Thanks @ahmaddanialmohd  for reporting this one :+1: 
