### PR TITLE
[MM-32670] Replace reset CLI command during automated comparisons

### DIFF
--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -157,17 +157,18 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		clients: appClients,
 	}
 
+	dbName := dpConfig.ClusterName + "db"
 	resetCmd := cmd{
 		msg:     "Resetting database",
 		clients: []*ssh.Client{appClients[0]},
 	}
 	switch dpConfig.TerraformDBSettings.InstanceEngine {
 	case "aurora-postgresql":
-		subCmd := fmt.Sprintf("-U %s -h %s %sdb", dpConfig.TerraformDBSettings.UserName, tfOutput.DBCluster.ClusterEndpoint, dpConfig.ClusterName)
+		subCmd := fmt.Sprintf("-U %s -h %s %s", dpConfig.TerraformDBSettings.UserName, tfOutput.DBCluster.ClusterEndpoint, dbName)
 		resetCmd.value = fmt.Sprintf("export PGPASSWORD='%s' && dropdb %s && createdb %s", dpConfig.TerraformDBSettings.Password, subCmd, subCmd)
 	case "aurora-mysql":
 		subCmd := fmt.Sprintf("mysqladmin -h %s -u %s -p%s -f", tfOutput.DBCluster.ClusterEndpoint, dpConfig.TerraformDBSettings.UserName, dpConfig.TerraformDBSettings.Password)
-		resetCmd.value = fmt.Sprintf("%s drop %sdb && %s create %sdb", subCmd, dpConfig.ClusterName, subCmd, dpConfig.ClusterName)
+		resetCmd.value = fmt.Sprintf("%s drop %s && %s create %s", subCmd, dbName, subCmd, dbName)
 	default:
 		return fmt.Errorf("invalid db engine %s", dpConfig.TerraformDBSettings.InstanceEngine)
 	}
@@ -200,11 +201,11 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 	}
 	switch dpConfig.TerraformDBSettings.InstanceEngine {
 	case "aurora-postgresql":
-		loadDBDumpCmd.value = fmt.Sprintf("zcat %s | psql 'postgres://%s:%s@%s/%sdb?sslmode=disable'", dumpFilename,
-			dpConfig.TerraformDBSettings.UserName, dpConfig.TerraformDBSettings.Password, tfOutput.DBCluster.ClusterEndpoint, dpConfig.ClusterName)
+		loadDBDumpCmd.value = fmt.Sprintf("zcat %s | psql 'postgres://%s:%s@%s/%s?sslmode=disable'", dumpFilename,
+			dpConfig.TerraformDBSettings.UserName, dpConfig.TerraformDBSettings.Password, tfOutput.DBCluster.ClusterEndpoint, dbName)
 	case "aurora-mysql":
-		loadDBDumpCmd.value = fmt.Sprintf("zcat %s | mysql -h %s -u %s -p%s %sdb", dumpFilename,
-			tfOutput.DBCluster.ClusterEndpoint, dpConfig.TerraformDBSettings.UserName, dpConfig.TerraformDBSettings.Password, dpConfig.ClusterName)
+		loadDBDumpCmd.value = fmt.Sprintf("zcat %s | mysql -h %s -u %s -p%s %s", dumpFilename,
+			tfOutput.DBCluster.ClusterEndpoint, dpConfig.TerraformDBSettings.UserName, dpConfig.TerraformDBSettings.Password, dbName)
 	default:
 		return fmt.Errorf("invalid db engine %s", dpConfig.TerraformDBSettings.InstanceEngine)
 	}

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -157,7 +157,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		clients: appClients,
 	}
 
-	dbName := dpConfig.ClusterName + "db"
+	dbName := dpConfig.DBName()
 	resetCmd := cmd{
 		msg:     "Resetting database",
 		clients: []*ssh.Client{appClients[0]},

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -128,6 +128,11 @@ func (c *Config) IsValid() error {
 	return nil
 }
 
+// DBName returns the database name for the deployment.
+func (c *Config) DBName() string {
+	return c.ClusterName + "db"
+}
+
 func checkPrefix(str string) bool {
 	return strings.HasPrefix(str, "https://") ||
 		strings.HasPrefix(str, "http://") ||

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -334,7 +334,7 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client) error {
 			readerDSN = []string{"postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + t.output.DBCluster.ReaderEndpoint + "/" + t.config.DBName() + "?sslmode=disable"}
 			driverName = "postgres"
 		case "aurora-mysql":
-			clusterDSN = t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ClusterEndpoint + ")/" + t.config.DBName() + "?charset=utf8mb4,utf8\u0026readTimeout=300s\u0026writeTimeout=300s"
+			clusterDSN = t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ClusterEndpoint + ")/" + t.config.DBName() + "?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"
 			readerDSN = []string{t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ReaderEndpoint + ")/" + t.config.DBName() + "?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"}
 			driverName = "mysql"
 		}

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -330,12 +330,12 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client) error {
 	if t.output.HasDB() {
 		switch t.config.TerraformDBSettings.InstanceEngine {
 		case "aurora-postgresql":
-			clusterDSN = "postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + t.output.DBCluster.ClusterEndpoint + "/" + t.config.ClusterName + "db?sslmode=disable"
-			readerDSN = []string{"postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + t.output.DBCluster.ReaderEndpoint + "/" + t.config.ClusterName + "db?sslmode=disable"}
+			clusterDSN = "postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + t.output.DBCluster.ClusterEndpoint + "/" + t.config.DBName() + "?sslmode=disable"
+			readerDSN = []string{"postgres://" + t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@" + t.output.DBCluster.ReaderEndpoint + "/" + t.config.DBName() + "?sslmode=disable"}
 			driverName = "postgres"
 		case "aurora-mysql":
-			clusterDSN = t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ClusterEndpoint + ")/" + t.config.ClusterName + "db?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"
-			readerDSN = []string{t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ReaderEndpoint + ")/" + t.config.ClusterName + "db?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"}
+			clusterDSN = t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ClusterEndpoint + ")/" + t.config.DBName() + "?charset=utf8mb4,utf8\u0026readTimeout=300s\u0026writeTimeout=300s"
+			readerDSN = []string{t.config.TerraformDBSettings.UserName + ":" + t.config.TerraformDBSettings.Password + "@tcp(" + t.output.DBCluster.ReaderEndpoint + ")/" + t.config.DBName() + "?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"}
 			driverName = "mysql"
 		}
 	}


### PR DESCRIPTION
#### Summary

PR replaces the `mattermost reset` CLI command during automated comparisons.
The main reason behind the change is that the `reset` command can cause unnecessary delays during store initialization.

#### Ticket

https://mattermost.atlassian.net/browse/MM-32670
