### PR TITLE
[MM-30951] Add versioning support for SimulController actions

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -287,7 +287,7 @@ func getServerVersion(serverURL string) (string, error) {
 	}
 
 	if version == "" {
-		return version, errors.New("server version should not be empty")
+		return version, errors.New("server version is empty")
 	}
 
 	return version, nil

--- a/docs/loadtest_config.md
+++ b/docs/loadtest_config.md
@@ -58,6 +58,13 @@ A rate > 1.0 will run actions at a slower pace.
 
 Percentage is the percentage of controllers that should run with the specified rate.
 
+### ServerVersion
+
+*string*
+
+An optional MM server version to use when running actions (e.g. `5.30.0`).
+This value overrides the actual server version. If left empty, the one returned by the server is used instead.
+
 ## InstanceConfiguration
 
 ### NumTeams

--- a/examples/loadtest/samplestore/store.go
+++ b/examples/loadtest/samplestore/store.go
@@ -370,3 +370,11 @@ func (s *SampleStore) UserForPost(postId string) (string, error) {
 func (s *SampleStore) FileInfoForPost(postId string) ([]*model.FileInfo, error) {
 	return nil, nil
 }
+
+func (s *SampleStore) ServerVersion() (string, error) {
+	return "", nil
+}
+
+func (s *SampleStore) SetServerVersion(version string) error {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattermost/mattermost-load-test-ng
 go 1.12
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/fatih/color v1.9.0
 	github.com/gavv/httpexpect v2.0.0+incompatible
 	github.com/gocolly/colly/v2 v2.0.1

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -58,6 +58,10 @@ type UserControllerConfiguration struct {
 	// A Rate of 1.0 will run actions at the default pace.
 	// A Rate > 1.0 will run actions at a slower pace.
 	RatesDistribution []RatesDistribution `default_len:"1"`
+	// An optional MM server version to use when running actions (e.g. `5.30.0`).
+	// This value overrides the actual server version. If left empty,
+	// the one returned by the server is used instead.
+	ServerVersion string
 }
 
 // IsValid reports whether a given UserControllerConfiguration is valid or not.

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -22,6 +22,8 @@ import (
 type userAction struct {
 	run       control.UserAction
 	frequency int
+	// Minimum supported server version
+	minServerVersion string
 }
 
 func (c *SimulController) connect() error {

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -74,6 +74,8 @@ func (c *SimulController) Run() {
 		close(c.stoppedChan)
 	}()
 
+	serverVersion, _ := c.user.Store().ServerVersion()
+
 	initActions := []userAction{
 		{
 			run: control.SignUp,
@@ -179,6 +181,15 @@ func (c *SimulController) Run() {
 		action, err := pickAction(actions)
 		if err != nil {
 			panic(fmt.Sprintf("simulcontroller: failed to pick action %s", err.Error()))
+		}
+
+		if action.minServerVersion != "" {
+			supported, err := control.IsVersionSupported(action.minServerVersion, serverVersion)
+			if err != nil {
+				c.status <- c.newErrorStatus(err)
+			} else if !supported {
+				continue
+			}
 		}
 
 		if resp := action.run(c.user); resp.Err != nil {

--- a/loadtest/control/utils.go
+++ b/loadtest/control/utils.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/blang/semver"
 )
 
 type PostsSearchOpts struct {
@@ -40,6 +42,7 @@ var (
 	teamDisplayNameRe = regexp.MustCompile(`team[0-9]+(.*)`)
 	words             = []string{}
 	emojis            = []string{":grinning:", ":slightly_smiling_face:", ":smile:", ":sunglasses:"}
+	serverVersionRE   = regexp.MustCompile(`\d+.\d+\.\d+`)
 )
 
 // getErrOrigin returns a string indicating the location of the error that
@@ -212,4 +215,22 @@ func PickIdleTimeMs(minIdleTimeMs, avgIdleTimeMs int, rate float64) time.Duratio
 	idleTimeMs := time.Duration(math.Round(float64(idleMs) * rate))
 
 	return idleTimeMs * time.Millisecond
+}
+
+// IsVersionSupported returns whether a given version is supported
+// by the provided server version string.
+func IsVersionSupported(version, serverVersionString string) (bool, error) {
+	v, err := semver.Parse(version)
+	if err != nil {
+		return false, err
+	}
+
+	serverVersion := serverVersionRE.FindString(serverVersionString)
+
+	sv, err := semver.Parse(serverVersion)
+	if err != nil {
+		return false, err
+	}
+
+	return v.LTE(sv), nil
 }

--- a/loadtest/control/utils_test.go
+++ b/loadtest/control/utils_test.go
@@ -219,3 +219,65 @@ func TestGeneratePostsSearchTerm(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("from:user1 in:town-square on:%s one", now.Format("2006-01-02")), term)
 	})
 }
+
+func TestIsVersionSupported(t *testing.T) {
+	testCases := []struct {
+		version       string
+		serverVersion string
+		expected      bool
+		expectedErr   string
+	}{
+		{
+			version:       "",
+			serverVersion: "",
+			expected:      false,
+			expectedErr:   "Version string empty",
+		},
+		{
+			version:       "invalid",
+			serverVersion: "",
+			expected:      false,
+			expectedErr:   "No Major.Minor.Patch elements found",
+		},
+		{
+			version:       "5.30.0",
+			serverVersion: "invalid",
+			expected:      false,
+			expectedErr:   "Version string empty",
+		},
+		{
+			version:       "5.30.1",
+			serverVersion: "5.30.0",
+			expected:      false,
+			expectedErr:   "",
+		},
+		{
+			version:       "5.30.0",
+			serverVersion: "5.30.0",
+			expected:      true,
+			expectedErr:   "",
+		},
+		{
+			version:       "5.29.0",
+			serverVersion: "5.30.0",
+			expected:      true,
+			expectedErr:   "",
+		},
+		{
+			version:       "5.29.0",
+			serverVersion: "5.30.0.dev.d74e4887bd588dbe342a45c77d6dc52a.false",
+			expected:      true,
+			expectedErr:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		ok, err := IsVersionSupported(tc.version, tc.serverVersion)
+		if tc.expectedErr == "" {
+			require.Nil(t, err)
+		} else {
+			require.Equal(t, tc.expectedErr, err.Error())
+		}
+		require.Equal(t, tc.expected, ok)
+	}
+}

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -39,6 +39,7 @@ type MemStore struct {
 	currentTeam         *model.Team
 	channelViews        map[string]int64
 	profileImages       map[string]bool
+	serverVersion       string
 }
 
 // New returns a new instance of MemStore with the given config.
@@ -908,5 +909,20 @@ func (s *MemStore) SetProfileImage(userId string) error {
 	}
 
 	s.profileImages[userId] = true
+	return nil
+}
+
+// ServerVersion returns the server version string.
+func (s *MemStore) ServerVersion() (string, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.serverVersion, nil
+}
+
+// SetProfileImage sets as stored the profile image for the given user.
+func (s *MemStore) SetServerVersion(version string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.serverVersion = version
 	return nil
 }

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -113,6 +113,9 @@ type UserStore interface {
 	// PostsIdsSince returns a list of post ids for posts created
 	// after a specified timestamp in milliseconds.
 	PostsIdsSince(ts int64) ([]string, error)
+
+	// ServerVersion returns the server version string.
+	ServerVersion() (string, error)
 }
 
 // MutableUserStore is a super-set of UserStore which, apart from providing
@@ -209,4 +212,7 @@ type MutableUserStore interface {
 	// profile
 	// SetProfileImage sets as stored the profile image for the given user.
 	SetProfileImage(userId string) error
+
+	// SetServerVersion sets the server version string.
+	SetServerVersion(version string) error
 }


### PR DESCRIPTION
#### Summary

PR adds simple versioning support for `SimulController` actions.
This is done by adding a `minServerVersion` field to the user action struct and compare that with the provided server version which is either loaded from config or directly fetched from the target MM server.

#### Ticket

https://mattermost.atlassian.net/browse/MM-30951