### PR TITLE
MM-40229: Add loadtests for insights feature

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1738,3 +1738,40 @@ func (c *SimulController) updateThreadRead(u user.User) control.UserActionRespon
 
 	return control.UserActionResponse{Info: fmt.Sprintf("updated read state of thread %s", thread.PostId)}
 }
+
+func (c *SimulController) getInsights(u user.User) control.UserActionResponse {
+	team, err := u.Store().CurrentTeam()
+	if errors.Is(err, memstore.ErrTeamStoreEmpty) {
+		return control.UserActionResponse{Info: "no team set"}
+	} else if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	userID := u.Store().Id()
+
+	if rand.Float64() < 0.50 {
+		// view user insights
+		if _, err := u.GetTopThreadsForTeamSince(userID, team.Id, "28_day", 0, 100); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+		if _, err := u.GetTopChannelsForTeamSince(userID, team.Id, "28_day", 0, 100); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+		if _, err := u.GetTopChannelsForTeamSince(userID, team.Id, "28_day", 0, 100); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+	} else {
+		// view team insights
+		if _, err := u.GetTopThreadsForUserSince(userID, team.Id, "28_day", 0, 100); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+		if _, err := u.GetTopChannelsForUserSince(userID, team.Id, "28_day", 0, 100); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+		if _, err := u.GetTopChannelsForUserSince(userID, team.Id, "28_day", 0, 100); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+	}
+
+	return control.UserActionResponse{Info: fmt.Sprintf("viewed insights for user id %s", userID)}
+}

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -218,6 +218,10 @@ func (c *SimulController) Run() {
 			run:       c.updateThreadRead,
 			frequency: 1.17,
 		},
+		{
+			run:       c.getInsights,
+			frequency: 0.8,
+		},
 	}
 
 	for {

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -288,4 +288,12 @@ type User interface {
 	GetSidebarCategories(userID, teamID string) error
 	CreateSidebarCategory(userID, teamID string, category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error)
 	UpdateSidebarCategory(userID, teamID string, categories []*model.SidebarCategoryWithChannels) error
+
+	// Insights
+	GetTopThreadsForTeamSince(userID, teamID string, duration string, offset int, limit int) (*model.TopThreadList, error)
+	GetTopThreadsForUserSince(userID, teamID string, duration string, offset int, limit int) (*model.TopThreadList, error)
+	GetTopChannelsForTeamSince(userID, teamID string, duration string, offset int, limit int) (*model.TopChannelList, error)
+	GetTopChannelsForUserSince(userID, teamID string, duration string, offset int, limit int) (*model.TopChannelList, error)
+	GetTopReactionsForTeamSince(userID, teamID string, duration string, offset int, limit int) (*model.TopReactionList, error)
+	GetTopReactionsForUserSince(userID, teamID string, duration string, offset int, limit int) (*model.TopReactionList, error)
 }

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -1245,3 +1245,71 @@ func (ue *UserEntity) UpdateSidebarCategory(userID, teamID string, categories []
 	// The client fetches and stores all categories again.
 	return ue.GetSidebarCategories(userID, teamID)
 }
+
+// insights related actions
+
+// GetTopThreadsForTeamSince fetches statistics for top threads in a team
+func (ue *UserEntity) GetTopThreadsForTeamSince(userID, teamID string, duration string, offset int, limit int) (*model.TopThreadList, error) {
+	topThreads, _, err := ue.client.GetTopThreadsForTeamSince(teamID, duration, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// The client fetches and stores all categories again.
+	return topThreads, nil
+}
+
+// GetTopThreadsForUserSince fetches statistics for top threads for the logged in user in a team
+func (ue *UserEntity) GetTopThreadsForUserSince(userID, teamID string, duration string, offset int, limit int) (*model.TopThreadList, error) {
+	topThreads, _, err := ue.client.GetTopThreadsForUserSince(teamID, duration, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// The client fetches and stores all categories again.
+	return topThreads, nil
+}
+
+// GetTopChannelsForTeamSince fetches statistics for top channels in a team
+func (ue *UserEntity) GetTopChannelsForTeamSince(userID, teamID string, duration string, offset int, limit int) (*model.TopChannelList, error) {
+	topChannels, _, err := ue.client.GetTopChannelsForTeamSince(teamID, duration, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// The client fetches and stores all categories again.
+	return topChannels, nil
+}
+
+// GetTopChannelsForUserSince fetches statistics for top channels for the logged in user in a team
+func (ue *UserEntity) GetTopChannelsForUserSince(userID, teamID string, duration string, offset int, limit int) (*model.TopChannelList, error) {
+	topChannels, _, err := ue.client.GetTopChannelsForUserSince(teamID, duration, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// The client fetches and stores all categories again.
+	return topChannels, nil
+}
+
+// GetTopReactionsForTeamSince fetches statistics for top threads in a team
+func (ue *UserEntity) GetTopReactionsForTeamSince(userID, teamID string, duration string, offset int, limit int) (*model.TopReactionList, error) {
+	topReactions, _, err := ue.client.GetTopReactionsForTeamSince(teamID, duration, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// The client fetches and stores all categories again.
+	return topReactions, nil
+}
+
+// GetTopReactionsForUserSince fetches statistics for top threads for the logged in user in a team
+func (ue *UserEntity) GetTopReactionsForUserSince(userID, teamID string, duration string, offset int, limit int) (*model.TopReactionList, error) {
+	topReactions, _, err := ue.client.GetTopReactionsForUserSince(teamID, duration, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// The client fetches and stores all categories again.
+	return topReactions, nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Add load tests for top [threads, reactions, channels] endpoints.

W.R.T PRs in mattermost-server:
- https://github.com/mattermost/mattermost-server/pull/20195/
- https://github.com/mattermost/mattermost-server/pull/19850/
- https://github.com/mattermost/mattermost-server/pull/19953

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40229

Subtickets: 
 - https://mattermost.atlassian.net/browse/MM-44371
 - https://mattermost.atlassian.net/browse/MM-44374
 - https://mattermost.atlassian.net/browse/MM-44372
