### PR TITLE
CRT Tweaks

### DIFF
--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -746,6 +746,10 @@ func Reload(u user.User) UserActionResponse {
 }
 
 func CollapsedThreadsEnabled(u user.User) (bool, UserActionResponse) {
+	if u.Store().ClientConfig()["CollapsedThreads"] == model.CollapsedThreadsDisabled {
+		return false, UserActionResponse{}
+	}
+
 	collapsedThreads := u.Store().ClientConfig()["CollapsedThreads"] == model.CollapsedThreadsDefaultOn
 	prefs, err := u.Store().Preferences()
 	if err != nil {

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1382,7 +1382,7 @@ func (c *SimulController) viewGlobalThreads(u user.User) control.UserActionRespo
 		if err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
-		if len(threads) == 0 {
+		if len(unreadThreads) == 0 {
 			break
 		}
 		oldestUnreadThreadId = unreadThreads[len(unreadThreads)-1].PostId


### PR DESCRIPTION
#### Summary
Two small fixes to the recent extensions to loadtest CRT:
* Check for `CollapsedThreads` set to `disabled` and ignore user preferences altogether. This would only have caused an issue if it was enabled for some users, then disabled globally.
* Fix an index out of range panic accessing the wrong data structure
```
panic: runtime error: index out of range [-1]

goroutine 132 [running]:
github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller.(*SimulController).viewGlobalThreads(0xc00017a7e0, {0x1161b00, 0xc0000326c0})
        github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller/actions.go:1388 +0xc85
github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller.(*SimulController).Run(0xc00017a7e0)
        github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller/controller.go:230 +0xbf9
github.com/mattermost/mattermost-load-test-ng/loadtest.(*LoadTester).addUser.func1()
        github.com/mattermost/mattermost-load-test-ng/loadtest/loadtest.go:127 +0x22
created by github.com/mattermost/mattermost-load-test-ng/loadtest.(*LoadTester).addUser
        github.com/mattermost/mattermost-load-test-ng/loadtest/loadtest.go:126 +0x37e
```

#### Ticket Link
N/A