### PR TITLE
add config validation in coordinator for MaxActiveUsers

### DIFF
--- a/api/coordinator_test.go
+++ b/api/coordinator_test.go
@@ -97,6 +97,7 @@ func TestCoordinatorAPI(t *testing.T) {
 		}
 
 		data.CoordinatorConfig.ClusterConfig.Agents[0].ApiURL = server.URL
+		data.CoordinatorConfig.ClusterConfig.MaxActiveUsers = 1000
 
 		obj := e.POST("/create").WithQuery("id", id).WithJSON(data).
 			Expect().Status(http.StatusCreated).

--- a/api/coordinator_test.go
+++ b/api/coordinator_test.go
@@ -40,6 +40,7 @@ func TestCoordinatorAPI(t *testing.T) {
 	config.MonitorConfig.Queries[0].Description = "Query"
 	config.MonitorConfig.Queries[0].Query = "query"
 	config.ClusterConfig.Agents[0].ApiURL = server.URL
+	config.ClusterConfig.MaxActiveUsers = 100
 
 	t.Run("create/destroy", func(t *testing.T) {
 		data := struct {
@@ -97,7 +98,6 @@ func TestCoordinatorAPI(t *testing.T) {
 		}
 
 		data.CoordinatorConfig.ClusterConfig.Agents[0].ApiURL = server.URL
-		data.CoordinatorConfig.ClusterConfig.MaxActiveUsers = 1000
 
 		obj := e.POST("/create").WithQuery("id", id).WithJSON(data).
 			Expect().Status(http.StatusCreated).

--- a/coordinator/cluster/config.go
+++ b/coordinator/cluster/config.go
@@ -3,6 +3,12 @@
 
 package cluster
 
+import (
+	"errors"
+
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+)
+
 // LoadAgentConfig holds information about the load-test agent instance.
 type LoadAgentConfig struct {
 	// A sring that identifies the load-test agent instance.
@@ -21,4 +27,11 @@ type LoadAgentClusterConfig struct {
 	// MaxActiveUsers defines the upper limit of concurrently active users to run across
 	// the whole cluster.
 	MaxActiveUsers int `default:"1000" validate:"range:(0,]"`
+}
+
+func (c *LoadAgentClusterConfig) IsValid(ltConfig loadtest.Config) error {
+	if ltConfig.UsersConfiguration.MaxActiveUsers*len(c.Agents) < c.MaxActiveUsers {
+		return errors.New("coordinator: total MaxActiveUsers in loadTest should not be less than clusterConfig.MaxActiveUsers")
+	}
+	return nil
 }

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -254,7 +254,6 @@ func New(config *Config, ltConfig loadtest.Config, log *mlog.Logger) (*Coordinat
 
 	clusterConfig := config.ClusterConfig
 
-	clusterConfig.IsValid(ltConfig)
 	if err := clusterConfig.IsValid(ltConfig); err != nil {
 		return nil, fmt.Errorf("could not validate ltConfig against clusterConfig: %w", err)
 	}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -254,7 +254,7 @@ func New(config *Config, ltConfig loadtest.Config, log *mlog.Logger) (*Coordinat
 
 	clusterConfig := config.ClusterConfig
 
-	if ltConfig.UsersConfiguration.MaxActiveUsers < clusterConfig.MaxActiveUsers {
+	if ltConfig.UsersConfiguration.MaxActiveUsers*len(clusterConfig.Agents) < clusterConfig.MaxActiveUsers {
 		return nil, errors.New("coordinator: ltConfig.UsersConfiguration.MaxActiveUsers should not be less than config.clusterConfig.MaxActiveUsers")
 	}
 

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -252,7 +252,13 @@ func New(config *Config, ltConfig loadtest.Config, log *mlog.Logger) (*Coordinat
 		return nil, fmt.Errorf("could not validate configuration: %w", err)
 	}
 
-	cluster, err := cluster.New(config.ClusterConfig, ltConfig, log)
+	clusterConfig := config.ClusterConfig
+
+	if ltConfig.UsersConfiguration.MaxActiveUsers < clusterConfig.MaxActiveUsers {
+		return nil, errors.New("coordinator: ltConfig.UsersConfiguration.MaxActiveUsers should not be less than config.clusterConfig.MaxActiveUsers")
+	}
+
+	cluster, err := cluster.New(clusterConfig, ltConfig, log)
 	if err != nil {
 		return nil, fmt.Errorf("coordinator: failed to create cluster: %w", err)
 	}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -254,8 +254,9 @@ func New(config *Config, ltConfig loadtest.Config, log *mlog.Logger) (*Coordinat
 
 	clusterConfig := config.ClusterConfig
 
-	if ltConfig.UsersConfiguration.MaxActiveUsers*len(clusterConfig.Agents) < clusterConfig.MaxActiveUsers {
-		return nil, errors.New("coordinator: ltConfig.UsersConfiguration.MaxActiveUsers should not be less than config.clusterConfig.MaxActiveUsers")
+	clusterConfig.IsValid(ltConfig)
+	if err := clusterConfig.IsValid(ltConfig); err != nil {
+		return nil, fmt.Errorf("could not validate ltConfig against clusterConfig: %w", err)
 	}
 
 	cluster, err := cluster.New(clusterConfig, ltConfig, log)


### PR DESCRIPTION
#### Summary
Validate UsersConfig.MaxActiveUsers is not less than clusterConfig.MaxActiveUsers

#### Ticket Link
Github: https://github.com/mattermost/mattermost-server/issues/19676
JIRA: https://mattermost.atlassian.net/browse/MM-42253

