### PR TITLE
[MM-30332] Add connected users count to coordinator status output

### DIFF
--- a/cmd/ltctl/loadtest.go
+++ b/cmd/ltctl/loadtest.go
@@ -15,6 +15,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func getUsersCount(helper *prometheus.Helper) (int, error) {
+	value, err := helper.VectorFirst("sum(mattermost_http_websockets_total)")
+	if err != nil {
+		return 0, fmt.Errorf("failed to query Prometheus: %w", err)
+	}
+	return int(value), nil
+}
+
 func getErrorsInfo(helper *prometheus.Helper, startTime time.Time) (map[string]int64, error) {
 	timeRange := int(time.Since(startTime).Round(time.Second).Seconds())
 	queries := []struct {
@@ -71,7 +79,7 @@ func RunLoadTestStopCmdF(cmd *cobra.Command, args []string) error {
 	return t.StopCoordinator()
 }
 
-func printCoordinatorStatus(status coordinator.Status, errInfo map[string]int64) {
+func printCoordinatorStatus(status coordinator.Status, errInfo map[string]int64, usersCount int) {
 	fmt.Println("==================================================")
 	fmt.Println("load-test status:")
 	fmt.Println("")
@@ -84,6 +92,7 @@ func printCoordinatorStatus(status coordinator.Status, errInfo map[string]int64)
 		fmt.Println("Running time:", time.Since(status.StartTime).Round(time.Second))
 	}
 	fmt.Println("Active users:", status.ActiveUsers)
+	fmt.Println("Connected users:", usersCount)
 	numErrs := status.NumErrors
 	if numErrs < errInfo["total"] {
 		numErrs = errInfo["total"]
@@ -130,7 +139,12 @@ func RunLoadTestStatusCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	printCoordinatorStatus(status, errInfo)
+	usersCount, err := getUsersCount(helper)
+	if err != nil {
+		return err
+	}
+
+	printCoordinatorStatus(status, errInfo, usersCount)
 
 	return nil
 }


### PR DESCRIPTION
#### Summary

PR adds a connected users count to the output of `ltctl loadtest status`. This can further help to identify possible issues with the load-test.

#### Ticket

https://mattermost.atlassian.net/browse/MM-30332
