### PR TITLE
Remove final logout on SimulController stop

### DIFF
--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -66,8 +66,8 @@ func (c *SimulController) Run() {
 	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
 
 	defer func() {
-		if resp := c.logout(); resp.Err != nil {
-			c.status <- c.newErrorStatus(resp.Err)
+		if err := c.disconnect(); err != nil {
+			c.status <- c.newErrorStatus(control.NewUserError(err))
 		}
 		c.user.ClearUserData()
 		c.sendStopStatus()


### PR DESCRIPTION
#### Summary

We remove the final `logout` action when stopping a `SimulController`. 

This was causing an enormous spike in server response times which was skewing metrics and making them less readable overall.

It was originally introduced to avoid keeping many old sessions in the DB but that's not really an issue anymore since we end up resetting the DB during comparisons.
