### PR TITLE
Add `S3BucketDumpURI` to `deployer.sample.json`

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -22,6 +22,7 @@
   "ProxyInstanceType": "c5.xlarge",
   "SSHPublicKey": "~/.ssh/id_rsa.pub",
   "TerraformStateDir" : "/var/lib/mattermost-load-test-ng",
+  "S3BucketDumpURI" : "",
   "TerraformDBSettings": {
     "InstanceCount": 1,
     "InstanceEngine": "aurora-postgresql",


### PR DESCRIPTION
## Summary

Adding a default value for `S3BucketDumpURI` to the deployer config. This value doesn't appear required, but this should remove confusion when going to set it. 