### PR TITLE
MM-47828: Replace deprecated ioutil package

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -290,7 +289,7 @@ func getServerVersion(serverURL string) (string, error) {
 		return version, fmt.Errorf("failed to get server version: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(ioutil.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body)
 
 	header := resp.Header["X-Version-Id"]
 	if len(header) > 0 {

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,7 +19,7 @@ import (
 )
 
 func createArchive(inPath, outPath string) error {
-	files, err := ioutil.ReadDir(inPath)
+	files, err := os.ReadDir(inPath)
 	if err != nil {
 		return err
 	}
@@ -95,7 +94,7 @@ func writeReports(results []comparison.Result, outPath string) error {
 			continue
 		}
 		filePath := filepath.Join(outPath, getReportFilename(i, res))
-		if err := ioutil.WriteFile(filePath, []byte(res.Report), 0660); err != nil {
+		if err := os.WriteFile(filePath, []byte(res.Report), 0660); err != nil {
 			return err
 		}
 	}
@@ -128,7 +127,7 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 	archivePath := outputPath
 	archive, _ := cmd.Flags().GetBool("archive")
 	if archive {
-		dir, err := ioutil.TempDir("", "comparison")
+		dir, err := os.MkdirTemp("", "comparison")
 		if err != nil {
 			return fmt.Errorf("failed to create temp dir: %w", err)
 		}

--- a/cmd/metricswatcher/prometheushealthcheck/healthprovider.go
+++ b/cmd/metricswatcher/prometheushealthcheck/healthprovider.go
@@ -6,7 +6,7 @@ package prometheushealthcheck
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -51,7 +51,7 @@ func (h *HealthProvider) Check() HealthCheckResult {
 
 	if !healthy {
 		defer response.Body.Close()
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 		err = errors.New(string(body))
 	}
 

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -481,7 +480,7 @@ func (t *Terraform) updateAppConfig(ip string, sshc *ssh.Client, jobServerEnable
 	}
 
 	if t.config.MattermostConfigPatchFile != "" {
-		data, err := ioutil.ReadFile(t.config.MattermostConfigPatchFile)
+		data, err := os.ReadFile(t.config.MattermostConfigPatchFile)
 		if err != nil {
 			return fmt.Errorf("error reading MattermostConfigPatchFile: %w", err)
 		}
@@ -533,7 +532,7 @@ func (t *Terraform) preFlightCheck() error {
 }
 
 func (t *Terraform) init() error {
-	dir, err := ioutil.TempDir("", "terraform")
+	dir, err := os.MkdirTemp("", "terraform")
 	if err != nil {
 		return err
 	}

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -43,7 +43,7 @@ func doAPIRequest(url, method string, payload io.Reader) (string, error) {
 	defer resp.Body.Close()
 
 	// Dump body.
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -161,7 +161,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	}
 
 	// Upload datasource file
-	buf, err := ioutil.ReadFile(path.Join(t.dir, "datasource.yaml"))
+	buf, err := os.ReadFile(path.Join(t.dir, "datasource.yaml"))
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	}
 
 	// Upload dashboard file
-	buf, err = ioutil.ReadFile(path.Join(t.dir, "dashboard.yaml"))
+	buf, err = os.ReadFile(path.Join(t.dir, "dashboard.yaml"))
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	}
 
 	// Upload dashboard json
-	buf, err = ioutil.ReadFile(path.Join(t.dir, "dashboard_data.json"))
+	buf, err = os.ReadFile(path.Join(t.dir, "dashboard_data.json"))
 	if err != nil {
 		return err
 	}
@@ -193,7 +193,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	}
 
 	if t.output.HasElasticSearch() {
-		buf, err = ioutil.ReadFile(path.Join(t.dir, "es_dashboard_data.json"))
+		buf, err = os.ReadFile(path.Join(t.dir, "es_dashboard_data.json"))
 		if err != nil {
 			return err
 		}

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -161,7 +160,7 @@ func openBrowser(url string) (err error) {
 }
 
 func validateLicense(filename string) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("failed to read license file: %w", err)
 	}

--- a/loadtest/report/generate.go
+++ b/loadtest/report/generate.go
@@ -6,8 +6,8 @@ package report
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
@@ -66,7 +66,7 @@ func New(label string, helper *prometheus.Helper, cfg Config) *Generator {
 // Load loads a report from a given file path.
 func Load(path string) (Report, error) {
 	var r Report
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return r, err
 	}

--- a/loadtest/report/output.go
+++ b/loadtest/report/output.go
@@ -7,7 +7,6 @@ package report
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/exec"
@@ -178,7 +177,7 @@ func printHeader(target io.Writer, cols int) {
 
 // generateGraph creates an input file for GNUplot to create a plot from.
 func generateGraph(name, prefix, baseLabel string, base graph, others []labelValues) error {
-	f, err := ioutil.TempFile("", "tmp.out")
+	f, err := os.CreateTemp("", "tmp.out")
 	if err != nil {
 		return err
 	}
@@ -215,7 +214,7 @@ func generateGraph(name, prefix, baseLabel string, base graph, others []labelVal
 
 // plot creates a gnu plot file and then creates a png output file from it.
 func plot(metric, prefix, fileName string, others []labelValues, baseLabel string) error {
-	f, err := ioutil.TempFile("", "tmp.plt")
+	f, err := os.CreateTemp("", "tmp.plt")
 	if err != nil {
 		return err
 	}

--- a/loadtest/report/output_test.go
+++ b/loadtest/report/output_test.go
@@ -4,7 +4,6 @@
 package report
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestPrintSummary(t *testing.T) {
-	f, err := ioutil.TempFile("", "output")
+	f, err := os.CreateTemp("", "output")
 	require.Nil(t, err)
 	defer os.Remove(f.Name())
 
@@ -355,7 +354,7 @@ func TestPrintSummary(t *testing.T) {
 			_, err = f.Seek(0, os.SEEK_SET)
 			require.Nil(t, err)
 			printSummary(c.cmp, f, 1)
-			output, err := ioutil.ReadFile(f.Name())
+			output, err := os.ReadFile(f.Name())
 			require.Nil(t, err)
 			require.Equal(t, c.expectedOutput, string(output))
 		})


### PR DESCRIPTION
This pr replaces deprecated `ioutil` package usages with corresponding functions in `os` and `io` packages.
Also, there are 3 generated bindata.go files still uses `ioutil`, I am not sure about what to with those.

Fixes https://github.com/mattermost/mattermost-server/issues/21479