### PR TITLE
[MM-34719] Filter out system messages when randomly picking posts

### DIFF
--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -217,11 +217,18 @@ func (s *MemStore) RandomPost() (model.Post, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	key, err := pickRandomKeyFromMap(s.posts)
-	if err != nil {
-		return model.Post{}, err
+	var postIds []string
+	for _, p := range s.posts {
+		if p.Type == "" {
+			postIds = append(postIds, p.Id)
+		}
 	}
-	return *s.posts[key.(string)].Clone(), nil
+
+	if len(postIds) == 0 {
+		return model.Post{}, ErrPostNotFound
+	}
+
+	return *s.posts[postIds[rand.Intn(len(postIds))]].Clone(), nil
 }
 
 // RandomPostForChannel returns a random post for the given channel.
@@ -231,7 +238,7 @@ func (s *MemStore) RandomPostForChannel(channelId string) (model.Post, error) {
 
 	var postIds []string
 	for _, p := range s.posts {
-		if p.ChannelId == channelId {
+		if p.ChannelId == channelId && p.Type == "" {
 			postIds = append(postIds, p.Id)
 		}
 	}

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -221,6 +221,28 @@ func TestRandomPost(t *testing.T) {
 			return false
 		}
 	})
+
+	s = newStore(t)
+	for i := 0; i < 10; i++ {
+		err := s.SetPost(&model.Post{
+			Id:   model.NewId(),
+			Type: "some_type",
+		})
+		require.NoError(t, err)
+	}
+
+	p, err = s.RandomPost()
+	require.Equal(t, ErrPostNotFound, err)
+	require.Empty(t, p.Clone())
+
+	err = s.SetPost(&model.Post{
+		Id: id1,
+	})
+	require.NoError(t, err)
+
+	p, err = s.RandomPost()
+	require.NoError(t, err)
+	require.Equal(t, id1, p.Id)
 }
 
 func TestRandomPostForChannel(t *testing.T) {


### PR DESCRIPTION
#### Summary

At times the controllers would be trying to run actions on system messages which would fail. PR implements the necessary changes to filter out posts not directly created by users (where `Posts.Type` is set). This was already correctly handled by `memstore.RandomPostForChannelByUser()` but not by other post picking methods, hence this PR.

This is also the last fix I was planning before releasing 1.3.0 

#### Ticket

https://mattermost.atlassian.net/browse/MM-34719
