### PR TITLE
MM-34289: Run ssh command

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -152,15 +152,19 @@ func main() {
 	rootCmd.AddCommand(loadtestCmd)
 
 	sshCmd := &cobra.Command{
-		Use:     "ssh [instance]",
+		Use:     "ssh [instance] [command]",
 		Short:   "ssh into instance",
-		Example: "ltctl ssh agent-0",
+		Example: "ltctl ssh agent-0 [command]",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
+			switch len(args) {
+			case 0:
 				fmt.Println("Available instances:")
 				return RunSSHListCmdF(cmd, args)
+			case 1:
+				return terraform.New("", nil).OpenSSHFor(args[0])
+			default: // run a command on a machine
+				return terraform.New("", nil).RunSSHCommand(args[0], args[1:])
 			}
-			return terraform.New("", nil).OpenSSHFor(args[0])
 		},
 	}
 

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -63,6 +63,24 @@ func (t *Terraform) OpenSSHFor(resource string) error {
 	return cmd.Wait()
 }
 
+// RunSSHCommand runs a command on a given machine.
+func (t *Terraform) RunSSHCommand(resource string, args []string) error {
+	cmd, err := t.makeCmdForResource(resource)
+	if err != nil {
+		return fmt.Errorf("failed to make cmd for resource: %w", err)
+	}
+	cmd.Args = append(cmd.Args, args...)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}
+
 func (t *Terraform) makeCmdForResource(resource string) (*exec.Cmd, error) {
 	output, err := t.Output()
 	if err != nil {


### PR DESCRIPTION
Often we just need to run some commands like restarting mattermost,
or backing up a DB before a test.

Logging in every time, and running the command needs an extra step.
This makes things a bit easier.

https://mattermost.atlassian.net/browse/MM-34289
