### PR TITLE
MM-31367: Support custom credential file

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -337,7 +337,7 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 	f, err := os.Open(config.UsersConfiguration.UsersFilePath)
 	if err == nil {
 		// The file is an optional parameter which may not be present.
-		// So we
+		// So we read it only if it opens successfully.
 		defer f.Close()
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -117,7 +117,11 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	lt, err := loadtest.New(config, api.NewControllerWrapper(config, &genConfig, 0, userPrefix, nil), log)
+	newC, err := api.NewControllerWrapper(config, &genConfig, 0, userPrefix, nil)
+	if err != nil {
+		return fmt.Errorf("error while creating new controller: %w", err)
+	}
+	lt, err := loadtest.New(config, newC, log)
 	if err != nil {
 		return fmt.Errorf("error while initializing loadtest: %w", err)
 	}

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -108,7 +108,11 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	lt, err := loadtest.New(config, api.NewControllerWrapper(config, ucConfig, userOffset, userPrefix, nil), log)
+	newC, err := api.NewControllerWrapper(config, ucConfig, userOffset, userPrefix, nil)
+	if err != nil {
+		return fmt.Errorf("error while creating new controller: %w", err)
+	}
+	lt, err := loadtest.New(config, newC, log)
 	if err != nil {
 		return fmt.Errorf("error while initializing loadtest: %w", err)
 	}

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -39,6 +39,7 @@
   },
   "UsersConfiguration": {
     "InitialActiveUsers": 0,
+    "UsersFilePath": "",
     "MaxActiveUsers": 2000,
     "AvgSessionsPerUser": 1
   },

--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -147,6 +147,7 @@ func (c *LoadAgentCluster) IncrementUsers(n int) error {
 	for i, inc := range dist {
 		c.log.Info("cluster: adding users to agent", mlog.Int("num_users", inc), mlog.String("agent_id", c.config.Agents[i].Id))
 		if _, err := c.agents[i].AddUsers(inc); err != nil {
+			c.log.Error("cluster: adding users failed", mlog.Err(err))
 			// Most probably the agent crashed, so we just start it again.
 			if _, err := c.agents[i].Run(); err != nil {
 				c.log.Error("agent restart failed", mlog.Err(err))

--- a/docs/loadtest_config.md
+++ b/docs/loadtest_config.md
@@ -12,7 +12,7 @@ The URL to direct the load. Should be the public facing URL of the target Matter
 
 *string*
 
-The URL to the WebSocket endpoint the users will connect to.
+The URL to the WebSocket endpoint the users will connect to.  
 In most cases this will be the same as `ServerURL` with `http` replaced with `ws` or `https` replaced with `wss`.
 
 ### AdminEmail
@@ -52,9 +52,9 @@ The distribution of action rates for running controllers.
 
 Rate is a multiplier that will affect the speed at which user actions are executed by the `UserController`.
 
-A rate < 1.0 will run actions at a faster pace.
-A rate == 1.0 will run actions at the default pace.
-A rate > 1.0 will run actions at a slower pace.
+A rate < 1.0 will run actions at a faster pace.   
+A rate == 1.0 will run actions at the default pace.    
+A rate > 1.0 will run actions at a slower pace.  
 
 Percentage is the percentage of controllers that should run with the specified rate.
 
@@ -71,7 +71,7 @@ This value overrides the actual server version. If left empty, the one returned 
 
 *int*
 
-The number of teams the target Mattermost instance should have.
+The number of teams the target Mattermost instance should have.  
 These will be created during the `init` process.
 
 ## UsersConfiguration
@@ -86,7 +86,7 @@ The amount of active users to run when the load-test starts.
 
 *string*
 
-The path to the file which contains a list of user email and passwords that will be used by the tool if set. Each line should be for a user containing an email and password separated by space. It should have enough lines to contain the maximum number of users a load-test is expected to reach.
+The path to the file which contains a list of user email and passwords that will be used by the tool if set. Each line should be for a user containing an email and password separated by space. The number of lines in the file should be at least equal to MaxActiveUsers.
 
 ### MaxActiveUsers
 

--- a/docs/loadtest_config.md
+++ b/docs/loadtest_config.md
@@ -12,7 +12,7 @@ The URL to direct the load. Should be the public facing URL of the target Matter
 
 *string*
 
-The URL to the WebSocket endpoint the users will connect to.  
+The URL to the WebSocket endpoint the users will connect to.
 In most cases this will be the same as `ServerURL` with `http` replaced with `ws` or `https` replaced with `wss`.
 
 ### AdminEmail
@@ -52,9 +52,9 @@ The distribution of action rates for running controllers.
 
 Rate is a multiplier that will affect the speed at which user actions are executed by the `UserController`.
 
-A rate < 1.0 will run actions at a faster pace.   
-A rate == 1.0 will run actions at the default pace.    
-A rate > 1.0 will run actions at a slower pace.  
+A rate < 1.0 will run actions at a faster pace.
+A rate == 1.0 will run actions at the default pace.
+A rate > 1.0 will run actions at a slower pace.
 
 Percentage is the percentage of controllers that should run with the specified rate.
 
@@ -71,7 +71,7 @@ This value overrides the actual server version. If left empty, the one returned 
 
 *int*
 
-The number of teams the target Mattermost instance should have.  
+The number of teams the target Mattermost instance should have.
 These will be created during the `init` process.
 
 ## UsersConfiguration
@@ -81,6 +81,12 @@ These will be created during the `init` process.
 *int*
 
 The amount of active users to run when the load-test starts.
+
+### UsersFilePath
+
+*string*
+
+The path to the file which contains a list of user email and passwords that will be used by the tool if set. Each line should be for a user containing an email and password separated by space. It should have enough lines to contain the maximum number of users a load-test is expected to reach.
 
 ### MaxActiveUsers
 

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -118,6 +118,10 @@ func (c *InstanceConfiguration) IsValid() error {
 
 // UsersConfiguration holds information about the users of the load-test.
 type UsersConfiguration struct {
+	// The file which contains the user emails and passwords in case the operator
+	// wants to login using a different set of credentials. This is helpful during
+	// LDAP logins.
+	UsersFilePath string
 	// The number of initial users the load-test should start with.
 	InitialActiveUsers int `default:"0" validate:"range:[0,$MaxActiveUsers]"`
 	// The maximum number of users that can be simulated by a single load-test


### PR DESCRIPTION
This extends the load-test functionality to read
user credentials from an external file and then
use them in the load-test.

This is helpful to simulate LDAP users which weren't possible
in the existing load-test framework

https://mattermost.atlassian.net/browse/MM-31367
