### PR TITLE
Improve error check on failing login

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -133,7 +134,7 @@ func (c *SimulController) login(u user.User) control.UserActionResponse {
 		}
 
 		errId := resp.Err.(*control.UserError).Err.(*model.AppError).Id
-		if errId == "api.user.login.invalid_credentials_email_username" {
+		if strings.Contains(errId, "invalid_credentials") {
 			return resp
 		}
 


### PR DESCRIPTION
#### Summary

The returned login failure error changes from `api.user.login.invalid_credentials_email_username` to `api.user.login.invalid_credentials_sso` when an SSO method is enabled on server, leading to the users not being able to ever sign up after an initial login failure.

@sadohert 
This should fix what you've been experiencing. Unfortunately we rarely run load-test on SSO setups so this got unnoticed for a long time.