### PR TITLE
ltctl ssh: extra targets

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -58,8 +58,9 @@ func RunSSHListCmdF(cmd *cobra.Command, args []string) error {
 	}
 	for _, instance := range output.Instances {
 		fmt.Printf(" - %s\n", instance.Tags.Name)
-
 	}
+	fmt.Printf(" - %s\n", output.Proxy.Tags.Name)
+	fmt.Printf(" - %s\n", output.MetricsServer.Tags.Name)
 	return nil
 }
 

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -68,6 +68,14 @@ func (t *Terraform) OpenSSHFor(resource string) error {
 		}
 	}
 	if cmd == nil {
+		switch resource {
+		case "proxy", output.Proxy.Tags.Name:
+			cmd = exec.Command("ssh", fmt.Sprintf("ubuntu@%s", output.Proxy.PublicIP))
+		case "metrics", "prometheus", "grafana", output.MetricsServer.Tags.Name:
+			cmd = exec.Command("ssh", fmt.Sprintf("ubuntu@%s", output.MetricsServer.PublicIP))
+		}
+	}
+	if cmd == nil {
 		return fmt.Errorf("could not find any resource with name %q", resource)
 	}
 

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -48,35 +48,9 @@ func uploadBatch(sshc *ssh.Client, batch []uploadInfo) error {
 
 // OpenSSHFor starts a ssh connection to the resource
 func (t *Terraform) OpenSSHFor(resource string) error {
-	output, err := t.Output()
+	cmd, err := t.makeCmdForResource(resource)
 	if err != nil {
-		return fmt.Errorf("could not parse output: %w", err)
-	}
-	var cmd *exec.Cmd
-	for i, agent := range output.Agents {
-		if resource == agent.Tags.Name || (i == 0 && resource == "coordinator") {
-			cmd = exec.Command("ssh", fmt.Sprintf("ubuntu@%s", agent.PublicIP))
-			break
-		}
-	}
-	if cmd == nil {
-		for _, instance := range output.Instances {
-			if resource == instance.Tags.Name {
-				cmd = exec.Command("ssh", fmt.Sprintf("ubuntu@%s", instance.PublicIP))
-				break
-			}
-		}
-	}
-	if cmd == nil {
-		switch resource {
-		case "proxy", output.Proxy.Tags.Name:
-			cmd = exec.Command("ssh", fmt.Sprintf("ubuntu@%s", output.Proxy.PublicIP))
-		case "metrics", "prometheus", "grafana", output.MetricsServer.Tags.Name:
-			cmd = exec.Command("ssh", fmt.Sprintf("ubuntu@%s", output.MetricsServer.PublicIP))
-		}
-	}
-	if cmd == nil {
-		return fmt.Errorf("could not find any resource with name %q", resource)
+		return fmt.Errorf("failed to make cmd for resource: %w", err)
 	}
 
 	cmd.Stdout = os.Stdout
@@ -87,6 +61,38 @@ func (t *Terraform) OpenSSHFor(resource string) error {
 	}
 
 	return cmd.Wait()
+}
+
+func (t *Terraform) makeCmdForResource(resource string) (*exec.Cmd, error) {
+	output, err := t.Output()
+	if err != nil {
+		return nil, fmt.Errorf("could not parse output: %w", err)
+	}
+
+	// Match against the agent names, or the reserved "coordinator" keyword referring to the
+	// first agent.
+	for i, agent := range output.Agents {
+		if resource == agent.Tags.Name || (i == 0 && resource == "coordinator") {
+			return exec.Command("ssh", fmt.Sprintf("ubuntu@%s", agent.PublicIP)), nil
+		}
+	}
+
+	// Match against the instance names.
+	for _, instance := range output.Instances {
+		if resource == instance.Tags.Name {
+			return exec.Command("ssh", fmt.Sprintf("ubuntu@%s", instance.PublicIP)), nil
+		}
+	}
+
+	// Match against the proxy or metrics servers, as well as convenient aliases.
+	switch resource {
+	case "proxy", output.Proxy.Tags.Name:
+		return exec.Command("ssh", fmt.Sprintf("ubuntu@%s", output.Proxy.PublicIP)), nil
+	case "metrics", "prometheus", "grafana", output.MetricsServer.Tags.Name:
+		return exec.Command("ssh", fmt.Sprintf("ubuntu@%s", output.MetricsServer.PublicIP)), nil
+	}
+
+	return nil, fmt.Errorf("could not find any resource with name %q", resource)
 }
 
 // OpenBrowserFor opens a web browser for the resource

--- a/docs/terraform_loadtest.md
+++ b/docs/terraform_loadtest.md
@@ -133,3 +133,12 @@ go run ./cmd/ltctl deployment destroy
 
 This will permanently destroy all resources for the current deployment.
 
+## Debugging
+
+### SSH access to the terraformed hosts
+
+To access one of the terraformed hosts via ssh, invoke `ltctl ssh` with the appropriate target:
+* One of the instance names (invoke `ltctl ssh` to list them)
+* `coordinator` to connect to the first agent doing double duty as the loadtest coordinator
+* `proxy` to connect to the instance running Nginx
+* `metrics`, `prometheus` or `grafana` to connect to the instance running all metrics related services


### PR DESCRIPTION
#### Summary
Support the following extra `ltctl ssh` targets: `loadtest-proxy` (or just `proxy`), `loadtest-metrics` (or just `metrics`, `grafana`, or `prometheus`).

#### Ticket Link
None.