### PR TITLE
[MM-29276] Set correct error count when done

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -87,12 +87,19 @@ func (c *Coordinator) Run() (<-chan struct{}, error) {
 
 		defer func() {
 			c.monitor.Stop()
+			clusterStatus, err := c.cluster.Status()
+			if err != nil {
+				c.log.Error("coordinator: cluster status error:", mlog.Err(err))
+			}
 			c.cluster.Shutdown()
 			close(c.doneChan)
 			c.mut.Lock()
 			c.status.State = Done
 			c.status.SupportedUsers = supported
 			c.status.StopTime = time.Now()
+			if clusterStatus.NumErrors > 0 {
+				c.status.NumErrors = clusterStatus.NumErrors
+			}
 			c.mut.Unlock()
 		}()
 

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -911,7 +911,6 @@ func searchPosts(u user.User) control.UserActionResponse {
 		}
 		opts.In = channel.Name
 		control.EmulateUserTyping(opts.In, func(term string) control.UserActionResponse {
-			fmt.Println(term)
 			channels, err := u.AutocompleteChannelsForTeamForSearch(team.Id, term)
 			if err != nil {
 				return control.UserActionResponse{Err: control.NewUserError(err)}


### PR DESCRIPTION
#### Summary

PR fixes an issue with the coordinator failing to set the total errors count once done.
This would result in `ltctl loadtest status` showing zero errors at the end of a load-test.

#### Ticket

https://mattermost.atlassian.net/browse/MM-29276
