### PR TITLE
fixed emulate typing username on searchGroupChannels for simulcontroller

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1240,7 +1240,13 @@ func searchGroupChannels(u user.User) control.UserActionResponse {
 	// We simulate the user typing up to 4 characters when searching for
 	// a group channel. This is an arbitrary value which fits well with the current
 	// frequency value for this action.
-	return control.EmulateUserTyping(user.Username[:1+rand.Intn(4)], func(term string) control.UserActionResponse {
+	numChars := 4
+	if numChars > len(channel.Name) {
+		// rand.Intn returns a number exclusive of the max limit.
+		// So there's no need to subtract 1.
+		numChars = len(channel.Name)
+	}
+	return control.EmulateUserTyping(user.Username[:1+rand.Intn(numChars)], func(term string) control.UserActionResponse {
 		channels, err := u.SearchGroupChannels(&model.ChannelSearch{
 			Term: user.Username,
 		})

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1241,10 +1241,10 @@ func searchGroupChannels(u user.User) control.UserActionResponse {
 	// a group channel. This is an arbitrary value which fits well with the current
 	// frequency value for this action.
 	numChars := 4
-	if numChars > len(user.UserName) {
+	if numChars > len(user.Username) {
 		// rand.Intn returns a number exclusive of the max limit.
 		// So there's no need to subtract 1.
-		numChars = len(user.UserName)
+		numChars = len(user.Username)
 	}
 	return control.EmulateUserTyping(user.Username[:1+rand.Intn(numChars)], func(term string) control.UserActionResponse {
 		channels, err := u.SearchGroupChannels(&model.ChannelSearch{

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1241,10 +1241,10 @@ func searchGroupChannels(u user.User) control.UserActionResponse {
 	// a group channel. This is an arbitrary value which fits well with the current
 	// frequency value for this action.
 	numChars := 4
-	if numChars > len(channel.Name) {
+	if numChars > len(user.UserName) {
 		// rand.Intn returns a number exclusive of the max limit.
 		// So there's no need to subtract 1.
-		numChars = len(channel.Name)
+		numChars = len(user.UserName)
 	}
 	return control.EmulateUserTyping(user.Username[:1+rand.Intn(numChars)], func(term string) control.UserActionResponse {
 		channels, err := u.SearchGroupChannels(&model.ChannelSearch{


### PR DESCRIPTION
if length username less than 4 then an error occurs "slice bounds out of range"

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fixed length of string on emulate typing username on searchGroupChannels for simulcontroller

#### Ticket Link
https://github.com/mattermost/mattermost-load-test-ng/issues/525

