### PR TITLE
MM-48193: Get a cfg value in terraform.New, not a pointer

### DIFF
--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -136,7 +136,7 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		outputPath = dir
 	}
 
-	cmp, err := comparison.New(cfg, deployerConfig)
+	cmp, err := comparison.New(cfg, &deployerConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize comparison object: %w", err)
 	}
@@ -184,7 +184,7 @@ func DestroyComparisonCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read comparison config: %w", err)
 	}
 
-	cmp, err := comparison.New(cfg, deployerConfig)
+	cmp, err := comparison.New(cfg, &deployerConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize comparison object: %w", err)
 	}

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -71,7 +71,12 @@ func RunSyncCmdF(cmd *cobra.Command, args []string) error {
 }
 
 func RunSSHListCmdF(cmd *cobra.Command, args []string) error {
-	t, err := terraform.New("", nil)
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	t, err := terraform.New("", config)
 	if err != nil {
 		return fmt.Errorf("failed to create terraform engine: %w", err)
 	}
@@ -95,19 +100,19 @@ func RunSSHListCmdF(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getConfig(cmd *cobra.Command) (*deployment.Config, error) {
+func getConfig(cmd *cobra.Command) (deployment.Config, error) {
 	configFilePath, _ := cmd.Flags().GetString("config")
 	cfg, err := deployment.ReadConfig(configFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config: %w", err)
+		return deployment.Config{}, fmt.Errorf("failed to read config: %w", err)
 	}
 
 	if err := defaults.Validate(cfg); err != nil {
-		return nil, fmt.Errorf("failed to validate config: %w", err)
+		return deployment.Config{}, fmt.Errorf("failed to validate config: %w", err)
 	}
 
 	logger.Init(&cfg.LogSettings)
-	return cfg, nil
+	return *cfg, nil
 }
 
 func main() {
@@ -193,7 +198,12 @@ func main() {
 				return RunSSHListCmdF(cmd, args)
 			}
 
-			t, err := terraform.New("", nil)
+			config, err := getConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			t, err := terraform.New("", config)
 			if err != nil {
 				return fmt.Errorf("failed to create terraform engine: %w", err)
 			}
@@ -230,7 +240,12 @@ func main() {
 				return nil
 			}
 
-			t, err := terraform.New("", nil)
+			config, err := getConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			t, err := terraform.New("", config)
 			if err != nil {
 				return fmt.Errorf("failed to create terraform engine: %w", err)
 			}

--- a/cmd/ltctl/report.go
+++ b/cmd/ltctl/report.go
@@ -76,7 +76,12 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if promURL == "" {
-		t, err := terraform.New("", nil)
+		config, err := getConfig(cmd)
+		if err != nil {
+			return err
+		}
+
+		t, err := terraform.New("", config)
 		if err != nil {
 			return fmt.Errorf("failed to create terraform engine: %w", err)
 		}

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -88,7 +88,7 @@ func (c *Comparison) Run() (Output, error) {
 	for dpID, dp := range c.deployments {
 		go func(dpID string, dp *deploymentConfig) {
 			defer wg.Done()
-			t, err := terraform.New(dpID, &dp.config)
+			t, err := terraform.New(dpID, dp.config)
 			if err != nil {
 				errsCh <- fmt.Errorf("failed to create terraform engine: %w", err)
 				return

--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -24,7 +24,7 @@ func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpConf
 	for id, dp := range c.deployments {
 		go func(id string, dp *deploymentConfig) {
 			defer wg.Done()
-			t, err := terraform.New(id, &dp.config)
+			t, err := terraform.New(id, dp.config)
 			if err != nil {
 				errsCh <- fmt.Errorf("failed to create terraform engine: %w", err)
 				return

--- a/comparison/output.go
+++ b/comparison/output.go
@@ -90,7 +90,7 @@ func (c *Comparison) getResults(resultsCh <-chan Result) []Result {
 			defer wg.Done()
 
 			dp := c.deployments[res.deploymentID]
-			t, err := terraform.New(res.deploymentID, &dp.config)
+			t, err := terraform.New(res.deploymentID, dp.config)
 			if err != nil {
 				mlog.Error("Failed to create terraform engine", mlog.Err(err))
 				return

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -53,7 +53,7 @@ type Terraform struct {
 }
 
 // New returns a new Terraform instance.
-func New(id string, cfg *deployment.Config) (*Terraform, error) {
+func New(id string, cfg deployment.Config) (*Terraform, error) {
 	if err := ensureTerraformStateDir(cfg.TerraformStateDir); err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			errStr := fmt.Sprintf("not enough permissions to create Terraform state directory %q.\n", cfg.TerraformStateDir)
@@ -68,7 +68,7 @@ func New(id string, cfg *deployment.Config) (*Terraform, error) {
 
 	return &Terraform{
 		id:     id,
-		config: cfg,
+		config: &cfg,
 	}, nil
 }
 


### PR DESCRIPTION
#### Summary
Now that `terraform.New` always dereferences `cfg`, it's safer to pass it by value. This PR fixes errors such as:
```
❯ go run ./cmd/ltctl ssh
Available instances:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x258 pc=0xb90910]

goroutine 1 [running]:
github.com/mattermost/mattermost-load-test-ng/deployment/terraform.New({0x0, 0x0}, 0x0)
        /home/alejandro/projects/mattermost/mattermost-load-test-ng/deployment/terraform/create.go:57 +0x30
main.RunSSHListCmdF(0xf3da60?, {0xc000010018?, 0xc000a33c50?, 0x1?})
        /home/alejandro/projects/mattermost/mattermost-load-test-ng/cmd/ltctl/main.go:74 +0x34
main.main.func1(0xc0000ccf00?, {0x16f0da0?, 0x0, 0x0})
        /home/alejandro/projects/mattermost/mattermost-load-test-ng/cmd/ltctl/main.go:193 +0x185
github.com/spf13/cobra.(*Command).execute(0xc0000ccf00, {0x16f0da0, 0x0, 0x0})
        /home/alejandro/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:872 +0x694
github.com/spf13/cobra.(*Command).ExecuteC(0xc000628a00)
        /home/alejandro/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
        /home/alejandro/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
main.main()
        /home/alejandro/projects/mattermost/mattermost-load-test-ng/cmd/ltctl/main.go:304 +0xd57
exit status 2
```

I will release a `v1.7.1` with this fix

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48193