### PR TITLE
[MM-32270] Limit terraform re-initialization during comparisons

### DIFF
--- a/cmd/ltctl/loadtest.go
+++ b/cmd/ltctl/loadtest.go
@@ -65,7 +65,14 @@ func RunLoadTestStartCmdF(cmd *cobra.Command, args []string) error {
 
 	t := terraform.New("", config)
 	defer t.Cleanup()
-	return t.StartCoordinator(nil)
+	if err := t.PreFlightCheck(); err != nil {
+		return err
+	}
+	output, err := t.Output()
+	if err != nil {
+		return err
+	}
+	return terraform.StartCoordinator(config, output, nil)
 }
 
 func RunLoadTestStopCmdF(cmd *cobra.Command, args []string) error {
@@ -76,7 +83,15 @@ func RunLoadTestStopCmdF(cmd *cobra.Command, args []string) error {
 
 	t := terraform.New("", config)
 	defer t.Cleanup()
-	_, err = t.StopCoordinator()
+	if err := t.PreFlightCheck(); err != nil {
+		return err
+	}
+	output, err := t.Output()
+	if err != nil {
+		return err
+	}
+
+	_, err = terraform.StopCoordinator(config, output)
 	return err
 }
 
@@ -119,12 +134,15 @@ func RunLoadTestStatusCmdF(cmd *cobra.Command, args []string) error {
 	t := terraform.New("", config)
 	defer t.Cleanup()
 
-	status, err := t.GetCoordinatorStatus()
+	if err := t.PreFlightCheck(); err != nil {
+		return err
+	}
+	output, err := t.Output()
 	if err != nil {
 		return err
 	}
 
-	output, err := t.Output()
+	status, err := terraform.GetCoordinatorStatus(config, output)
 	if err != nil {
 		return err
 	}

--- a/cmd/ltctl/loadtest.go
+++ b/cmd/ltctl/loadtest.go
@@ -65,14 +65,7 @@ func RunLoadTestStartCmdF(cmd *cobra.Command, args []string) error {
 
 	t := terraform.New("", config)
 	defer t.Cleanup()
-	if err := t.PreFlightCheck(); err != nil {
-		return err
-	}
-	output, err := t.Output()
-	if err != nil {
-		return err
-	}
-	return terraform.StartCoordinator(config, output, nil)
+	return t.StartCoordinator(nil)
 }
 
 func RunLoadTestStopCmdF(cmd *cobra.Command, args []string) error {
@@ -83,15 +76,7 @@ func RunLoadTestStopCmdF(cmd *cobra.Command, args []string) error {
 
 	t := terraform.New("", config)
 	defer t.Cleanup()
-	if err := t.PreFlightCheck(); err != nil {
-		return err
-	}
-	output, err := t.Output()
-	if err != nil {
-		return err
-	}
-
-	_, err = terraform.StopCoordinator(config, output)
+	_, err = t.StopCoordinator()
 	return err
 }
 
@@ -134,20 +119,17 @@ func RunLoadTestStatusCmdF(cmd *cobra.Command, args []string) error {
 	t := terraform.New("", config)
 	defer t.Cleanup()
 
-	if err := t.PreFlightCheck(); err != nil {
-		return err
-	}
-	output, err := t.Output()
+	status, err := t.GetCoordinatorStatus()
 	if err != nil {
 		return err
 	}
 
-	status, err := terraform.GetCoordinatorStatus(config, output)
+	tfOutput, err := t.Output()
 	if err != nil {
 		return err
 	}
 
-	prometheusURL := fmt.Sprintf("http://%s:9090", output.MetricsServer.PublicIP)
+	prometheusURL := fmt.Sprintf("http://%s:9090", tfOutput.MetricsServer.PublicIP)
 	helper, err := prometheus.NewHelper(prometheusURL)
 	if err != nil {
 		return fmt.Errorf("failed to create prometheus.Helper: %w", err)

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -15,6 +15,7 @@ import (
 )
 
 type deploymentConfig struct {
+	tfOutput  *terraform.Output
 	config    deployment.Config
 	loadTests []LoadTestConfig
 }
@@ -73,6 +74,13 @@ func (c *Comparison) Run() (Output, error) {
 		if err := t.Create(false); err != nil {
 			return err
 		}
+
+		tfOutput, err := t.Output()
+		if err != nil {
+			return err
+		}
+		dpConfig.tfOutput = tfOutput
+
 		return provisionFiles(t, dpConfig, c.config.BaseBuild.URL, c.config.NewBuild.URL)
 	})
 	if err != nil {
@@ -97,13 +105,13 @@ func (c *Comparison) Run() (Output, error) {
 				for i, buildCfg := range []BuildConfig{c.config.BaseBuild, c.config.NewBuild} {
 					mlog.Debug("initializing load-test")
 					// initialize instance state
-					if err := initLoadTest(t, &dp.config, buildCfg, dumpFilename, c.cancelCh); err != nil {
+					if err := initLoadTest(dp, buildCfg, dumpFilename, c.cancelCh); err != nil {
 						errsCh <- err
 						return
 					}
 					mlog.Debug("load-test init done")
 
-					status, err := runLoadTest(t, lt, c.cancelCh)
+					status, err := runLoadTest(dp, lt, c.cancelCh)
 					if err != nil {
 						errsCh <- err
 						return

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -15,7 +15,6 @@ import (
 )
 
 type deploymentConfig struct {
-	tfOutput  *terraform.Output
 	config    deployment.Config
 	loadTests []LoadTestConfig
 }
@@ -74,13 +73,6 @@ func (c *Comparison) Run() (Output, error) {
 		if err := t.Create(false); err != nil {
 			return err
 		}
-
-		tfOutput, err := t.Output()
-		if err != nil {
-			return err
-		}
-		dpConfig.tfOutput = tfOutput
-
 		return provisionFiles(t, dpConfig, c.config.BaseBuild.URL, c.config.NewBuild.URL)
 	})
 	if err != nil {
@@ -105,13 +97,13 @@ func (c *Comparison) Run() (Output, error) {
 				for i, buildCfg := range []BuildConfig{c.config.BaseBuild, c.config.NewBuild} {
 					mlog.Debug("initializing load-test")
 					// initialize instance state
-					if err := initLoadTest(dp, buildCfg, dumpFilename, c.cancelCh); err != nil {
+					if err := initLoadTest(t, buildCfg, dumpFilename, c.cancelCh); err != nil {
 						errsCh <- err
 						return
 					}
 					mlog.Debug("load-test init done")
 
-					status, err := runLoadTest(dp, lt, c.cancelCh)
+					status, err := runLoadTest(t, lt, c.cancelCh)
 					if err != nil {
 						errsCh <- err
 						return

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -9,27 +9,26 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
-func generateLoadtestAgentConfig(dpConfig *deployment.Config, output *Output) (*loadtest.Config, error) {
+func (t *Terraform) generateLoadtestAgentConfig() (*loadtest.Config, error) {
 	cfg, err := loadtest.ReadConfig("")
 	if err != nil {
 		return nil, err
 	}
-	url := output.Instances[0].PrivateIP + ":8065"
-	if output.HasProxy() {
-		url = output.Proxy.PrivateIP
+	url := t.output.Instances[0].PrivateIP + ":8065"
+	if t.output.HasProxy() {
+		url = t.output.Proxy.PrivateIP
 	}
 
 	cfg.ConnectionConfiguration.ServerURL = "http://" + url
 	cfg.ConnectionConfiguration.WebSocketURL = "ws://" + url
-	cfg.ConnectionConfiguration.AdminEmail = dpConfig.AdminEmail
-	cfg.ConnectionConfiguration.AdminPassword = dpConfig.AdminPassword
+	cfg.ConnectionConfiguration.AdminEmail = t.config.AdminEmail
+	cfg.ConnectionConfiguration.AdminPassword = t.config.AdminPassword
 
 	return cfg, nil
 }
@@ -118,7 +117,7 @@ func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, initData bool) error {
 		return err
 	}
 	mlog.Info("Generating load-test config")
-	cfg, err := generateLoadtestAgentConfig(t.config, t.output)
+	cfg, err := t.generateLoadtestAgentConfig()
 	if err != nil {
 		return err
 	}

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
 
-func (t *Terraform) generateLoadtestAgentConfig(output *Output) (*loadtest.Config, error) {
+func generateLoadtestAgentConfig(dpConfig *deployment.Config, output *Output) (*loadtest.Config, error) {
 	cfg, err := loadtest.ReadConfig("")
 	if err != nil {
 		return nil, err
@@ -27,8 +28,8 @@ func (t *Terraform) generateLoadtestAgentConfig(output *Output) (*loadtest.Confi
 
 	cfg.ConnectionConfiguration.ServerURL = "http://" + url
 	cfg.ConnectionConfiguration.WebSocketURL = "ws://" + url
-	cfg.ConnectionConfiguration.AdminEmail = t.config.AdminEmail
-	cfg.ConnectionConfiguration.AdminPassword = t.config.AdminPassword
+	cfg.ConnectionConfiguration.AdminEmail = dpConfig.AdminEmail
+	cfg.ConnectionConfiguration.AdminPassword = dpConfig.AdminPassword
 
 	return cfg, nil
 }
@@ -117,7 +118,7 @@ func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, output *Output, initDat
 		return err
 	}
 	mlog.Info("Generating load-test config")
-	cfg, err := t.generateLoadtestAgentConfig(output)
+	cfg, err := generateLoadtestAgentConfig(t.config, output)
 	if err != nil {
 		return err
 	}

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -23,7 +23,7 @@ func (t *Terraform) StartCoordinator(config *coordinator.Config) error {
 		return err
 	}
 
-	if _, err := t.Output(); err != nil {
+	if err := t.setOutput(); err != nil {
 		return err
 	}
 
@@ -76,7 +76,7 @@ func (t *Terraform) StartCoordinator(config *coordinator.Config) error {
 
 	var agentConfig *loadtest.Config
 	if len(t.output.Instances) > 0 {
-		agentConfig, err = generateLoadtestAgentConfig(t.config, t.output)
+		agentConfig, err = t.generateLoadtestAgentConfig()
 	} else {
 		agentConfig, err = loadtest.ReadConfig("")
 	}
@@ -152,7 +152,7 @@ func (t *Terraform) StartCoordinator(config *coordinator.Config) error {
 func (t *Terraform) StopCoordinator() (coordinator.Status, error) {
 	var status coordinator.Status
 
-	if _, err := t.Output(); err != nil {
+	if err := t.setOutput(); err != nil {
 		return status, err
 	}
 
@@ -183,7 +183,7 @@ func (t *Terraform) StopCoordinator() (coordinator.Status, error) {
 func (t *Terraform) GetCoordinatorStatus() (coordinator.Status, error) {
 	var status coordinator.Status
 
-	if _, err := t.Output(); err != nil {
+	if err := t.setOutput(); err != nil {
 		return status, err
 	}
 

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -42,9 +42,11 @@ var initMut sync.Mutex
 // Terraform manages all operations related to interacting with
 // an AWS environment using Terraform.
 type Terraform struct {
-	id     string
-	config *deployment.Config
-	dir    string
+	id          string
+	config      *deployment.Config
+	output      *Output
+	dir         string
+	initialized bool
 }
 
 // New returns a new Terraform instance.
@@ -57,7 +59,7 @@ func New(id string, cfg *deployment.Config) *Terraform {
 
 // Create creates a new load test environment.
 func (t *Terraform) Create(initData bool) error {
-	if err := t.PreFlightCheck(); err != nil {
+	if err := t.preFlightCheck(); err != nil {
 		return err
 	}
 
@@ -129,27 +131,26 @@ func (t *Terraform) Create(initData bool) error {
 		return err
 	}
 
-	output, err := t.Output()
-	if err != nil {
+	if err := t.loadOutput(); err != nil {
 		return err
 	}
 
-	if output.HasMetrics() {
+	if t.output.HasMetrics() {
 		// Setting up metrics server.
-		if err := t.setupMetrics(extAgent, output); err != nil {
+		if err := t.setupMetrics(extAgent); err != nil {
 			return fmt.Errorf("error setting up metrics server: %w", err)
 		}
 	}
 
-	if output.HasAppServers() {
-		url := output.Instances[0].PublicDNS + ":8065"
+	if t.output.HasAppServers() {
+		url := t.output.Instances[0].PublicDNS + ":8065"
 
 		// Updating the config.json for each instance of app server
-		t.setupAppServers(output, extAgent, uploadBinary, binaryPath)
-		if output.HasProxy() {
+		t.setupAppServers(extAgent, uploadBinary, binaryPath)
+		if t.output.HasProxy() {
 			// Updating the nginx config on proxy server
-			t.setupProxyServer(output, extAgent)
-			url = output.Proxy.PublicDNS
+			t.setupProxyServer(extAgent)
+			url = t.output.Proxy.PublicDNS
 		}
 
 		if err := pingServer("http://" + url); err != nil {
@@ -157,18 +158,18 @@ func (t *Terraform) Create(initData bool) error {
 		}
 
 		if initData {
-			if err := t.createAdminUser(extAgent, output); err != nil {
+			if err := t.createAdminUser(extAgent); err != nil {
 				return fmt.Errorf("could not create admin user: %w", err)
 			}
 		}
 	}
 
-	if err := t.setupLoadtestAgents(extAgent, output, initData); err != nil {
+	if err := t.setupLoadtestAgents(extAgent, initData); err != nil {
 		return fmt.Errorf("error setting up loadtest agents: %w", err)
 	}
 
 	mlog.Info("Deployment complete.")
-	t.displayInfo(output)
+	displayInfo(t.output)
 	runcmd := "go run ./cmd/ltctl"
 	if strings.HasPrefix(os.Args[0], "ltctl") {
 		runcmd = "ltctl"
@@ -177,8 +178,8 @@ func (t *Terraform) Create(initData bool) error {
 	return nil
 }
 
-func (t *Terraform) setupAppServers(output *Output, extAgent *ssh.ExtAgent, uploadBinary bool, binaryPath string) {
-	for _, val := range output.Instances {
+func (t *Terraform) setupAppServers(extAgent *ssh.ExtAgent, uploadBinary bool, binaryPath string) {
+	for _, val := range t.output.Instances {
 		ip := val.PublicIP
 		sshc, err := extAgent.NewClient(ip)
 		if err != nil {
@@ -211,7 +212,7 @@ func (t *Terraform) setupAppServers(output *Output, extAgent *ssh.ExtAgent, uplo
 			}
 
 			mlog.Info("Updating config", mlog.String("host", ip))
-			if err := t.updateAppConfig(ip, sshc, output); err != nil {
+			if err := t.updateAppConfig(ip, sshc); err != nil {
 				mlog.Error("error updating config", mlog.Err(err))
 				return
 			}
@@ -237,24 +238,24 @@ func (t *Terraform) setupAppServers(output *Output, extAgent *ssh.ExtAgent, uplo
 	}
 }
 
-func (t *Terraform) setupLoadtestAgents(extAgent *ssh.ExtAgent, output *Output, initData bool) error {
-	if err := t.configureAndRunAgents(extAgent, output); err != nil {
+func (t *Terraform) setupLoadtestAgents(extAgent *ssh.ExtAgent, initData bool) error {
+	if err := t.configureAndRunAgents(extAgent); err != nil {
 		return fmt.Errorf("error while setting up an agents: %w", err)
 	}
 
-	if !output.HasAppServers() {
+	if !t.output.HasAppServers() {
 		return nil
 	}
 
-	if err := t.initLoadtest(extAgent, output, initData); err != nil {
+	if err := t.initLoadtest(extAgent, initData); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (t *Terraform) setupProxyServer(output *Output, extAgent *ssh.ExtAgent) {
-	ip := output.Proxy.PublicDNS
+func (t *Terraform) setupProxyServer(extAgent *ssh.ExtAgent) {
+	ip := t.output.Proxy.PublicDNS
 
 	sshc, err := extAgent.NewClient(ip)
 	if err != nil {
@@ -273,7 +274,7 @@ func (t *Terraform) setupProxyServer(output *Output, extAgent *ssh.ExtAgent) {
 		mlog.Info("Uploading nginx config", mlog.String("host", ip))
 
 		backends := ""
-		for _, addr := range output.Instances {
+		for _, addr := range t.output.Instances {
 			backends += "server " + addr.PrivateIP + ":8065 max_fails=3;\n"
 		}
 
@@ -297,14 +298,14 @@ func (t *Terraform) setupProxyServer(output *Output, extAgent *ssh.ExtAgent) {
 	}()
 }
 
-func (t *Terraform) createAdminUser(extAgent *ssh.ExtAgent, output *Output) error {
+func (t *Terraform) createAdminUser(extAgent *ssh.ExtAgent) error {
 	cmd := fmt.Sprintf("/opt/mattermost/bin/mattermost user create --email %s --username %s --password %s --system_admin",
 		t.config.AdminEmail,
 		t.config.AdminUsername,
 		t.config.AdminPassword,
 	)
 	mlog.Info("Creating admin user:", mlog.String("cmd", cmd))
-	sshc, err := extAgent.NewClient(output.Instances[0].PublicIP)
+	sshc, err := extAgent.NewClient(t.output.Instances[0].PublicIP)
 	if err != nil {
 		return err
 	}
@@ -318,7 +319,7 @@ func (t *Terraform) createAdminUser(extAgent *ssh.ExtAgent, output *Output) erro
 	return nil
 }
 
-func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output) error {
+func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client) error {
 	var clusterDSN, driverName string
 	var readerDSN []string
 
@@ -326,15 +327,15 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	readerDSN = t.config.ExternalDBSettings.DataSourceReplicas
 	driverName = t.config.ExternalDBSettings.DriverName
 
-	if output.HasDB() {
+	if t.output.HasDB() {
 		switch t.config.TerraformDBSettings.InstanceEngine {
 		case "aurora-postgresql":
-			clusterDSN = "postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + output.DBCluster.ClusterEndpoint + "/" + t.config.ClusterName + "db?sslmode=disable"
-			readerDSN = []string{"postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + output.DBCluster.ReaderEndpoint + "/" + t.config.ClusterName + "db?sslmode=disable"}
+			clusterDSN = "postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + t.output.DBCluster.ClusterEndpoint + "/" + t.config.ClusterName + "db?sslmode=disable"
+			readerDSN = []string{"postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + t.output.DBCluster.ReaderEndpoint + "/" + t.config.ClusterName + "db?sslmode=disable"}
 			driverName = "postgres"
 		case "aurora-mysql":
-			clusterDSN = t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + output.DBCluster.ClusterEndpoint + ")/" + t.config.ClusterName + "db?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"
-			readerDSN = []string{t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + output.DBCluster.ReaderEndpoint + ")/" + t.config.ClusterName + "db?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"}
+			clusterDSN = t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ClusterEndpoint + ")/" + t.config.ClusterName + "db?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"
+			readerDSN = []string{t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ReaderEndpoint + ")/" + t.config.ClusterName + "db?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"}
 			driverName = "mysql"
 		}
 	}
@@ -348,15 +349,15 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	cfg.ServiceSettings.WriteTimeout = model.NewInt(60)
 	cfg.ServiceSettings.IdleTimeout = model.NewInt(90)
 	cfg.ServiceSettings.CollapsedThreads = model.NewString(model.COLLAPSED_THREADS_DEFAULT_OFF)
-	cfg.EmailSettings.SMTPServer = model.NewString(output.MetricsServer.PrivateIP)
+	cfg.EmailSettings.SMTPServer = model.NewString(t.output.MetricsServer.PrivateIP)
 	cfg.EmailSettings.SMTPPort = model.NewString("2500")
 
-	if output.HasProxy() && output.HasS3Key() && output.HasS3Bucket() {
+	if t.output.HasProxy() && t.output.HasS3Key() && t.output.HasS3Bucket() {
 		cfg.FileSettings.DriverName = model.NewString("amazons3")
-		cfg.FileSettings.AmazonS3AccessKeyId = model.NewString(output.S3Key.Id)
-		cfg.FileSettings.AmazonS3SecretAccessKey = model.NewString(output.S3Key.Secret)
-		cfg.FileSettings.AmazonS3Bucket = model.NewString(output.S3Bucket.Id)
-		cfg.FileSettings.AmazonS3Region = model.NewString(output.S3Bucket.Region)
+		cfg.FileSettings.AmazonS3AccessKeyId = model.NewString(t.output.S3Key.Id)
+		cfg.FileSettings.AmazonS3SecretAccessKey = model.NewString(t.output.S3Key.Secret)
+		cfg.FileSettings.AmazonS3Bucket = model.NewString(t.output.S3Bucket.Id)
+		cfg.FileSettings.AmazonS3Region = model.NewString(t.output.S3Bucket.Region)
 	}
 
 	cfg.LogSettings.EnableConsole = model.NewBool(true)
@@ -384,8 +385,8 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	cfg.PluginSettings.Enable = model.NewBool(true)
 	cfg.PluginSettings.EnableUploads = model.NewBool(true)
 
-	if output.HasElasticSearch() {
-		cfg.ElasticsearchSettings.ConnectionUrl = model.NewString("https://" + output.ElasticSearchServer.Endpoint)
+	if t.output.HasElasticSearch() {
+		cfg.ElasticsearchSettings.ConnectionUrl = model.NewString("https://" + t.output.ElasticSearchServer.Endpoint)
 		cfg.ElasticsearchSettings.Username = model.NewString("")
 		cfg.ElasticsearchSettings.Password = model.NewString("")
 		cfg.ElasticsearchSettings.Sniff = model.NewBool(false)
@@ -406,7 +407,7 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	return nil
 }
 
-func (t *Terraform) PreFlightCheck() error {
+func (t *Terraform) preFlightCheck() error {
 	if os.Getenv("SSH_AUTH_SOCK") == "" {
 		return errors.New("ssh agent not running. Please run eval \"$(ssh-agent -s)\" and then ssh-add")
 	}
@@ -415,13 +416,17 @@ func (t *Terraform) PreFlightCheck() error {
 		return fmt.Errorf("failed when checking terraform version: %w", err)
 	}
 
-	if err := t.init(); err != nil {
-		return err
+	if !t.initialized {
+		if err := t.init(); err != nil {
+			return err
+		}
+		if err := t.validate(); err != nil {
+			return err
+		}
 	}
 
-	if err := t.validate(); err != nil {
-		return err
-	}
+	t.initialized = true
+
 	return nil
 }
 

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -57,7 +57,7 @@ func New(id string, cfg *deployment.Config) *Terraform {
 
 // Create creates a new load test environment.
 func (t *Terraform) Create(initData bool) error {
-	if err := t.preFlightCheck(); err != nil {
+	if err := t.PreFlightCheck(); err != nil {
 		return err
 	}
 
@@ -406,7 +406,7 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, output *Output)
 	return nil
 }
 
-func (t *Terraform) preFlightCheck() error {
+func (t *Terraform) PreFlightCheck() error {
 	if os.Getenv("SSH_AUTH_SOCK") == "" {
 		return errors.New("ssh agent not running. Please run eval \"$(ssh-agent -s)\" and then ssh-add")
 	}

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -9,7 +9,7 @@ import (
 
 // Destroy destroys the created load-test environment.
 func (t *Terraform) Destroy() error {
-	err := t.preFlightCheck()
+	err := t.PreFlightCheck()
 	if err != nil {
 		return err
 	}

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -9,12 +9,11 @@ import (
 
 // Destroy destroys the created load-test environment.
 func (t *Terraform) Destroy() error {
-	err := t.PreFlightCheck()
-	if err != nil {
+	if err := t.preFlightCheck(); err != nil {
 		return err
 	}
 
-	return t.runCommand(nil, "destroy",
+	if err := t.runCommand(nil, "destroy",
 		"-var", fmt.Sprintf("cluster_name=%s", t.config.ClusterName),
 		"-var", fmt.Sprintf("app_instance_count=%d", t.config.AppInstanceCount),
 		"-var", fmt.Sprintf("app_instance_type=%s", t.config.AppInstanceType),
@@ -37,6 +36,9 @@ func (t *Terraform) Destroy() error {
 		"-var", fmt.Sprintf("load_test_download_url=%s", t.config.LoadTestDownloadURL),
 		"-auto-approve",
 		"-state="+t.getStatePath(),
-		t.dir,
-	)
+		t.dir); err != nil {
+		return err
+	}
+
+	return t.loadOutput()
 }

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -15,8 +15,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
+
 	"github.com/mattermost/mattermost-server/v5/mlog"
 )
+
+// Config returns the deployment config associated with the Terraform instance.
+func (t *Terraform) Config() *deployment.Config {
+	return t.config
+}
 
 // Cleanup is called at the end of each command to clean temporary files
 func (t *Terraform) Cleanup() {

--- a/deployment/terraform/info.go
+++ b/deployment/terraform/info.go
@@ -14,12 +14,12 @@ func (t *Terraform) Info() error {
 		return err
 	}
 
-	t.displayInfo(output)
+	displayInfo(output)
 
 	return nil
 }
 
-func (t *Terraform) displayInfo(output *Output) {
+func displayInfo(output *Output) {
 	if len(output.Agents) == 0 {
 		fmt.Println("No active deployment found.")
 		return

--- a/deployment/terraform/output.go
+++ b/deployment/terraform/output.go
@@ -136,7 +136,10 @@ func (t *Terraform) setOutput() error {
 // Output reads the current terraform output and caches it internally for future use.
 // The output is guaranteed to be up to date after calls to Create and Destroy.
 func (t *Terraform) Output() (*Output, error) {
-	return t.output, t.setOutput()
+	if err := t.setOutput(); err != nil {
+		return nil, err
+	}
+	return t.output, nil
 }
 
 // HasProxy returns whether a deployment has proxy installed in it or not.

--- a/deployment/terraform/output.go
+++ b/deployment/terraform/output.go
@@ -126,13 +126,17 @@ func (t *Terraform) loadOutput() error {
 	return nil
 }
 
-// Output reads the current terraform output
-func (t *Terraform) Output() (*Output, error) {
-	var err error
+func (t *Terraform) setOutput() error {
 	if t.output == nil {
-		err = t.loadOutput()
+		return t.loadOutput()
 	}
-	return t.output, err
+	return nil
+}
+
+// Output reads the current terraform output and caches it internally for future use.
+// The output is guaranteed to be up to date after calls to Create and Destroy.
+func (t *Terraform) Output() (*Output, error) {
+	return t.output, t.setOutput()
 }
 
 // HasProxy returns whether a deployment has proxy installed in it or not.


### PR DESCRIPTION
#### Summary

PR addresses the unhelpful spam of logs returned by the comparison process.
Mostly was due to terraform initialization when performing coordinator's commands (start/stop/getstatus).
To fix this I've decoupled the logic a bit and cached the terraform outputs from the deployments.

#### Ticket

https://mattermost.atlassian.net/browse/MM-32270
