### PR TITLE
MM-47262: Bump to v1.3.3

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -30,7 +30,11 @@ const (
 	filePrefix       = "file://"
 )
 
-var minimumRequiredVersion = semver.MustParse("1.3.3")
+// requiredVersion specifies the supported versions of Terraform,
+// which are those that meet the following criteria:
+// 1. installedVersion.Major = requiredVersion.Major
+// 2. installedVersion >= requiredVersion
+var requiredVersion = semver.MustParse("1.3.3")
 
 // A global mutex used to make t.init() safe for concurrent use.
 // This is needed to prevent a data race caused by the "terraform init"

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/assets"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
@@ -27,8 +28,9 @@ const cmdExecTimeoutMinutes = 30
 const (
 	latestReleaseURL = "https://latest.mattermost.com/mattermost-enterprise-linux"
 	filePrefix       = "file://"
-	supportedVersion = 0.15
 )
+
+var minimumRequiredVersion = semver.MustParse("1.3.3")
 
 // A global mutex used to make t.init() safe for concurrent use.
 // This is needed to prevent a data race caused by the "terraform init"

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -115,8 +115,12 @@ func checkTerraformVersion() error {
 		return fmt.Errorf("could not parse installed version: %w", err)
 	}
 
-	if installedVersion.LT(minimumRequiredVersion) {
-		return fmt.Errorf("installed version %q is lower than supported version %q", installedVersion.String(), minimumRequiredVersion.String())
+	if installedVersion.Major > requiredVersion.Major {
+		return fmt.Errorf("installed major version %q is greater than supported major version %q", installedVersion.Major, requiredVersion.Major)
+	}
+
+	if installedVersion.LT(requiredVersion) {
+		return fmt.Errorf("installed version %q is lower than supported version %q", installedVersion.String(), requiredVersion.String())
 	}
 
 	return nil

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -6,15 +6,15 @@ package terraform
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"regexp"
-	"strconv"
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -97,22 +97,26 @@ func (t *Terraform) runCommand(dst io.Writer, args ...string) error {
 }
 
 func checkTerraformVersion() error {
-	out, err := exec.Command("terraform", "version").Output()
+	versionInfoJSON, err := exec.Command("terraform", "version", "-json").Output()
 	if err != nil {
 		return fmt.Errorf("could not run %q command: %w", "terraform version", err)
 	}
 
-	re := regexp.MustCompile(`v\d+.?\d+`)
-	if !re.Match(out) {
-		return fmt.Errorf("could not parse terraform command output: %s", out)
+	var versionInfo struct {
+		Version string `json:"terraform_version"`
 	}
 
-	version, err := strconv.ParseFloat(string(re.Find(out)[1:]), 64)
-	if err != nil {
+	if err := json.Unmarshal(versionInfoJSON, &versionInfo); err != nil {
 		return fmt.Errorf("could not parse terraform command output: %w", err)
 	}
-	if version != supportedVersion {
-		return fmt.Errorf("Terraform version %.2f is required, you have %.2f", supportedVersion, version)
+
+	installedVersion, err := semver.Parse(versionInfo.Version)
+	if err != nil {
+		return fmt.Errorf("could not parse installed version: %w", err)
+	}
+
+	if installedVersion.LT(minimumRequiredVersion) {
+		return fmt.Errorf("installed version %q is lower than supported version %q", installedVersion.String(), minimumRequiredVersion.String())
 	}
 
 	return nil

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -6,7 +6,7 @@ This document explains how to run an automated load-test comparison. **This conf
 
 ## Prerequisites
 
-- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install). Version 0.14 is required.
+- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install). Version 1.3.3 or greater (as long as it's in the v1.x series) is required.
 - AWS credentials to be used as described [here](https://www.terraform.io/docs/providers/aws/index.html#authentication).
 - A valid Mattermost E20 license, required to run the load-test through the [`coordinator`](coordinator.md).
 

--- a/docs/terraform_loadtest.md
+++ b/docs/terraform_loadtest.md
@@ -6,7 +6,7 @@ This is the recommended way to load-test a Mattermost instance for production.
 
 ## Prerequisites
 
-- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install). Version 0.14 is required and can be found [here](https://releases.hashicorp.com/terraform/).
+- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install). Version 1.3.3 or greater (as long as it's in the v1.x series) is required.
 - AWS credentials to be used as described [here](https://www.terraform.io/docs/providers/aws/index.html#authentication-and-configuration). If you're a Mattermost staff member, please use [AWS Single Sign-On](https://aws.amazon.com/blogs/security/aws-single-sign-on-now-enables-command-line-interface-access-for-aws-accounts-using-corporate-credentials/) to generate API credentials for the [AWS credentials file](https://www.terraform.io/docs/providers/aws/index.html#shared-credentials-file). Credentials generated for mattermost-loadtest will remain active for 12 hours, at which point you will need to generate new credentials using the Single Sign-On portal. If you save the profile in the credentials file, make sure to use the name `mm-loadtest`.
 - A valid Mattermost Enterprise license, required to run the load-test through the [`coordinator`](coordinator.md). If you're a Mattermost staff member, you can get a test license in the [~Team: Self-Serve](https://community.mattermost.com/private-core/channels/team-self-serve) channel.
 


### PR DESCRIPTION
#### Summary
It turns out that v1.0 is [basically the same](https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/1-0) as v0.15. That, along with [Terraform v1.x compatibility promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises) makes it so that updating from v0.15 to the latest version, v1.3.3, is just a matter of bumping the supported version.

The only real change in this PR is that the supported version is now actually a minimum supported version, which is now stored under the hood as a `semver` instead of a float.

I've tested this the same way I did with the bump to v0.15:
- Running a normal load test with:
  - `go run ./cmd/ltctl deployment create`
  - `go run ./cmd/ltctl deployment sync`
  - `go run ./cmd/ltctl loadtest start`
  - `go run ./cmd/ltctl loadtest stop`
  - `go run ./cmd/ltctl deployment destroy`
- Running a comparison with:
  - `go run ./cmd/ltctl comparison run`
  - `go run ./cmd/ltctl comparison destroy`

The issue noticed when bumping to v0.15 (see [this comment](https://github.com/mattermost/mattermost-load-test-ng/pull/513#issuecomment-1288515478)) is still there and a ticket has been created to tackle it separately (https://mattermost.atlassian.net/browse/MM-47877), as well as a ticket to tackle the removal of the deprecated `acl` attribute (https://mattermost.atlassian.net/browse/MM-47876).

As the issue reproduces with 0.14 as well and the `acl` issue is not urgent, it's safe to bump now to v1.3.3.

Bonus point: both `comparison destroy` and `deployment destroy` did destroy the S3 bucket, so maybe https://mattermost.atlassian.net/browse/MM-47263 was magically fixed, as we hoped for. I'll test that more thoroughly in the coming days.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47262
