### PR TITLE
MM-33228: Fix searchChannel for short channel names

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -885,8 +885,10 @@ func searchChannels(u user.User) control.UserActionResponse {
 	// to search for a channel. This is an arbitrary value which fits well with the current
 	// frequency value for this action.
 	numChars := 4
-	if len(channel.Name) < numChars {
-		return control.UserActionResponse{Info: "channel name too short"}
+	if numChars > len(channel.Name) {
+		// rand.Intn returns a number exclusive of the max limit.
+		// So there's no need to subtract 1.
+		numChars = len(channel.Name)
 	}
 
 	return control.EmulateUserTyping(channel.Name[:1+rand.Intn(numChars)], func(term string) control.UserActionResponse {

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -881,10 +881,15 @@ func searchChannels(u user.User) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	// We simulate the user typing up to 4 characters when searching for
-	// a channel. This is an arbitrary value which fits well with the current
+	// numChars simulates how many characters does a user type
+	// to search for a channel. This is an arbitrary value which fits well with the current
 	// frequency value for this action.
-	return control.EmulateUserTyping(channel.Name[:1+rand.Intn(4)], func(term string) control.UserActionResponse {
+	numChars := 4
+	if len(channel.Name) < numChars {
+		return control.UserActionResponse{Info: "channel name too short"}
+	}
+
+	return control.EmulateUserTyping(channel.Name[:1+rand.Intn(numChars)], func(term string) control.UserActionResponse {
 		channels, err := u.SearchChannels(team.Id, &model.ChannelSearch{
 			Term: term,
 		})


### PR DESCRIPTION
We check for the length of the channel name before searching for it, and if it exceeds the channel name length, we trim it to the max length.

https://mattermost.atlassian.net/browse/MM-33228
