### PR TITLE
MM-34079: Improve notificationLog settings

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -393,6 +393,11 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, jobServerEnable
 	cfg.LogSettings.EnableFile = model.NewBool(true)
 	cfg.LogSettings.FileLevel = model.NewString("WARN")
 
+	cfg.NotificationLogSettings.EnableConsole = model.NewBool(true)
+	cfg.NotificationLogSettings.ConsoleLevel = model.NewString("ERROR")
+	cfg.NotificationLogSettings.EnableFile = model.NewBool(true)
+	cfg.NotificationLogSettings.FileLevel = model.NewString("WARN")
+
 	cfg.SqlSettings.DriverName = model.NewString(driverName)
 	cfg.SqlSettings.DataSource = model.NewString(clusterDSN)
 	cfg.SqlSettings.DataSourceReplicas = readerDSN


### PR DESCRIPTION
The notification console logs still defaulted to debug which flooded
the journal logs. Taming it down to be the same as the application logs.

https://mattermost.atlassian.net/browse/MM-34079
