### PR TITLE
[MM-34673] Fix nil pointer dereference crash in SimulController

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1182,6 +1182,8 @@ func shouldSendTypingEvent(u user.User, channelId string) (bool, error) {
 	channelStats, err := u.Store().ChannelStats(channelId)
 	if err != nil {
 		return false, err
+	} else if channelStats == nil {
+		return false, fmt.Errorf("no stats found for channel %q", channelId)
 	}
 	maxNotifications, err := strconv.ParseInt(u.Store().ClientConfig()["MaxNotificationsPerChannel"], 10, 64)
 	if err != nil {

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -80,7 +80,11 @@ func (s *MemStore) Clear() {
 	s.postsQueue.Reset()
 	s.teams = map[string]*model.Team{}
 	s.channels = map[string]*model.Channel{}
-	s.channelStats = map[string]*model.ChannelStats{}
+	channelStats := map[string]*model.ChannelStats{}
+	if s.currentChannel != nil && s.channelStats[s.currentChannel.Id] != nil {
+		channelStats[s.currentChannel.Id] = s.channelStats[s.currentChannel.Id]
+	}
+	s.channelStats = channelStats
 	s.channelMembers = map[string]map[string]*model.ChannelMember{}
 	s.channelMembersQueue.Reset()
 	s.teamMembers = map[string]map[string]*model.TeamMember{}

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -629,3 +629,43 @@ outer:
 	}
 	require.Equal(t, 2, doneCount)
 }
+
+func TestChannelStats(t *testing.T) {
+	s := newStore(t)
+
+	channelId := model.NewId()
+	stats := model.ChannelStats{
+		ChannelId: channelId,
+	}
+
+	t.Run("Set", func(t *testing.T) {
+		err := s.SetChannelStats(channelId, &stats)
+		require.NoError(t, err)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		storedStats, err := s.ChannelStats(channelId)
+		require.NoError(t, err)
+		require.Equal(t, &stats, storedStats)
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		s.Clear()
+
+		storedStats, err := s.ChannelStats(channelId)
+		require.NoError(t, err)
+		require.Nil(t, storedStats)
+
+		err = s.SetCurrentChannel(&model.Channel{Id: channelId})
+		require.NoError(t, err)
+
+		err = s.SetChannelStats(channelId, &stats)
+		require.NoError(t, err)
+
+		s.Clear()
+
+		storedStats, err = s.ChannelStats(channelId)
+		require.NoError(t, err)
+		require.Equal(t, &stats, storedStats)
+	})
+}


### PR DESCRIPTION
#### Summary

PR fixes a possible crash due to `nil` pointer dereference. 
It also addresses the underlying issue that was causing the returned channel stats to be `nil`.

#### Ticket

https://mattermost.atlassian.net/browse/MM-34673