### PR TITLE
[MM-30333] Avoid unnecessary sign-up attempts in SimulController

### DIFF
--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -76,10 +76,7 @@ func (c *SimulController) Run() {
 
 	initActions := []userAction{
 		{
-			run: control.SignUp,
-		},
-		{
-			run: c.login,
+			run: c.loginOrSignUp,
 		},
 		{
 			run: c.joinTeam,


### PR DESCRIPTION
#### Summary

PR attempts to lower the server side performance impact of the initial signup/login sequence.
This is done by first attempting a login and then try to signup if the account does not exist.
This will avoid having the server do password hashing every time a controller starts.

#### Ticket

https://mattermost.atlassian.net/browse/MM-30333
