### PR TITLE
[MM-43618] Fix possible panic in SimulController.updateThreadRead

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1647,7 +1647,7 @@ func (c *SimulController) updateThreadRead(u user.User) control.UserActionRespon
 		if err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
-		channel, err := u.Store().Channel(thread.Post.ChannelId)
+		channel, err = u.Store().Channel(thread.Post.ChannelId)
 		if err != nil || channel == nil {
 			return control.UserActionResponse{Err: control.NewUserError(errors.New("updateThreadRead: can't get channel for thread"))}
 		}


### PR DESCRIPTION
#### Summary

PR fixes a possible panic due to wrong variable assignment.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43618
