### PR TITLE
MM-32747: Display command output from ssh commands during ltctl reset

### DIFF
--- a/cmd/ltctl/reset.go
+++ b/cmd/ltctl/reset.go
@@ -98,8 +98,8 @@ func RunResetCmdF(cmd *cobra.Command, args []string) error {
 	for _, c := range cmds {
 		fmt.Printf(c.msg)
 		for _, client := range c.clients {
-			if _, err := client.RunCommand(c.value); err != nil {
-				return fmt.Errorf("failed to run cmd %q: %w", c.value, err)
+			if out, err := client.RunCommand(c.value); err != nil {
+				return fmt.Errorf("failed to run cmd %q: %w %s", c.value, err, out)
 			}
 		}
 		fmt.Println(" done")


### PR DESCRIPTION
We were doing this elsewhere but missed out on this one. Without this,
the only error message we get is "exit code 1", and the actual command error
is missed out.

https://mattermost.atlassian.net/browse/MM-32747
