### PR TITLE
Added `ServerVersion` to the usercontroller config

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -28,7 +28,8 @@
         "Rate": 30.0,
         "Percentage": 0.3
       }
-    ]
+    ],
+    "ServerVersion" : ""
   },
   "InstanceConfiguration": {
     "NumTeams": 2,


### PR DESCRIPTION
Reading the docs [here](https://github.com/mattermost/mattermost-load-test-ng/blob/master/docs/loadtest_config.md#serverversion) and noticed the serverVersion setting was not included. This PR just includes it as a blank string, since that appears to be the default. 