### PR TITLE
[MM-30326] Fix empty StopTime in coordinator.Status

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -205,7 +205,7 @@ func (c *Coordinator) Stop() error {
 	c.status = Status{
 		State:          Done,
 		StartTime:      c.status.StartTime,
-		StopTime:       c.status.StopTime,
+		StopTime:       time.Now(),
 		ActiveUsers:    clusterStatus.ActiveUsers,
 		NumErrors:      clusterStatus.NumErrors,
 		SupportedUsers: c.status.SupportedUsers,

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -149,7 +149,7 @@ func TestStop(t *testing.T) {
 	require.Equal(t, Running, c.status.State)
 	c.mut.RUnlock()
 
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(time.Millisecond)
 
 	err = c.Stop()
 	require.NoError(t, err)

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
@@ -148,10 +149,14 @@ func TestStop(t *testing.T) {
 	require.Equal(t, Running, c.status.State)
 	c.mut.RUnlock()
 
+	time.Sleep(1 * time.Millisecond)
+
 	err = c.Stop()
 	require.NoError(t, err)
 	c.mut.RLock()
 	require.Equal(t, Done, c.status.State)
+	require.NotEmpty(t, c.status.StopTime)
+	require.True(t, c.status.StopTime.After(c.status.StartTime))
 	c.mut.RUnlock()
 
 	err = c.Stop()


### PR DESCRIPTION
#### Summary

We were failing to set the `StopTime` when the `coordinator` was explicitly stopped (e.g. during a bounded load-test).

#### Ticket

https://mattermost.atlassian.net/browse/MM-30326
