### PR TITLE
Do not ignore lt{agent,api,coordinator}/ dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,11 @@ config/deployer.json
 config/comparison.json
 config/metricswatcher.json
 
+# binaries
+/ltagent
+/ltcoordinator
+/ltapi
+
 # terraform stuff
 /terraformenv
 .terraform

--- a/.gitignore
+++ b/.gitignore
@@ -74,11 +74,6 @@ config/deployer.json
 config/comparison.json
 config/metricswatcher.json
 
-# binaries
-ltagent
-ltcoordinator
-ltapi
-
 # terraform stuff
 /terraformenv
 .terraform

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ endif
 DIST_PATH=$(DIST_ROOT)/$(DIST_VER)
 STATUS=$(shell git diff-index --quiet HEAD --; echo $$?)
 
-AGENT=ltagent
-AGENT_ARGS=-mod=readonly -trimpath ./cmd/ltagent
-API_SERVER=ltapi
-API_SERVER_ARGS=-mod=readonly -trimpath ./cmd/ltapi
-
 GOBIN=$(PWD)/bin
 PATH=$(shell printenv PATH):$(GOBIN)
+
+AGENT=$(GOBIN)/ltagent
+AGENT_ARGS=-mod=readonly -trimpath ./cmd/ltagent
+API_SERVER=$(GOBIN)/ltapi
+API_SERVER_ARGS=-mod=readonly -trimpath ./cmd/ltapi
 
 # GOOS/GOARCH of the build host, used to determine whether we're cross-compiling or not
 BUILDER_GOOS_GOARCH="$(shell $(GO) env GOOS)_$(shell $(GO) env GOARCH)"


### PR DESCRIPTION
#### Summary
Trying to ignore the binaries named `ltagent`, `ltapi` and `ltcoordinator`, we ended up ignoring the whole directories `cmd/ltagent/`, `cmd/ltapi/` and `cmd/ltcoordinator/`, since a line in .gitignore without any slashes matches both files and directories. It seems we have not tried to add *new* files to those directories since we ignored those files [two years ago](https://github.com/mattermost/mattermost-load-test-ng/pull/275), and since the current files there were created before .gitignore contained these matches, this problem has not been detected until now. 

The way I detected it is through a bug in my editor, which was not showing any file under those directories because they were matched by .gitignore, even if git was tracking all files there since before they were added to .gitignore. I'll open a ticket upstream to fix that :)

This fix just removes the culprit lines from `.gitignore` altogether, building the binaries instead in the `bin/` directory, which is already ignored. I've tested that both `make build` and `make package` still work, and `goreleaser` was actually building these in `bin/` already, so I'd say this is safe. But please take a thorough look.

#### Ticket Link
--