### PR TITLE
[MM-33009] Use HTTP 1.1 for NGINX ws upgrade

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -127,6 +127,7 @@ server {
      proxy_connect_timeout   30s;
      proxy_send_timeout      90s;
      proxy_read_timeout      90s;
+     proxy_http_version 1.1;
      proxy_pass http://backend;
    }
 


### PR DESCRIPTION
#### Summary

Adding the HTTP version to correctly perform the WS upgrade when behind NGINX.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-33009
