### PR TITLE
Force cross-compilation to fix GLIBC versions mismatch error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ all: install
 
 build-linux:
 	@echo Build Linux amd64
-	env GOOS=linux GOARCH=amd64 $(GO) build -o $(AGENT) $(AGENT_ARGS)
-	env GOOS=linux GOARCH=amd64 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
+	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(AGENT) $(AGENT_ARGS)
+	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
 
 build-osx:
 	@echo Build OSX amd64


### PR DESCRIPTION
#### Summary

Took a good look at this and while I can't explain why this issue hasn't occurred before (my local system never matched versions with the AWS AMI used to run load-tests) it seems that `CGO_ENABLED` is set to 1 by default (more info at https://golang.org/cmd/cgo/) if the host `GOOS` and `GOARCH` are the same as the target build. You can probably check it yourself by running ```GOOS=linux GOARCH=amd64 go env | grep CGO_ENABLED```.

PR forces cross-compilation by setting `CGO_ENABLED=0` which fixes the GLIBC version mismatch issue.

I've also taken a look at a couple other Golang projects and they all have this set to 0 as well when building releases.