### PR TITLE
Fix comparison output

### DIFF
--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -147,7 +147,7 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		}
 		defer f.Close()
 
-		if err := json.NewEncoder(f).Encode(output.Results); err != nil {
+		if err := json.NewEncoder(f).Encode(output); err != nil {
 			return fmt.Errorf("failed to encode results: %w", err)
 		}
 	} else {

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -143,6 +143,9 @@ func (c *Comparison) Run() (Output, error) {
 // current automated load-test comparisons.
 func (c *Comparison) Destroy() error {
 	return c.deploymentAction(func(t *terraform.Terraform, _ *deploymentConfig) error {
+		if err := t.Sync(); err != nil {
+			return err
+		}
 		return t.Destroy()
 	})
 }


### PR DESCRIPTION
#### Summary

We were saving only the comparison results and missing the deployment info which are quite useful for historical purposes.
Also added a sync operation on destroy which helps in certain cases where the deployment has been modified by hand.