### PR TITLE
[GH-21586] - Removed deprecated windows build function in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,6 @@ build-osx: ## Build the binary (only for OSX on AMD64).
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(AGENT) $(AGENT_ARGS)
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
 
-build-windows: ## Build the binary (only for Windows on AMD64).
-	@echo Build Windows amd64
-	env GOOS=windows GOARCH=amd64 $(GO) build -o $(AGENT) $(AGENT_ARGS)
-	env GOOS=windows GOARCH=amd64 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
-
 assets: ## Generate the assets. Install go-bindata if needed.
 	go install github.com/kevinburke/go-bindata/go-bindata@v3.23.0
 	go generate ./...

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,6 +1,6 @@
 ## Developer's workflow
 ### Notes
-The load-test tool does not support Windows
+The load-test tool does not support Windows.
 
 ### Code checking
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,4 +1,6 @@
 ## Developer's workflow
+### Notes
+The load-test tool does not support Windows
 
 ### Code checking
 
@@ -27,8 +29,6 @@ make package
 ### Releasing
 
 We use a combination of `Makefile` and [Goreleser](https://goreleaser.com/) to automate our release process.
-
-NOTE: Makefile no longer supports building the binary file using Windows on AMD64
 
 The release process consists of two steps:
 1. Prepare the release and get the automatically created PR merged.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -28,6 +28,8 @@ make package
 
 We use a combination of `Makefile` and [Goreleser](https://goreleaser.com/) to automate our release process.
 
+NOTE: Makefile no longer supports building the binary file using Windows on AMD64
+
 The release process consists of two steps:
 1. Prepare the release and get the automatically created PR merged.
 2. Do the actual release.


### PR DESCRIPTION


#### Summary
The PR includes the removal of the deprecated build-windows command in the Makefile. Additionally, there is an update to the documentation that windows is no longer supported for make commands.

Please let me know if there is any additional documentation spots that may be a good candidate to add this change, as this is my first OSS PR!

#### Ticket Link
Fixes the following Github issue: https://github.com/mattermost/mattermost-server/issues/21586

