### PR TITLE
[MM-29800] Improve load-test comparisons

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -52,12 +52,27 @@
         "Query": "avg(go_memstats_stack_inuse_bytes{instance=~\"app.*:8067\"})"
       },
       {
+        "Name": "Goroutines In Use",
+        "Query": "sum(go_goroutines{instance=~\"app.*:8067\"})"
+      {
         "Name":  "RPS",
         "Query": "sum(rate(mattermost_http_requests_total{instance=~\"app.*:8067\"}[1m]))"
       },
       {
         "Name":  "Avg Store times",
         "Query": "sum(rate(mattermost_db_store_time_sum{instance=~\"app.*:8067\"}[1m])) / sum(rate(mattermost_db_store_time_count{instance=~\"app.*:8067\"}[1m]))"
+      },
+      {
+        "Name":  "P99 Store times",
+        "Query": "histogram_quantile(0.99, sum(rate(mattermost_db_store_time_bucket[1m])) by (le))"
+      },
+      {
+        "Name":  "Avg API times",
+        "Query": "sum(rate(mattermost_api_time_sum[1m])) / sum(rate(mattermost_api_time_count[1m]))"
+      },
+      {
+        "Name":  "P99 API times",
+        "Query": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket[1m])) by (le))"
       }
     ]
   }

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -41,7 +41,7 @@
     "GraphQueries": [
       {
         "Name":  "CPU Utilization",
-        "Query": "avg(irate(mattermost_process_cpu_seconds_total{instance=~\"app.*\"}[1m])* 100)"
+        "Query": "avg(rate(mattermost_process_cpu_seconds_total{instance=~\"app.*\"}[1m])* 100)"
       },
       {
         "Name":  "Heap In Use",

--- a/coordinator/performance/prometheus/helper.go
+++ b/coordinator/performance/prometheus/helper.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	requestTimeout = 5 * time.Second
+	requestTimeout = 60 * time.Second
 )
 
 type Helper struct {

--- a/loadtest/report/output.go
+++ b/loadtest/report/output.go
@@ -251,9 +251,9 @@ func sortKeys(m map[model.LabelValue]avgp99, t sortByType, desc bool) []model.La
 			return m[labels[i]][0][0].deltaPercent < m[labels[j]][0][0].deltaPercent
 		case sortByP99:
 			return m[labels[i]][1][0].deltaPercent < m[labels[j]][1][0].deltaPercent
+		default:
+			return labels[i] < labels[j]
 		}
-
-		return labels[i] < labels[j]
 	})
 	return labels
 }


### PR DESCRIPTION
#### Summary

PR helps the performance analysis of a comparative load-test by:

- Including more insightful queries in the default config.
- Sorting the results by the amount of change (`deltaPercent`) and grouping them in improved/worsened lists.

<details><summary>Example output</summary>


