### PR TITLE
Minor doc additions to smooth process for first time users

### DIFF
--- a/docs/local_loadtest.md
+++ b/docs/local_loadtest.md
@@ -2,19 +2,19 @@
 
 ## Introduction
 
-This guide describes how to run a load-test locally (and mostly manually).  
-Doing this is particularly useful when testing changes to the load-test tool itself.  
+This guide describes how to run a load-test locally (and mostly manually).
+Doing this is particularly useful when testing changes to the load-test tool itself.
 It's also a great way to learn how the whole load-testing process works before trying with more advanced deployments.
 
 There are a few ways to run a load-test locally, in order of complexity:
 
-- Run the `ltagent` command directly. 
+- Run the `ltagent` command directly.
 - Run a load-test through the load-test agent API server `ltapi`.
 - Run a load-test through the [`coordinator`](coordinator.md).
 
 ## Prerequisites
 
-Before starting a new load-test, a newly created (and running) Mattermost instance with system admin credentials is required.  
+Before starting a new load-test, a newly created (and running) Mattermost instance with system admin credentials is required.
 
 ### Clone the repository
 
@@ -37,8 +37,8 @@ cp config/config.sample.json config/config.json
 cp config/simplecontroller.sample.json config/simplecontroller.json
 ```
 
-The load-test config file is documented [here](loadtest_config.md).  
-The default [`UserController`](controllers.md) is the `SimpleController`. Its config file is documented [here](simplecontroller_config.md).  
+The load-test config file is documented [here](loadtest_config.md).
+The default [`UserController`](controllers.md) is the `SimpleController`. Its config file is documented [here](simplecontroller_config.md).
 
 ### Run the initialization
 
@@ -50,7 +50,7 @@ Running this command will create initial teams and channels for the users to joi
 
 #### Note
 
-The `init` command generates data as configured by the `InstanceConfiguration` section. It does not pre-populate all the users.  
+The `init` command generates data as configured by the `InstanceConfiguration` section. It does not pre-populate all the users.
 In fact, only 50 users are created and used to generate data. This value was chosen to maximize overall throughput.
 
 ## Running a basic load-test
@@ -77,7 +77,7 @@ A more advanced way to run a load-test is to use the provided load-test agent AP
 go run ./cmd/ltapi
 ```
 
-This will start the server and expose the HTTP API on port 4000 (default).  
+This will start the server and expose the HTTP API on port 4000 (default).
 Using a different terminal it's possible to issue commands to create and run a load-test agent:
 
 ### Create a new load-test agent
@@ -136,14 +136,14 @@ curl -X DELETE http://localhost:4000/loadagent/lt0
 
 ## Running a load-test through the coordinator
 
-An even more advanced way to run a load-test is through the use of the [`coordinator`](coordinator.md).  
-This is especially needed when we need to figure out the maximum number of users the target instance supports.  
+An even more advanced way to run a load-test is through the use of the [`coordinator`](coordinator.md).
+This is especially needed when we need to figure out the maximum number of users the target instance supports.
 The [`coordinator`](coordinator.md) does also help running a load-test across a cluster of agents.
 
-### Prerequisites 
+### Prerequisites
 
 In order to run the [`coordinator`](coordinator.md) a [Prometheus](https://prometheus.io/docs/introduction/overview/) server needs to be running and
-correctly [configured](https://docs.mattermost.com/deployment/metrics.html) for the target Mattermost instance.  
+correctly [configured](https://docs.mattermost.com/deployment/metrics.html) for the target Mattermost instance.
 
 ### Start the load-test agent API server
 
@@ -207,3 +207,6 @@ curl -X POST http://localhost:4000/coordinator/ltc0/stop
 ```sh
 curl -X DELETE http://localhost:4000/coordinator/ltc0
 ```
+## Comparing results
+
+To compare the results of your load tests, see [here](compare.md).

--- a/docs/terraform_loadtest.md
+++ b/docs/terraform_loadtest.md
@@ -6,9 +6,11 @@ This is the recommended way to load-test a Mattermost instance for production.
 
 ## Prerequisites
 
-- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install). Version 0.14 is required.
+- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install). Version 0.14 is required and can be found [here](https://releases.hashicorp.com/terraform/).
 - AWS credentials to be used as described [here](https://www.terraform.io/docs/providers/aws/index.html#authentication).
 - A valid Mattermost E20 license, required to run the load-test through the [`coordinator`](coordinator.md).
+
+If you're a Mattermost staff member, see the [Vault documentation](https://docs.google.com/document/d/1S4i1XFGn7a1VXbtFV28GtbAe56m7fOHDZDgRmm5FBkg/edit#heading=h.ortqmqq1zjyx) for how to generate AWS keys.
 
 **Note**
 
@@ -140,6 +142,10 @@ go run ./cmd/ltctl deployment destroy
 ```
 
 This will permanently destroy all resources for the current deployment.
+
+## Comparing results
+
+To compare the results of your load tests, see [here](compare.md).
 
 ## Debugging
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Some minor doc updates from my experience running the ng load tests for the first time:
* After running through the set up and how to run the load test I didn't immediately no where to look to view results of my test - so added a quick link to the compare doc at the bottom of the setup docs to smooth that out a bit
* Terraform 0.14 took a bit of digging for me to find so I linked it directly - once we have a new perf owner getting this updated to latest terraform versions might be a good idea
* For staff, added a link to the Vault documentation that details how to get AWS credentials since that's not something everyone on the feature teams uses all the time
* My editor killed a bunch of whitespace

