### PR TITLE
Accept empty queries in coordinator's config

### DIFF
--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -74,6 +74,14 @@ func TestNew(t *testing.T) {
 	c, err = New(cfg, newLoadTestConfig(t), logger.New(&logger.Settings{}))
 	require.NoError(t, err)
 	require.NotNil(t, c)
+
+	// should also work with empty/nil queries
+	cfg = newConfig(t)
+	cfg.ClusterConfig.Agents[0].ApiURL = srv.URL
+	cfg.MonitorConfig.Queries = nil
+	c, err = New(cfg, newLoadTestConfig(t), logger.New(&logger.Settings{}))
+	require.NoError(t, err)
+	require.NotNil(t, c)
 }
 
 func TestRun(t *testing.T) {

--- a/coordinator/performance/config.go
+++ b/coordinator/performance/config.go
@@ -28,8 +28,5 @@ func (c MonitorConfig) IsValid() error {
 	if c.UpdateIntervalMs < 1000 {
 		return errors.New("UpdateInterval cannot be less than 1000")
 	}
-	if len(c.Queries) == 0 {
-		return errors.New("Queries cannot be empty")
-	}
 	return nil
 }


### PR DESCRIPTION
#### Summary

PR removes a check not allowing for an empty queries array in coordinator's config.
This was a purely config validation detail since `performance.Monitor` will simply range over the queries so it will not cause any real issue to have that empty/nil and it's something that makes sense in case of a bounded load-test where no feedback loop is needed.