### PR TITLE
Bump version to v1.6.0

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -40,7 +40,7 @@
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",
-  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.5.0/mattermost-load-test-ng-v1.5.0-linux-amd64.tar.gz",
+  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.6.0/mattermost-load-test-ng-v1.6.0-linux-amd64.tar.gz",
   "LogSettings": {
     "EnableConsole": true,
     "ConsoleLevel": "INFO",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -63,7 +63,7 @@ type Config struct {
 	// URL from where to download load-test-ng binaries and configuration files.
 	// The configuration files provided in the package will be overridden in
 	// the deployment process.
-	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.5.0/mattermost-load-test-ng-v1.5.0-linux-amd64.tar.gz" validate:"url"`
+	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.6.0/mattermost-load-test-ng-v1.6.0-linux-amd64.tar.gz" validate:"url"`
 	ElasticSearchSettings ElasticSearchSettings
 	JobServerSettings     JobServerSettings
 	LogSettings           logger.Settings


### PR DESCRIPTION
#### Summary
Created running

```sh
NEXT_VER=v1.6.0 make prepare-release
```

#### Ticket Link
--