### PR TITLE
Adding `TerraformStateDir` to deployer config

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -21,6 +21,7 @@
   "EnableAgentFullLogs": true,
   "ProxyInstanceType": "c5.xlarge",
   "SSHPublicKey": "~/.ssh/id_rsa.pub",
+  "TerraformStateDir" : "/var/lib/mattermost-load-test-ng",
   "TerraformDBSettings": {
     "InstanceCount": 1,
     "InstanceEngine": "aurora-postgresql",


### PR DESCRIPTION

#### Summary
You get the below error when this isn't added

```bash
ubuntu@ip-172-31-86-142:~/mattermost-load-test-ng$ go run ./cmd/ltctl deployment create
Error: failed to validate config: TerraformStateDir is empty
exit status 1
```

I manually added it to my `deployer.json` and it fixed the error
