### PR TITLE
[MM-30796] Improve automated comparison output

### DIFF
--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -90,11 +90,12 @@ func printResults(results []comparison.Result) {
 
 func writeReports(results []comparison.Result, outPath string) error {
 	for i, res := range results {
-		if res.Report != "" {
-			filePath := filepath.Join(outPath, getReportFilename(i, res))
-			if err := ioutil.WriteFile(filePath, []byte(res.Report), 0660); err != nil {
-				return err
-			}
+		if res.Report == "" {
+			continue
+		}
+		filePath := filepath.Join(outPath, getReportFilename(i, res))
+		if err := ioutil.WriteFile(filePath, []byte(res.Report), 0660); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -60,12 +60,12 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize comparison object: %w", err)
 	}
 
-	results, err := cmp.Run()
+	output, err := cmp.Run()
 	if err != nil {
 		return fmt.Errorf("failed to run comparisons: %w", err)
 	}
 
-	if err := printResults(results); err != nil {
+	if err := printResults(output.Results); err != nil {
 		return err
 	}
 

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -4,24 +4,70 @@
 package main
 
 import (
+	"archive/zip"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/comparison"
 
 	"github.com/spf13/cobra"
 )
 
-func printResults(results []comparison.Result) error {
+func createArchive(inPath, outPath string) error {
+	files, err := ioutil.ReadDir(inPath)
+	if err != nil {
+		return err
+	}
+
+	zipFile, err := os.Create(filepath.Join(outPath,
+		fmt.Sprintf("comparison_%d.zip", time.Now().Unix())))
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+	wr := zip.NewWriter(zipFile)
+	defer wr.Close()
+
+	for _, file := range files {
+		fwr, err := wr.Create(file.Name())
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Open(filepath.Join(inPath, file.Name()))
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if _, err := io.Copy(fwr, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getReportFilename(id int, res comparison.Result) string {
+	ltConfig := res.LoadTests[0].Config
+	name := fmt.Sprintf("%d_%s_%s", id, ltConfig.DBEngine, ltConfig.Type)
+	if ltConfig.Type == comparison.LoadTestTypeBounded {
+		name += fmt.Sprintf("_%d", ltConfig.NumUsers)
+	}
+	return fmt.Sprintf("report_%s.md", name)
+}
+
+func printResults(results []comparison.Result) {
 	for i, res := range results {
 		fmt.Println("==================================================")
 		fmt.Println("Comparison result:")
 		if res.Report != "" {
-			filename := fmt.Sprintf("report_%d.md", i)
-			if err := ioutil.WriteFile(filename, []byte(res.Report), 0660); err != nil {
-				return err
-			}
-			fmt.Printf("Report: %s\n", filename)
+			fmt.Printf("Report: %s\n", getReportFilename(i, res))
 		}
 		if res.DashboardURL != "" {
 			fmt.Printf("Grafana Dashboard: %s\n", res.DashboardURL)
@@ -40,6 +86,17 @@ func printResults(results []comparison.Result) error {
 		}
 		fmt.Printf("==================================================\n\n")
 	}
+}
+
+func writeReports(results []comparison.Result, outPath string) error {
+	for i, res := range results {
+		if res.Report != "" {
+			filePath := filepath.Join(outPath, getReportFilename(i, res))
+			if err := ioutil.WriteFile(filePath, []byte(res.Report), 0660); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -55,6 +112,23 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read comparison config: %w", err)
 	}
 
+	outputPath, _ := cmd.Flags().GetString("output-dir")
+	if outputPath != "" {
+		cfg.Output.GraphsPath = outputPath
+	}
+
+	archivePath := outputPath
+	archive, _ := cmd.Flags().GetBool("archive")
+	if archive {
+		dir, err := ioutil.TempDir("", "comparison")
+		if err != nil {
+			return fmt.Errorf("failed to create temp dir: %w", err)
+		}
+		defer os.RemoveAll(dir)
+		cfg.Output.GraphsPath = dir
+		outputPath = dir
+	}
+
 	cmp, err := comparison.New(cfg, deployerConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize comparison object: %w", err)
@@ -65,8 +139,27 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to run comparisons: %w", err)
 	}
 
-	if err := printResults(output.Results); err != nil {
-		return err
+	if format, _ := cmd.Flags().GetString("format"); format == "json" {
+		f, err := os.Create(filepath.Join(outputPath, "comparison.json"))
+		if err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		defer f.Close()
+
+		if err := json.NewEncoder(f).Encode(output.Results); err != nil {
+			return fmt.Errorf("failed to encode results: %w", err)
+		}
+	} else {
+		if err := writeReports(output.Results, outputPath); err != nil {
+			return fmt.Errorf("failed to write reports: %w", err)
+		}
+		printResults(output.Results)
+	}
+
+	if archive {
+		if err := createArchive(outputPath, archivePath); err != nil {
+			return fmt.Errorf("failed to create archive: %w", err)
+		}
 	}
 
 	return nil

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -236,6 +236,10 @@ func main() {
 		Short: "Run fully automated load-test comparisons",
 		RunE:  RunComparisonCmdF,
 	}
+	runComparisonCmd.Flags().Bool("archive", false, "create zip archive")
+	runComparisonCmd.Flags().StringP("output-dir", "d", "", "path to output directory")
+	runComparisonCmd.Flags().StringP("format", "f", "plain", "output format [plain, json]")
+
 	destroyComparisonCmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy the current load-test comparison environment",

--- a/comparison/config.go
+++ b/comparison/config.go
@@ -73,6 +73,8 @@ type OutputConfig struct {
 	// A boolean indicating whether to generate gnuplot graphs
 	// at the end of the comparison.
 	GenerateGraphs bool `default:"false"`
+	// An optional path indicating where to write the graphs.
+	GraphsPath string
 }
 
 // Config holds information needed perform automated load-test comparisons.

--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -22,7 +22,7 @@ func (c *Comparison) deploymentAction(action func(t *terraform.Terraform) error)
 	wg.Add(len(c.deployments))
 	errsCh := make(chan error, len(c.deployments))
 	for id, dp := range c.deployments {
-		go func(id string, dp *deploymentInfo) {
+		go func(id string, dp *deploymentConfig) {
 			defer wg.Done()
 			t := terraform.New(id, &dp.config)
 			defer t.Cleanup()

--- a/comparison/output.go
+++ b/comparison/output.go
@@ -9,9 +9,28 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/report"
 )
+
+// DeploymentInfo holds information regarding a deployment.
+type DeploymentInfo struct {
+	// Number of application instances.
+	AppInstanceCount int
+	// Type of EC2 application instances.
+	AppInstanceType string
+	// Number of load-test agent instances.
+	AgentInstanceCount int
+	// Type of EC2 load-test agent instances.
+	AgentInstanceType string
+	// Type of EC2 proxy instance.
+	ProxyInstanceType string
+	// Number of RDS nodes.
+	DBInstanceCount int
+	// Type of RDS instance.
+	DBInstanceType string
+}
 
 // LoadTestResult holds information regarding a load-test
 // performed during a comparison.
@@ -35,6 +54,25 @@ type Result struct {
 	DashboardURL string
 
 	deploymentID string
+}
+
+type Output struct {
+	// Information about the deployment in which the comparison ran.
+	DeploymentInfo DeploymentInfo
+	// A list of results.
+	Results []Result
+}
+
+func getDeploymentInfo(config *deployment.Config) DeploymentInfo {
+	return DeploymentInfo{
+		AppInstanceCount:   config.AppInstanceCount,
+		AppInstanceType:    config.AppInstanceType,
+		AgentInstanceCount: config.AgentInstanceCount,
+		AgentInstanceType:  config.AgentInstanceType,
+		ProxyInstanceType:  config.ProxyInstanceType,
+		DBInstanceCount:    config.DBInstanceCount,
+		DBInstanceType:     config.DBInstanceType,
+	}
 }
 
 func (c *Comparison) getResults(resultsCh <-chan Result) ([]Result, error) {

--- a/comparison/output.go
+++ b/comparison/output.go
@@ -6,6 +6,7 @@ package comparison
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
@@ -105,9 +106,12 @@ func (c *Comparison) getResults(resultsCh <-chan Result) ([]Result, error) {
 		if c.config.Output.GenerateReport {
 			var buf bytes.Buffer
 			opts := report.CompareOpts{
-				GenGraph:     c.config.Output.GenerateGraphs,
-				GraphsPrefix: fmt.Sprintf("%s%d_", res.deploymentID, res.LoadTests[0].loadTestID),
+				GenGraph: c.config.Output.GenerateGraphs,
+				GraphsPrefix: fmt.Sprintf("%s_%s_%d_", res.LoadTests[0].Config.DBEngine,
+					res.LoadTests[0].Config.Type, res.LoadTests[0].loadTestID),
 			}
+			opts.GraphsPrefix = filepath.Join(c.config.Output.GraphsPath, opts.GraphsPrefix)
+
 			err := report.Compare(&buf, opts, baseReport, newReport)
 			if err != nil {
 				return results, err

--- a/comparison/output.go
+++ b/comparison/output.go
@@ -105,10 +105,11 @@ func (c *Comparison) getResults(resultsCh <-chan Result) ([]Result, error) {
 
 		if c.config.Output.GenerateReport {
 			var buf bytes.Buffer
+			graphsPrefix := fmt.Sprintf("%s_%s_%d_", res.LoadTests[0].Config.DBEngine,
+				res.LoadTests[0].Config.Type, res.LoadTests[0].loadTestID)
 			opts := report.CompareOpts{
-				GenGraph: c.config.Output.GenerateGraphs,
-				GraphsPrefix: fmt.Sprintf("%s_%s_%d_", res.LoadTests[0].Config.DBEngine,
-					res.LoadTests[0].Config.Type, res.LoadTests[0].loadTestID),
+				GenGraph:     c.config.Output.GenerateGraphs,
+				GraphsPrefix: graphsPrefix,
 			}
 			opts.GraphsPrefix = filepath.Join(c.config.Output.GraphsPath, opts.GraphsPrefix)
 


### PR DESCRIPTION
#### Summary

PR improves the output of an automated comparison by adding information about the deployment used.

It also improves the `ltctl comparison run` command by:

- Providing a new `json` output format for the comparison results.
- Providing an option to output a `zip` archive with all the artifacts (graphs, reports) included.

#### Ticket

https://mattermost.atlassian.net/browse/MM-30796
