### PR TITLE
Remove blank query from coordinator default config

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -199,8 +199,6 @@ func TestCoordClientConcurrency(t *testing.T) {
 		defaults.Set(&ltConfig)
 		coordConfig.ClusterConfig.Agents[0].Id = coord.Id() + "-agent"
 		coordConfig.ClusterConfig.Agents[0].ApiURL = server.URL
-		coordConfig.MonitorConfig.Queries[0].Description = "Query"
-		coordConfig.MonitorConfig.Queries[0].Query = "query"
 		_, err := coord.Create(&coordConfig, &ltConfig)
 		require.NoError(t, err)
 		return coord
@@ -214,8 +212,6 @@ func TestCoordClientConcurrency(t *testing.T) {
 		defaults.Set(&ltConfig)
 		coordConfig.ClusterConfig.Agents[0].Id = coord.Id() + "-agent"
 		coordConfig.ClusterConfig.Agents[0].ApiURL = server.URL
-		coordConfig.MonitorConfig.Queries[0].Description = "Query"
-		coordConfig.MonitorConfig.Queries[0].Query = "query"
 		var success int
 		wg.Add(n)
 		for i := 0; i < n; i++ {

--- a/api/coordinator_client_test.go
+++ b/api/coordinator_client_test.go
@@ -24,8 +24,6 @@ func createCoordinator(t *testing.T, id, serverURL string) *client.Coordinator {
 	defaults.Set(&coordConfig)
 	defaults.Set(&ltConfig)
 	coordConfig.ClusterConfig.Agents[0].ApiURL = serverURL
-	coordConfig.MonitorConfig.Queries[0].Description = "Query"
-	coordConfig.MonitorConfig.Queries[0].Query = "query"
 	coord, err := client.New(id, serverURL, nil)
 	require.NoError(t, err)
 	require.NotNil(t, coord)
@@ -66,8 +64,6 @@ func TestCreateCoordinator(t *testing.T) {
 		var ltConfig loadtest.Config
 		defaults.Set(&coordConfig)
 		defaults.Set(&ltConfig)
-		coordConfig.MonitorConfig.Queries[0].Description = "Query"
-		coordConfig.MonitorConfig.Queries[0].Query = "query"
 		coordConfig.ClusterConfig.Agents[0].ApiURL = server.URL
 		_, err := coord.Create(&coordConfig, &ltConfig)
 		require.NoError(t, err)
@@ -78,8 +74,6 @@ func TestCreateCoordinator(t *testing.T) {
 		var ltConfig loadtest.Config
 		defaults.Set(&coordConfig)
 		defaults.Set(&ltConfig)
-		coordConfig.MonitorConfig.Queries[0].Description = "Query"
-		coordConfig.MonitorConfig.Queries[0].Query = "query"
 		coordConfig.ClusterConfig.Agents[0].ApiURL = server.URL
 		status, err := coord.Create(&coordConfig, &ltConfig)
 		require.Error(t, err)

--- a/api/coordinator_test.go
+++ b/api/coordinator_test.go
@@ -37,8 +37,6 @@ func TestCoordinatorAPI(t *testing.T) {
 	var config coordinator.Config
 	err = defaults.Set(&config)
 	require.NoError(t, err)
-	config.MonitorConfig.Queries[0].Description = "Query"
-	config.MonitorConfig.Queries[0].Query = "query"
 	config.ClusterConfig.Agents[0].ApiURL = server.URL
 
 	t.Run("create/destroy", func(t *testing.T) {

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -22,8 +22,6 @@ func newConfig(t *testing.T) *Config {
 	t.Helper()
 	var cfg Config
 	defaults.Set(&cfg)
-	cfg.MonitorConfig.Queries[0].Description = "Query"
-	cfg.MonitorConfig.Queries[0].Query = "query"
 	return &cfg
 }
 

--- a/coordinator/performance/config.go
+++ b/coordinator/performance/config.go
@@ -16,7 +16,7 @@ type MonitorConfig struct {
 	// The time interval in milliseconds to wait before querying again.
 	UpdateIntervalMs int `default:"2000" validate:"range:[1000,]"`
 	// The slice of queries to run.
-	Queries []prometheus.Query `default_size:"1"`
+	Queries []prometheus.Query `default_size:"0"`
 }
 
 // IsValid checks whether a MonitorConfig is valid or not.


### PR DESCRIPTION
#### Summary
Not sure if this is the right solution or not but the default coordinator config failed on:

```
Error: failed to create coordinator: coordinator: coordinator api request error: could not create coordinator: could not validate configuration: Description is empty
```

if I didn't copy the sample coordinator config during the steps [here](https://github.com/mattermost/mattermost-load-test-ng/blob/master/docs/terraform_loadtest.md#optionally-configure-coordinator-and-load-test) which says it's optional to do.

The other option would be to add some of the queries from the sample in the code as a default.

