### PR TITLE
[MM-30334] Add file descriptors limit Sanity Check to the Agent

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -307,6 +307,8 @@ func getServerVersion(serverURL string) (string, error) {
 // NewControllerWrapper returns a constructor function used to create
 // a new UserController.
 func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{}, userOffset int, namePrefix string, metrics *performance.Metrics) (loadtest.NewController, error) {
+	maxHTTPconns := loadtest.MaxHTTPConns(config.UsersConfiguration.MaxActiveUsers)
+
 	// http.Transport to be shared amongst all clients.
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -315,9 +317,9 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
-		MaxConnsPerHost:       500,
-		MaxIdleConns:          500,
-		MaxIdleConnsPerHost:   500,
+		MaxConnsPerHost:       maxHTTPconns,
+		MaxIdleConns:          maxHTTPconns,
+		MaxIdleConnsPerHost:   maxHTTPconns,
 		ResponseHeaderTimeout: 5 * time.Second,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   1 * time.Second,

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -120,8 +120,8 @@ func TestAddUsers(t *testing.T) {
 func TestRemoveUsers(t *testing.T) {
 	log := logger.New(&ltConfig.LogSettings)
 	lt, err := New(&ltConfig, newController, log)
-	defer close(lt.statusChan)
 	require.Nil(t, err)
+	defer close(lt.statusChan)
 
 	n, err := lt.RemoveUsers(0)
 	require.Equal(t, ErrInvalidNumUsers, err)


### PR DESCRIPTION
#### Summary
Added a sanity check on `MaxActiveUsers` with `Rlimit`
Fixed a `defer` bug in testing - inside `TestRemoveUsers`
Changed the static `max connections in HTTP pool` to be dynamic

#### Ticket Link
JIRA - https://mattermost.atlassian.net/browse/MM-30334
Closes https://github.com/mattermost/mattermost-server/issues/16284