### PR TITLE
Set ThreadAutoFollow to true explicitly for terraform

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -382,6 +382,7 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, jobServerEnable
 	cfg.ServiceSettings.WriteTimeout = model.NewInt(60)
 	cfg.ServiceSettings.IdleTimeout = model.NewInt(90)
 	cfg.ServiceSettings.EnableLocalMode = model.NewBool(true)
+	cfg.ServiceSettings.ThreadAutoFollow = model.NewBool(true)
 	cfg.ServiceSettings.CollapsedThreads = model.NewString(model.CollapsedThreadsDefaultOn)
 	cfg.ServiceSettings.EnableLinkPreviews = model.NewBool(true)
 	cfg.ServiceSettings.EnablePermalinkPreviews = model.NewBool(true)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- In https://github.com/mattermost/mattermost-server/pull/19441 we set `ServiceSettings.ThreadAutoFollow` to `false` by default. The terraform deployment sets `ServiceSettings.CollapsedThreads` to `default_on`. ThreadAutoFollow needs to be true for CollapsedThreads to be on. In my tests, Terraform deployments were failing because the mattermost app wouldn't start because the mattermost config was in an inconsistent state. This change explicitly sets `ThreadAutoFollow` to `true`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

- N/A