### PR TITLE
Disable Grafana login

### DIFF
--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -154,6 +154,12 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 
 	mlog.Info("Setting up Grafana", mlog.String("host", t.output.MetricsServer.PublicIP))
 
+	// Upload config file
+	rdr = strings.NewReader(grafanaConfigFile)
+	if out, err := sshc.Upload(rdr, "/etc/grafana/grafana.ini", true); err != nil {
+		return fmt.Errorf("error upload grafana config: output: %s, error: %w", out, err)
+	}
+
 	// Upload datasource file
 	buf, err := ioutil.ReadFile(path.Join(t.dir, "datasource.yaml"))
 	if err != nil {

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -233,3 +233,15 @@ LimitNOFILE=49152
 [Install]
 WantedBy=multi-user.target
 `
+
+const grafanaConfigFile = `
+[auth]
+disable_login_form = false
+
+[auth.anonymous]
+enabled = true
+org_role = Editor
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/dashboard.json
+`


### PR DESCRIPTION
#### Summary

It was getting annoying to always login. We are not protecting the instance in the first place so the login is just in the way of accessing the data.