### PR TITLE
Prevent panic in case of server offline

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -133,8 +133,8 @@ func (c *SimulController) login(u user.User) control.UserActionResponse {
 			c.status <- c.newErrorStatus(err)
 		}
 
-		errId := resp.Err.(*control.UserError).Err.(*model.AppError).Id
-		if strings.Contains(errId, "invalid_credentials") {
+		appErr, ok := resp.Err.(*control.UserError).Err.(*model.AppError)
+		if !ok || strings.Contains(appErr.Id, "invalid_credentials") {
 			return resp
 		}
 


### PR DESCRIPTION
The type assertion would fail if the server wasn't available,
which would result in a panic.

panic: interface conversion: error is *url.Error, not *model.AppError

We avoid that by checking the result first.

After that:
```
{"timestamp":"2021-10-15 11:25:19.950 +05:30","level":"error","msg":"control.SignUp loadtest/control/actions.go:47 Post \"http://localhost:8065/api/v4/users\": dial tcp 127.0.0.1:8065: connect: connection refuse
 d","caller":"loadtest/loadtest.go:57","controller_id":8,"user_id":""}
```
