### PR TITLE
MM-41499: Use CRT switch in GetTeamsUnread

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -214,7 +214,12 @@ func loadTeam(u user.User, team *model.Team) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	if _, err := u.GetTeamsUnread("", false); err != nil {
+	collapsedThreads, resp := control.CollapsedThreadsEnabled(u)
+	if resp.Err != nil {
+		return resp
+	}
+
+	if _, err := u.GetTeamsUnread("", collapsedThreads); err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 


### PR DESCRIPTION
Previously, this was just hardcoded to false which
made it skip the CRT code paths. Now we actually
get the param from the store and pass that onwards.

https://mattermost.atlassian.net/browse/MM-41499
