### PR TITLE
MM-47539: Adjust frequency of insights based on Community

### DIFF
--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -232,7 +232,7 @@ func (c *SimulController) Run() {
 		},
 		{
 			run:       c.getInsights,
-			frequency: 1,
+			frequency: 0.011,
 		},
 	}
 


### PR DESCRIPTION
#### Summary
The weight of the Insights feature action in the load-test tool was a random value. This PR adjusts it based on data from Community.

I computed the ratio between the number of calls to `getTopChannelsForTeamSince` and the number of calls to `createPost` (and a bunch of others) at two times:
- Yesterday, Wednesday Oct 26, right after an hour of peak traffic (15:00-16:00 UTC)
- Today, Thursday Oct 27, right after an hour of peak traffic (15:00-16:00 UTC)
![image](https://user-images.githubusercontent.com/3924815/198366470-dd96601f-99cb-4481-b8ee-22a36c25496b.png)
![image](https://user-images.githubusercontent.com/3924815/198366724-65cf69e1-cc4a-4c12-841a-263f39ef71b1.png)

As you can see in the values in the table, we have two similar ratios: 0.0083 and 0.00654. Given that the weight of the action to create a post is 1.5, we have a range of weights for the Insights feature: 0.00981, 0.01245. The average of those two values is 0.01113. Simplifying this value (the data we're working with is just a sample of all possible servers, so the precision of the number is not perfect in any case), we can set the weight of the Insights action to 0.011.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47539

