### PR TITLE
[MM-34268] Respect server config when sending typing event

### DIFF
--- a/examples/loadtest/samplestore/store.go
+++ b/examples/loadtest/samplestore/store.go
@@ -386,3 +386,11 @@ func (s *SampleStore) ServerVersion() (string, error) {
 func (s *SampleStore) SetServerVersion(version string) error {
 	return nil
 }
+
+func (s *SampleStore) ChannelStats(channelId string) (*model.ChannelStats, error) {
+	return nil, nil
+}
+
+func (s *SampleStore) SetChannelStats(channelId string, stats *model.ChannelStats) error {
+	return nil
+}

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -531,13 +531,7 @@ func (c *SimulController) createPostReply(u user.User) control.UserActionRespons
 		rootId = post.Id
 	}
 
-	if ok, err := shouldSendTypingEvent(u, channel.Id); ok && err == nil {
-		// TODO: possibly add some additional idle time here to simulate the
-		// user actually taking time to type a post message.
-		if err := u.SendTypingEvent(channel.Id, ""); err != nil {
-			return control.UserActionResponse{Err: control.NewUserError(err)}
-		}
-	} else if err != nil {
+	if err := sendTypingEventIfEnabled(u, channel.Id); err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -574,13 +568,7 @@ func (c *SimulController) createPost(u user.User) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	if ok, err := shouldSendTypingEvent(u, channel.Id); ok && err == nil {
-		// TODO: possibly add some additional idle time here to simulate the
-		// user actually taking time to type a post message.
-		if err := u.SendTypingEvent(channel.Id, ""); err != nil {
-			return control.UserActionResponse{Err: control.NewUserError(err)}
-		}
-	} else if err != nil {
+	if err := sendTypingEventIfEnabled(u, channel.Id); err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -1048,4 +1036,15 @@ func shouldSendTypingEvent(u user.User, channelId string) (bool, error) {
 		return false, err
 	}
 	return channelStats.MemberCount < maxNotifications && enableTyping, nil
+}
+
+func sendTypingEventIfEnabled(u user.User, channelId string) error {
+	if ok, err := shouldSendTypingEvent(u, channelId); ok && err == nil {
+		// TODO: possibly add some additional idle time here to simulate the
+		// user actually taking time to type a post message.
+		return u.SendTypingEvent(channelId, "")
+	} else if err != nil {
+		return err
+	}
+	return nil
 }

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -26,6 +26,7 @@ type MemStore struct {
 	postsQueue          *CQueue
 	teams               map[string]*model.Team
 	channels            map[string]*model.Channel
+	channelStats        map[string]*model.ChannelStats
 	channelMembers      map[string]map[string]*model.ChannelMember
 	channelMembersQueue *CQueue
 	teamMembers         map[string]map[string]*model.TeamMember
@@ -78,6 +79,7 @@ func (s *MemStore) Clear() {
 	s.postsQueue.Reset()
 	s.teams = map[string]*model.Team{}
 	s.channels = map[string]*model.Channel{}
+	s.channelStats = map[string]*model.ChannelStats{}
 	s.channelMembers = map[string]map[string]*model.ChannelMember{}
 	s.channelMembersQueue.Reset()
 	s.teamMembers = map[string]map[string]*model.TeamMember{}
@@ -501,6 +503,32 @@ func (s *MemStore) ChannelView(channelId string) (int64, error) {
 	}
 
 	return s.channelViews[channelId], nil
+}
+
+// ChannelStats returns statistics for the given channelId.
+func (s *MemStore) ChannelStats(channelId string) (*model.ChannelStats, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if channelId == "" {
+		return nil, errors.New("memstore: channelId should not be empty")
+	}
+
+	return s.channelStats[channelId], nil
+}
+
+// SetChannelStats stores statistics for the given channelId.
+func (s *MemStore) SetChannelStats(channelId string, stats *model.ChannelStats) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if channelId == "" {
+		return errors.New("memstore: channelId should not be empty")
+	}
+
+	s.channelStats[channelId] = stats
+
+	return nil
 }
 
 // Team returns the team for the given teamId.

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -53,6 +53,8 @@ type UserStore interface {
 	ChannelPostsSorted(channelId string, asc bool) ([]*model.Post, error)
 	// ChannelView returns the timestamp of the last view for the given channelId.
 	ChannelView(channelId string) (int64, error)
+	// ChannelStats returns statistics for the given channelId.
+	ChannelStats(channelId string) (*model.ChannelStats, error)
 
 	// GetUser returns the user for the given userId.
 	GetUser(userId string) (model.User, error)
@@ -185,6 +187,8 @@ type MutableUserStore interface {
 	SetChannelMember(channelId string, channelMember *model.ChannelMember) error
 	// RemoveChannelMember removes the channel member for the specified channel and user.
 	RemoveChannelMember(channelId string, userId string) error
+	// SetChannelStats stores statistics for the given channelId.
+	SetChannelStats(channelId string, stats *model.ChannelStats) error
 
 	// teams
 	SetTeam(team *model.Team) error

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -520,12 +520,12 @@ func (ue *UserEntity) GetChannelMember(channelId, userId string) error {
 
 // GetChannelStats fetches statistics for the specified channel.
 func (ue *UserEntity) GetChannelStats(channelId string) error {
-	_, resp := ue.client.GetChannelStats(channelId, "")
+	stats, resp := ue.client.GetChannelStats(channelId, "")
 	if resp.Error != nil {
 		return resp.Error
 	}
 
-	return nil
+	return ue.store.SetChannelStats(channelId, stats)
 }
 
 // AutocompleteChannelsForTeam fetches and stores an ordered list of channels for a given


### PR DESCRIPTION
#### Summary

Similarly to what happens on the web client, we want to send the ws typing event only if enabled on server.

#### Ticket

https://mattermost.atlassian.net/browse/MM-34268