### PR TITLE
Change Vault instruction to AWS Single Sign-On

### DIFF
--- a/docs/terraform_loadtest.md
+++ b/docs/terraform_loadtest.md
@@ -10,11 +10,7 @@ This is the recommended way to load-test a Mattermost instance for production.
 - AWS credentials to be used as described [here](https://www.terraform.io/docs/providers/aws/index.html#authentication).
 - A valid Mattermost E20 license, required to run the load-test through the [`coordinator`](coordinator.md).
 
-If you're a Mattermost staff member, see the [Vault documentation](https://docs.google.com/document/d/1S4i1XFGn7a1VXbtFV28GtbAe56m7fOHDZDgRmm5FBkg/edit#heading=h.ortqmqq1zjyx) for how to generate AWS keys.
-
-**Note**
-
-If authenticating using the [AWS credentials file](https://www.terraform.io/docs/providers/aws/index.html#shared-credentials-file), the profile to use is `mm-loadtest`.
+If you're a Mattermost staff member, please use [AWS Single Sign-On](https://aws.amazon.com/blogs/security/aws-single-sign-on-now-enables-command-line-interface-access-for-aws-accounts-using-corporate-credentials/) to generate API credentials for the [AWS credentials file](https://www.terraform.io/docs/providers/aws/index.html#shared-credentials-file).
 
 ### Clone the repository
 

--- a/docs/terraform_loadtest.md
+++ b/docs/terraform_loadtest.md
@@ -10,7 +10,7 @@ This is the recommended way to load-test a Mattermost instance for production.
 - AWS credentials to be used as described [here](https://www.terraform.io/docs/providers/aws/index.html#authentication).
 - A valid Mattermost E20 license, required to run the load-test through the [`coordinator`](coordinator.md).
 
-If you're a Mattermost staff member, please use [AWS Single Sign-On](https://aws.amazon.com/blogs/security/aws-single-sign-on-now-enables-command-line-interface-access-for-aws-accounts-using-corporate-credentials/) to generate API credentials for the [AWS credentials file](https://www.terraform.io/docs/providers/aws/index.html#shared-credentials-file).
+If you're a Mattermost staff member, please use [AWS Single Sign-On](https://aws.amazon.com/blogs/security/aws-single-sign-on-now-enables-command-line-interface-access-for-aws-accounts-using-corporate-credentials/) to generate API credentials for the [AWS credentials file](https://www.terraform.io/docs/providers/aws/index.html#shared-credentials-file). Credentials generated for mattermost-loadtest will remain active for 12 hours, at which point you will need to generate new credentials using the Single Sign-On portal.
 
 ### Clone the repository
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

PR updates the Mattermost employee/staff member process to generate AWS credentials from the (legacy) Vault method to using AWS Single Sign-On

#### Ticket Link
Related to thread on Community: https://community.mattermost.com/core/pl/ei3yydgu6ibkfxs6wxjfgnfmpo