### Store times avg (worsened):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| ChannelStore.UpdateLastViewedAt |  avg| 4ms| 8ms | 4ms | 114.274
| ChannelStore.IncrementMentionCount |  avg| 4ms| 8ms | 4ms | 112.415
| SessionStore.GetSessionsWithActiveDeviceIds |  avg| 1ms| 2ms | 1ms | 81.041
| PreferenceStore.Get |  avg| 1ms| 2ms | 1ms | 76.054
| TeamStore.GetByName |  avg| 1ms| 2ms | 1ms | 73.547
| PreferenceStore.GetAll |  avg| 1ms| 2ms | 1ms | 72.197
| SessionStore.GetSessionsExpired |  avg| 2ms| 3ms | 1ms | 42.930
| PostStore.GetPosts |  avg| 2ms| 3ms | 1ms | 42.376
| StatusStore.UpdateLastActivityAt |  avg| 3ms| 4ms | 1ms | 35.595
| PostStore.SearchPostsInTeamForUser |  avg| 3ms| 4ms | 1ms | 29.451
| FileInfoStore.AttachToPost |  avg| 4ms| 5ms | 1ms | 25.689
| SessionStore.UpdateLastActivityAt |  avg| 4ms| 5ms | 1ms | 24.534
| PluginStore.SetWithOptions |  avg| 4ms| 5ms | 1ms | 22.925
| SessionStore.Save |  avg| 5ms| 6ms | 1ms | 18.651
| FileInfoStore.Save |  avg| 5ms| 6ms | 1ms | 18.391
| PreferenceStore.Save |  avg| 6ms| 7ms | 1ms | 16.316
| ChannelStore.Save |  avg| 7ms| 8ms | 1ms | 14.799
| ReactionStore.Save |  avg| 7ms| 8ms | 1ms | 14.039
| ChannelStore.SaveMember |  avg| 7ms| 8ms | 1ms | 14.010
| ChannelStore.AutocompleteInTeamForSearch |  avg| 8ms| 9ms | 1ms | 12.666
| PostStore.Update |  avg| 16ms| 18ms | 2ms | 12.496
| UserStore.GetAllProfilesInChannel |  avg| 10ms| 11ms | 1ms | 9.559
| PostStore.Save |  avg| 13ms| 14ms | 1ms | 7.927
| UserStore.InvalidateProfilesInChannelCacheByUser |  avg| 16ms| 17ms | 1ms | 6.172
### Store times p99 (worsened):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| ChannelStore.UpdateLastViewedAt |  p99| 4ms| 39ms | 20ms | 105.005
| ChannelStore.IncrementMentionCount |  p99| 4ms| 39ms | 19ms | 96.203
| FileInfoStore.AttachToPost |  p99| 4ms| 34ms | 16ms | 88.293
| JobStore.Save |  p99| 3ms| 9ms | 4ms | 80.808
| ChannelStore.SearchInTeam |  p99| 2ms| 17ms | 7ms | 72.607
| ClusterDiscoveryStore.SetLastPingAt |  p99| 4ms| 35ms | 14ms | 65.882
| TeamStore.GetByName |  p99| 1ms| 8ms | 3ms | 60.290
| ChannelStore.GetChannelUnread |  p99| 1ms| 8ms | 3ms | 60.139
| StatusStore.UpdateLastActivityAt |  p99| 3ms| 19ms | 7ms | 56.411
| PostStore.GetSingle |  p99| 1ms| 9ms | 3ms | 54.402
| UserStore.GetUnreadCount |  p99| 2ms| 14ms | 5ms | 54.251
| ChannelStore.SaveMember |  p99| 7ms| 37ms | 12ms | 47.751
| ChannelStore.Save |  p99| 7ms| 36ms | 11ms | 44.556
| ChannelStore.AutocompleteInTeamForSearch |  p99| 8ms| 46ms | 14ms | 44.094
| ReactionStore.Save |  p99| 7ms| 38ms | 11ms | 40.867
| PostStore.Update |  p99| 16ms| 69ms | 20ms | 40.735
| ChannelStore.GetChannels |  p99| 2ms| 14ms | 4ms | 40.468
| PostStore.GetPostIdBeforeTime |  p99| 1ms| 7ms | 2ms | 39.421
| ChannelStore.GetAllChannelMembersForUser |  p99| 0s| 7ms | 2ms | 37.392
| UserStore.AutocompleteUsersInChannel |  p99| 6ms| 34ms | 9ms | 36.707
| ChannelMemberHistoryStore.LogJoinEvent |  p99| 3ms| 20ms | 5ms | 33.582
| ChannelStore.GetMember |  p99| 2ms| 16ms | 4ms | 33.427
| TeamStore.Get |  p99| 1ms| 8ms | 2ms | 33.148
| UserTermsOfServiceStore.GetByUser |  p99| 1ms| 8ms | 2ms | 31.561
| TeamStore.GetAllTeamPageListing |  p99| 1ms| 8ms | 2ms | 31.561
| GroupStore.AdminRoleGroupsForSyncableMember |  p99| 1ms| 8ms | 2ms | 31.534
| SessionStore.GetSessionsWithActiveDeviceIds |  p99| 1ms| 9ms | 2ms | 28.585
| PreferenceStore.Save |  p99| 6ms| 32ms | 7ms | 28.189
| TeamStore.GetTeamsByUserId |  p99| 1ms| 9ms | 2ms | 28.150
| PostStore.SearchPostsInTeamForUser |  p99| 3ms| 20ms | 4ms | 25.177
| ChannelStore.GetMemberForPost |  p99| 3ms| 20ms | 4ms | 25.062
| PostStore.GetPostIdAfterTime |  p99| 1ms| 7ms | 1ms | 17.016
| FileInfoStore.Get |  p99| 1ms| 7ms | 1ms | 16.930
| ChannelStore.SearchGroupChannels |  p99| 3ms| 21ms | 3ms | 16.438
| UserStore.Search |  p99| 4ms| 23ms | 3ms | 14.987
| SessionStore.UpdateLastActivityAt |  p99| 4ms| 23ms | 3ms | 14.971
| UserStore.GetUnreadCountForChannel |  p99| 1ms| 8ms | 1ms | 14.748
| PostStore.Save |  p99| 13ms| 56ms | 7ms | 14.345
| PreferenceStore.Get |  p99| 1ms| 8ms | 1ms | 14.235
| WebhookStore.GetOutgoingByTeam |  p99| 2ms| 16ms | 2ms | 14.179
| GroupStore.GetGroups |  p99| 1ms| 8ms | 1ms | 14.074
| StatusStore.GetByIds |  p99| 1ms| 9ms | 1ms | 13.271
| ChannelStore.GetMembersForUser |  p99| 3ms| 17ms | 2ms | 13.191
| TeamStore.GetTeamsForUser |  p99| 1ms| 9ms | 1ms | 12.605
| TeamStore.GetChannelUnreadsForAllTeams |  p99| 2ms| 9ms | 1ms | 12.580
| UserStore.InvalidateProfilesInChannelCacheByUser |  p99| 16ms| 69ms | 7ms | 11.265
| PreferenceStore.GetAll |  p99| 1ms| 10ms | 1ms | 10.996
| ChannelStore.GetPublicChannelsForTeam |  p99| 2ms| 10ms | 1ms | 10.535
| SessionStore.Save |  p99| 5ms| 25ms | 2ms | 8.811
| PostStore.Get |  p99| 4ms| 25ms | 2ms | 8.566
| PostStore.GetPosts |  p99| 2ms| 13ms | 1ms | 8.037
| PluginStore.SetWithOptions |  p99| 4ms| 23ms | 1ms | 4.462
| PostStore.GetPostsBefore |  p99| 6ms| 24ms | 1ms | 4.327
| PostStore.GetPostsAfter |  p99| 6ms| 24ms | 1ms | 4.268
| PostStore.GetPostsSince |  p99| 4ms| 25ms | 1ms | 4.102
| ThreadStore.CreateMembershipIfNeeded |  p99| 7ms| 26ms | 1ms | 4.031
| UserStore.GetAllProfilesInChannel |  p99| 10ms| 48ms | 1ms | 2.123
### Store times avg (improved):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| SessionStore.Remove |  avg| 868ms| 3ms | -865ms | -99.707
| StatusStore.SaveOrUpdate |  avg| 532ms| 6ms | -526ms | -98.792
| AuditStore.Save |  avg| 389ms| 5ms | -384ms | -98.727
| ProductNoticesStore.ClearOldNotices |  avg| 8ms| 1ms | -7ms | -85.482
| SessionStore.Get |  avg| 16ms| 8ms | -8ms | -49.532
| PostStore.AnalyticsPostCount |  avg| 20ms| 13ms | -7ms | -34.880
| ClusterDiscoveryStore.SetLastPingAt |  avg| 4ms| 3ms | -1ms | -27.940
| JobStore.UpdateStatusOptimistically |  avg| 4ms| 3ms | -1ms | -26.364
| JobStore.UpdateStatus |  avg| 5ms| 4ms | -1ms | -20.658
### Store times p99 (improved):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| StatusStore.SaveOrUpdate |  p99| 532ms| 25ms | -8.84s | -99.718
| SessionStore.Remove |  p99| 868ms| 20ms | -4.141s | -99.520
| AuditStore.Save |  p99| 389ms| 22ms | -4.212s | -99.492
| SessionStore.Get |  p99| 16ms| 51ms | -121ms | -70.349
| UserStore.GetByUsername |  p99| 2ms| 7ms | -13ms | -64.838
| UserStore.Count |  p99| 5ms| 10ms | -14ms | -58.824
| JobStore.UpdateStatus |  p99| 5ms| 10ms | -14ms | -57.732
| ProductNoticesStore.ClearOldNotices |  p99| 8ms| 5ms | -5ms | -50.251
| JobStore.GetAllByStatus |  p99| 1ms| 5ms | -5ms | -49.751
| JobStore.UpdateStatusOptimistically |  p99| 4ms| 5ms | -4ms | -43.243
| ChannelStore.GetByName |  p99| 1ms| 9ms | -1ms | -10.215
| UserStore.GetAllProfiles |  p99| 4ms| 16ms | -1ms | -5.732
| UserStore.GetProfilesInChannel |  p99| 3ms| 17ms | -1ms | -5.690
| UserStore.GetProfilesByUsernames |  p99| 4ms| 21ms | -1ms | -4.638
| UserStore.UpdateFailedPasswordAttempts |  p99| 4ms| 21ms | -1ms | -4.537
| ChannelStore.CreateDirectChannel |  p99| 12ms| 46ms | -1ms | -2.134
### API times avg (worsened):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| getTeamsForUser |  avg| 0s| 2ms | 1ms | 73.292
| getTeamMembersForUser |  avg| 0s| 2ms | 1ms | 72.255
| getPreferences |  avg| 0s| 2ms | 1ms | 69.032
| viewChannel |  avg| 0s| 14ms | 5ms | 58.532
| searchGroupChannels |  avg| 0s| 4ms | 1ms | 30.885
| getFileThumbnail |  avg| 0s| 5ms | 1ms | 23.527
| getUsers |  avg| 0s| 5ms | 1ms | 22.294
| createPost |  avg| 0s| 54ms | 7ms | 14.981
| autocompleteChannelsForTeamForSearch |  avg| 0s| 9ms | 1ms | 12.560
| patchPost |  avg| 0s| 30ms | 3ms | 11.114
| saveReaction |  avg| 0s| 13ms | 1ms | 8.451
| getPostsForChannelAroundLastUnread |  avg| 0s| 14ms | 1ms | 7.756
| uploadFileStream |  avg| 0s| 30ms | 2ms | 7.069
| createGroupChannel |  avg| 0s| 189ms | 8ms | 4.419
| addChannelMember |  avg| 0s| 169ms | 5ms | 3.047
| login |  avg| 0s| 111ms | 3ms | 2.780
| createDirectChannel |  avg| 0s| 154ms | 3ms | 1.983
### API times p99 (worsened):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| searchChannelsForTeam |  p99| 0s| 18ms | 8ms | 81.772
| getChannelMember |  p99| 0s| 15ms | 6ms | 68.124
| getChannelUnread |  p99| 0s| 8ms | 3ms | 60.139
| viewChannel |  p99| 0s| 59ms | 21ms | 55.520
| getChannelsForTeamForUser |  p99| 0s| 15ms | 5ms | 48.184
| addChannelMember |  p99| 0s| 359ms | 110ms | 44.096
| autocompleteChannelsForTeamForSearch |  p99| 0s| 46ms | 14ms | 44.094
| autocompleteUsers |  p99| 0s| 33ms | 9ms | 36.790
| getPublicChannelsForTeam |  p99| 0s| 13ms | 3ms | 31.238
| getAllTeams |  p99| 0s| 8ms | 2ms | 31.196
| updatePreferences |  p99| 0s| 36ms | 8ms | 28.385
| getTeamsForUser |  p99| 0s| 9ms | 2ms | 27.187
| getPostsForChannelAroundLastUnread |  p99| 0s| 67ms | 14ms | 26.191
| getUsersByIds |  p99| 0s| 20ms | 4ms | 25.215
| getUserStatusesByIds |  p99| 0s| 8ms | 1ms | 14.814
| getUser |  p99| 0s| 8ms | 1ms | 14.706
| getChannelMembersForUser |  p99| 0s| 18ms | 2ms | 12.900
| getTeamMembersForUser |  p99| 0s| 9ms | 1ms | 12.605
| getChannelStats |  p99| 0s| 9ms | 1ms | 12.534
| createPost |  p99| 0s| 225ms | 25ms | 12.511
| getTeamsUnreadForUser |  p99| 0s| 9ms | 1ms | 12.427
| getPreferences |  p99| 0s| 10ms | 1ms | 10.996
| patchPost |  p99| 0s| 101ms | 10ms | 10.989
| searchGroupChannels |  p99| 0s| 21ms | 2ms | 10.268
| getFileThumbnail |  p99| 0s| 23ms | 2ms | 9.337
| searchUsers |  p99| 0s| 24ms | 2ms | 9.201
| getChannel |  p99| 0s| 24ms | 2ms | 9.085
| saveReaction |  p99| 0s| 50ms | 3ms | 6.334
| createGroupChannel |  p99| 0s| 436ms | 22ms | 5.316
| getUsers |  p99| 0s| 24ms | 1ms | 4.397
| getPostsForChannel |  p99| 0s| 49ms | 2ms | 4.230
| uploadFileStream |  p99| 0s| 99ms | 4ms | 4.216
### API times avg (improved):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| logout |  avg| 0s| 14ms | -2.009s | -99.317
### API times p99 (improved):
| | | Base | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- | --- |
| logout |  p99| 0s| 47ms | -6.677s | -99.304
| searchPosts |  p99| 0s| 21ms | -1ms | -4.481
</details>

#### Ticket

https://mattermost.atlassian.net/browse/MM-29800
