### PR TITLE
Fix channel switcher bug

### DIFF
--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -685,6 +685,22 @@ func Reload(u user.User) UserActionResponse {
 				return UserActionResponse{Err: NewUserError(err)}
 			}
 		}
+
+		ver, err := u.Store().ServerVersion()
+		if err != nil {
+			return UserActionResponse{Err: NewUserError(err)}
+		}
+
+		ok, err := IsVersionSupported("6.4.0", ver)
+		if err != nil {
+			return UserActionResponse{Err: NewUserError(err)}
+		}
+		if ok {
+			_, err = u.GetChannelsForUser(userId)
+			if err != nil {
+				return UserActionResponse{Err: NewUserError(err)}
+			}
+		}
 	}
 
 	// Getting unread teams.
@@ -721,22 +737,6 @@ func Reload(u user.User) UserActionResponse {
 
 		// Getting channel unread.
 		_, err = u.GetChannelUnread(chanId)
-		if err != nil {
-			return UserActionResponse{Err: NewUserError(err)}
-		}
-	}
-
-	ver, err := u.Store().ServerVersion()
-	if err != nil {
-		return UserActionResponse{Err: NewUserError(err)}
-	}
-
-	ok, err := IsVersionSupported("6.4.0", ver)
-	if err != nil {
-		return UserActionResponse{Err: NewUserError(err)}
-	}
-	if ok {
-		_, err = u.GetChannelsForUser(userId)
 		if err != nil {
 			return UserActionResponse{Err: NewUserError(err)}
 		}


### PR DESCRIPTION
We get channels for the user only after the curren team is set.
Without that a newly signed up user won't be part of any channels
unless they join a team first.
