### PR TITLE
Add help command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,36 +23,35 @@ PATH=$(shell printenv PATH):$(GOBIN)
 # GOOS/GOARCH of the build host, used to determine whether we're cross-compiling or not
 BUILDER_GOOS_GOARCH="$(shell $(GO) env GOOS)_$(shell $(GO) env GOARCH)"
 
-all: install
+all: install ## Default: alias for 'install'.
 
-build-linux:
+build-linux: ## Build the binary (only for Linux on AMD64).
 	@echo Build Linux amd64
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(AGENT) $(AGENT_ARGS)
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
 
-build-osx:
+build-osx: ## Build the binary (only for OSX on AMD64).
 	@echo Build OSX amd64
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(AGENT) $(AGENT_ARGS)
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
 
-build-windows:
+build-windows: ## Build the binary (only for Windows on AMD64).
 	@echo Build Windows amd64
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(AGENT) $(AGENT_ARGS)
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
 
-assets:
+assets: ## Generate the assets. Install go-bindata if needed.
 	go install github.com/kevinburke/go-bindata/go-bindata@v3.23.0
 	go generate ./...
 	go fmt ./...
 
-build: assets build-linux build-windows build-osx
+build: assets build-linux build-windows build-osx ## Generate the assets and build the binary for all platforms.
 
-# Build and install for the current platform
-install:
+
+install: ## Build and install for the current platform.
 	$(GO) install $(API_SERVER_ARGS)
 
-# We only support Linux to package for now. Package manually for other targets.
-package:
+package: ## Build and package (only available for Linux on AMD64).
 ifneq ($(STATUS), 0)
 	@echo Warning: Repository has uncommitted changes.
 endif
@@ -77,11 +76,11 @@ endif
 	tar -C $(DIST_PATH) -czf $(DIST_PATH)/$(PACKAGE_NAME).tar.gz $(PACKAGE_NAME)
 	rm -rf $(DIST_PATH)/$(PACKAGE_NAME)
 
-verify-gomod:
+verify-gomod: ## Run go mod verify.
 	$(GO) mod download
 	$(GO) mod verify
 
-check-style: golangci-lint
+check-style: golangci-lint ## Check the style of the code.
 
 golangci-lint:
 	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
@@ -89,7 +88,7 @@ golangci-lint:
 	@echo Running golangci-lint
 	golangci-lint run ./...
 
-test:
+test: ## Run all tests.
 	$(GO) test -v -mod=readonly -failfast -race ./...
 
 MATCH=v.+\/mattermost-load-test-ng-v.+-linux-amd64.tar.gz
@@ -99,7 +98,7 @@ BRANCH_NAME=bump-$(NEXT_VER)
 BRANCH_EXISTS=$(shell git rev-parse $(BRANCH_NAME) >/dev/null 2>&1; echo $$?)
 PR_URL=https://github.com/mattermost/mattermost-load-test-ng/compare/master...$(BRANCH_NAME)?quick_pull=1&labels=2:+Dev+Review
 
-prepare-release:
+prepare-release: ## Release step 1: Prepare the PR needed before releasing a new version, identified by the envvar NEXT_VER.
 ifndef NEXT_VER
 	@echo "Error: NEXT_VER must be defined"
 else
@@ -122,7 +121,7 @@ endif
 endif
 endif
 
-release:
+release: ## Release step 2: Perform the release of a new version, identified by the envvar NEXT_VER. Install goreleaser if needed.
 ifndef NEXT_VER
 	@echo "Error: NEXT_VER must be defined"
 else
@@ -137,8 +136,13 @@ else
 endif
 endif
 
-clean:
+clean: ## Remove all generated files to start from scratch.
 	rm -f errors.log cache.db stats.log status.log
 	rm -f .installdeps
 	rm -f loadtest.log
 	rm -rf $(DIST_ROOT)
+
+## Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help: ## Print this help text.
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' ./Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@echo


### PR DESCRIPTION
#### Summary
This PR copies the `make help` command from mattermost-server, so we can easily document every command in the Makefile. Something I missed when I first ran `make` in this repo :)

```
❯ make help
all                Default: alias for 'install'.
assets             Generate the assets. Install go-bindata if needed.
build              Generate the assets and build the binary for all platforms.
build-linux        Build the binary (only for Linux on AMD64).
build-osx          Build the binary (only for OSX on AMD64).
build-windows      Build the binary (only for Windows on AMD64).
check-style        Check the style of the code.
clean              Remove all generated files to start from scratch.
help               Print this help text.
install            Build and install for the current platform.
package            Build and package (only available for Linux on AMD64).
prepare-release    Release step 1: Prepare the PR needed before releasing a new version, identified by the envvar NEXT_VER.
release            Release step 2: Perform the release of a new version, identified by the envvar NEXT_VER. Install goreleaser if needed.
test               Run all tests.
verify-gomod       Run go mod verify.
```

#### Ticket Link
--
