### PR TITLE
[MM-45947] Added FAQ about using existing infrastructure

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ The rule of thumb is that when starting an unbounded load-test we should always 
 
 Yes, you can use an existing Mattermost deployment, or just the database portion.
 
-Note: You should **not** utilize an existing production setup to loadtest against because the loadtest agent will create users, posts, teams and channels to utilize and utilize most of your server resources. Best practice is to clone your production setup and loadtest against that.
+Note: You should **not** utilize an existing production setup to loadtest against because the loadtest agent will create users, posts, teams and channels and utilize most of your server resources. Best practice is to clone your production setup and loadtest against that.
 
 #### Using an existing Mattermost deployment
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,62 +22,62 @@ The rule of thumb is that when starting an unbounded load-test we should always 
 
 ### Can I use a pre-existing Mattermost or database deployment?
 
-Yes, you can use an existing Mattermost deployment, or just the database portion. 
+Yes, you can use an existing Mattermost deployment, or just the database portion.
 
 Note: You should **not** utilize an existing production setup to loadtest against because
 #### Using an existing Mattermost deployment
 
 1. Set the `AppInstanceCount` and `TerraformDBSettings.InstanceCount` to `0` in the `config/deployer.json`. This will prevent the Mattermost and database cluster from being created.
-2. Update the `ConnectionConfiguration` values in `config/config.json` to the correct information for your pre-existing Mattermost deployment. 
+2. Update the `ConnectionConfiguration` values in `config/config.json` to the correct information for your pre-existing Mattermost deployment.
 
-    `ServerURL` and `WebSocketURL` can be found in your **Mattermost** config.json file under `ServiceSettings`. If `WebSocketURL` is blank then replace `http` / `https` with the appropriate `ws` or `wss` value. 
+	`ServerURL` and `WebSocketURL` can be found in your **Mattermost** config.json file under `ServiceSettings`. If `WebSocketURL` is blank, then replace `http` / `https` with the appropriate `ws` or `wss` value.
 
-    ```json
-    "ConnectionConfiguration": {
-        "ServerURL": "http://localhost:8065",
-        "WebSocketURL": "ws://localhost:8065",
-        "AdminEmail": "sysadmin@sample.mattermost.com",
-        "AdminPassword": "Sys@dmin-sample1"
-    }
-    ```
+	```json
+	"ConnectionConfiguration": {
+    	"ServerURL": "http://localhost:8065",
+    	"WebSocketURL": "ws://localhost:8065",
+    	"AdminEmail": "sysadmin@sample.mattermost.com",
+    	"AdminPassword": "Sys@dmin-sample1"
+	}
+	```
 
 #### Using an existing database deployment
 
-Before attempting to use an existing database ensure your database will accept the connections from where you've configured your resources to deploy into on AWS.
+Before attempting to use an existing database, ensure your database will accept the connections from where you've configured your resources to deploy into on AWS.
 
-1. Set the `TerraformDBSettings.InstanceCount` to `0` in the `config/deployer.json`. This will prevent the database cluster from being created. 
-2. Create a config patch file with the appropriate config settings to access your database. Your patch file should look like the below file, with the values values representing your deployment. 
+1. Set the `TerraformDBSettings.InstanceCount` to `0` in the `config/deployer.json`. This will prevent the database cluster from being created.
+2. Create a config patch file with the appropriate config settings to access your database. Your patch file should look like the below file, with the values representing your deployment.
 
-    Note: In this example we will created a patch file with the below called `configPatch.json` stored in the root loadtest folder. 
+	Note: In this example, we will create a patch file with the below called `configPatch.json` stored in the root loadtest folder.
 
-    ```json
-    {
-    "SqlSettings": {
-            "DriverName": "postgres",
-            "DataSource": "postgres://mmuser:mostest@databaseURL:port/mattermost?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
-            "DataSourceReplicas": [],
-            "DataSourceSearchReplicas": [],
-            "MaxIdleConns": 20,
-            "ConnMaxLifetimeMilliseconds": 3600000,
-            "ConnMaxIdleTimeMilliseconds": 300000,
-            "MaxOpenConns": 300,
-            "Trace": false,
-            "AtRestEncryptKey": "x85qyzyufe7aoh9a7upbyq6jrf5yas1r",
-            "QueryTimeout": 30,
-            "DisableDatabaseSearch": false,
-            "MigrationsStatementTimeoutSeconds": 100000,
-            "ReplicaLagSettings": []
-        }
-    }
-    ```
+	```json
+	{
+	"SqlSettings": {
+        	"DriverName": "postgres",
+        	"DataSource": "postgres://mmuser:mostest@databaseURL:port/mattermost?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
+        	"DataSourceReplicas": [],
+        	"DataSourceSearchReplicas": [],
+        	"MaxIdleConns": 20,
+        	"ConnMaxLifetimeMilliseconds": 3600000,
+        	"ConnMaxIdleTimeMilliseconds": 300000,
+        	"MaxOpenConns": 300,
+        	"Trace": false,
+        	"AtRestEncryptKey": "x85qyzyufe7aoh9a7upbyq6jrf5yas1r",
+        	"QueryTimeout": 30,
+        	"DisableDatabaseSearch": false,
+        	"MigrationsStatementTimeoutSeconds": 100000,
+        	"ReplicaLagSettings": []
+    	}
+	}
+	```
 
 3. Modify `MattermostConfigPatchFile` within the `config/deployer.json` file to point to your patch file with an absolute path.
 
-    Example:
-    ```json
-    "MattermostConfigPatchFile": "/home/ubuntu/mattermost-load-test-ng/configPatch.json",
-    ```
-4. Continue with the deployment create process. 
+	Example:
+	```json
+	"MattermostConfigPatchFile": "/home/ubuntu/mattermost-load-test-ng/configPatch.json",
+	```
+4. Continue with the deployment create process.
 
 ## Troubleshooting
 
@@ -98,3 +98,5 @@ The following command can be run to raise the limit to the suggested value:
 ```sh
 ulimit -n VALUE
 ```
+
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,6 +20,65 @@ This type of load-test is used to determine the capacity of a system and will ou
 The rule of thumb is that when starting an unbounded load-test we should always shoot for more users than what we think an installation can support.
 `ClusterConfig.MaxActiveUsers`  should be set to  `AgentInstanceCount * UsersConfiguration.MaxActiveUsers`.
 
+### Can I use a pre-existing Mattermost or database deployment?
+
+Yes, you can use an existing Mattermost deployment, or just the database portion. 
+
+Note: You should **not** utilize an existing production setup to loadtest against because
+#### Using an existing Mattermost deployment
+
+1. Set the `AppInstanceCount` and `TerraformDBSettings.InstanceCount` to `0` in the `config/deployer.json`. This will prevent the Mattermost and database cluster from being created.
+2. Update the `ConnectionConfiguration` values in `config/config.json` to the correct information for your pre-existing Mattermost deployment. 
+
+    `ServerURL` and `WebSocketURL` can be found in your **Mattermost** config.json file under `ServiceSettings`. If `WebSocketURL` is blank then replace `http` / `https` with the appropriate `ws` or `wss` value. 
+
+    ```json
+    "ConnectionConfiguration": {
+        "ServerURL": "http://localhost:8065",
+        "WebSocketURL": "ws://localhost:8065",
+        "AdminEmail": "sysadmin@sample.mattermost.com",
+        "AdminPassword": "Sys@dmin-sample1"
+    }
+    ```
+
+#### Using an existing database deployment
+
+Before attempting to use an existing database ensure your database will accept the connections from where you've configured your resources to deploy into on AWS.
+
+1. Set the `TerraformDBSettings.InstanceCount` to `0` in the `config/deployer.json`. This will prevent the database cluster from being created. 
+2. Create a config patch file with the appropriate config settings to access your database. Your patch file should look like the below file, with the values values representing your deployment. 
+
+    Note: In this example we will created a patch file with the below called `configPatch.json` stored in the root loadtest folder. 
+
+    ```json
+    {
+    "SqlSettings": {
+            "DriverName": "postgres",
+            "DataSource": "postgres://mmuser:mostest@databaseURL:port/mattermost?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
+            "DataSourceReplicas": [],
+            "DataSourceSearchReplicas": [],
+            "MaxIdleConns": 20,
+            "ConnMaxLifetimeMilliseconds": 3600000,
+            "ConnMaxIdleTimeMilliseconds": 300000,
+            "MaxOpenConns": 300,
+            "Trace": false,
+            "AtRestEncryptKey": "x85qyzyufe7aoh9a7upbyq6jrf5yas1r",
+            "QueryTimeout": 30,
+            "DisableDatabaseSearch": false,
+            "MigrationsStatementTimeoutSeconds": 100000,
+            "ReplicaLagSettings": []
+        }
+    }
+    ```
+
+3. Modify `MattermostConfigPatchFile` within the `config/deployer.json` file to point to your patch file with an absolute path.
+
+    Example:
+    ```json
+    "MattermostConfigPatchFile": "/home/ubuntu/mattermost-load-test-ng/configPatch.json",
+    ```
+4. Continue with the deployment create process. 
+
 ## Troubleshooting
 
 ### Users are not connecting

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,28 +18,29 @@ To manually run a bounded load-test using the [`coordinator`](https://github.com
 We define a load-test to be unbounded when the number of simulated users can vary up to a pre-configured limit.
 This type of load-test is used to determine the capacity of a system and will output an estimated number of users.
 The rule of thumb is that when starting an unbounded load-test we should always shoot for more users than what we think an installation can support.
-`ClusterConfig.MaxActiveUsers`  should be set to  `AgentInstanceCount * UsersConfiguration.MaxActiveUsers`.
+`ClusterConfig.MaxActiveUsers` should be set to `AgentInstanceCount * UsersConfiguration.MaxActiveUsers`.
 
 ### Can I use a pre-existing Mattermost or database deployment?
 
 Yes, you can use an existing Mattermost deployment, or just the database portion.
 
 Note: You should **not** utilize an existing production setup to loadtest against because
+
 #### Using an existing Mattermost deployment
 
 1. Set the `AppInstanceCount` and `TerraformDBSettings.InstanceCount` to `0` in the `config/deployer.json`. This will prevent the Mattermost and database cluster from being created.
 2. Update the `ConnectionConfiguration` values in `config/config.json` to the correct information for your pre-existing Mattermost deployment.
 
-	`ServerURL` and `WebSocketURL` can be found in your **Mattermost** config.json file under `ServiceSettings`. If `WebSocketURL` is blank, then replace `http` / `https` with the appropriate `ws` or `wss` value.
+    `ServerURL` and `WebSocketURL` can be found in your **Mattermost** config.json file under `ServiceSettings`. If `WebSocketURL` is blank, then replace `http` / `https` with the appropriate `ws` or `wss` value.
 
-	```json
-	"ConnectionConfiguration": {
+    ```json
+    "ConnectionConfiguration": {
     	"ServerURL": "http://localhost:8065",
     	"WebSocketURL": "ws://localhost:8065",
     	"AdminEmail": "sysadmin@sample.mattermost.com",
     	"AdminPassword": "Sys@dmin-sample1"
-	}
-	```
+    }
+    ```
 
 #### Using an existing database deployment
 
@@ -48,35 +49,37 @@ Before attempting to use an existing database, ensure your database will accept 
 1. Set the `TerraformDBSettings.InstanceCount` to `0` in the `config/deployer.json`. This will prevent the database cluster from being created.
 2. Create a config patch file with the appropriate config settings to access your database. Your patch file should look like the below file, with the values representing your deployment.
 
-	Note: In this example, we will create a patch file with the below called `configPatch.json` stored in the root loadtest folder.
+    Note: In this example, we will create a patch file with the below called `configPatch.json` stored in the root loadtest folder.
 
-	```json
-	{
-	"SqlSettings": {
-        	"DriverName": "postgres",
-        	"DataSource": "postgres://mmuser:mostest@databaseURL:port/mattermost?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
-        	"DataSourceReplicas": [],
-        	"DataSourceSearchReplicas": [],
-        	"MaxIdleConns": 20,
-        	"ConnMaxLifetimeMilliseconds": 3600000,
-        	"ConnMaxIdleTimeMilliseconds": 300000,
-        	"MaxOpenConns": 300,
-        	"Trace": false,
-        	"AtRestEncryptKey": "x85qyzyufe7aoh9a7upbyq6jrf5yas1r",
-        	"QueryTimeout": 30,
-        	"DisableDatabaseSearch": false,
-        	"MigrationsStatementTimeoutSeconds": 100000,
-        	"ReplicaLagSettings": []
-    	}
-	}
-	```
+    ```json
+    {
+        "SqlSettings": {
+            "DriverName": "postgres",
+            "DataSource": "postgres://mmuser:mostest@databaseURL:port/mattermost?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
+            "DataSourceReplicas": [],
+            "DataSourceSearchReplicas": [],
+            "MaxIdleConns": 20,
+            "ConnMaxLifetimeMilliseconds": 3600000,
+            "ConnMaxIdleTimeMilliseconds": 300000,
+            "MaxOpenConns": 300,
+            "Trace": false,
+            "AtRestEncryptKey": "x85qyzyufe7aoh9a7upbyq6jrf5yas1r",
+            "QueryTimeout": 30,
+            "DisableDatabaseSearch": false,
+            "MigrationsStatementTimeoutSeconds": 100000,
+            "ReplicaLagSettings": []
+        }
+    }
+    ```
 
 3. Modify `MattermostConfigPatchFile` within the `config/deployer.json` file to point to your patch file with an absolute path.
 
-	Example:
-	```json
-	"MattermostConfigPatchFile": "/home/ubuntu/mattermost-load-test-ng/configPatch.json",
-	```
+    Example:
+
+    ```json
+    "MattermostConfigPatchFile": "/home/ubuntu/mattermost-load-test-ng/configPatch.json",
+    ```
+
 4. Continue with the deployment create process.
 
 ## Troubleshooting
@@ -95,8 +98,7 @@ Also the `Max Users Per Team` setting in Mattermost System Console should be eno
 
 This means the maximum number of file descriptors is lower than what the agent needs to operate.  
 The following command can be run to raise the limit to the suggested value:
+
 ```sh
 ulimit -n VALUE
 ```
-
-

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ The rule of thumb is that when starting an unbounded load-test we should always 
 
 Yes, you can use an existing Mattermost deployment, or just the database portion.
 
-Note: You should **not** utilize an existing production setup to loadtest against because
+Note: You should **not** utilize an existing production setup to loadtest against because the loadtest agent will create users, posts, teams and channels to utilize and utilize most of your server resources. Best practice is to clone your production setup and loadtest against that.
 
 #### Using an existing Mattermost deployment
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,7 +55,7 @@ Before attempting to use an existing database, ensure your database will accept 
     {
         "SqlSettings": {
             "DriverName": "postgres",
-            "DataSource": "postgres://mmuser:mostest@databaseURL:port/mattermost?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
+            "DataSource": "postgres://mmuser:mostest@databaseURL:port/mattermost_test?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
             "DataSourceReplicas": [],
             "DataSourceSearchReplicas": [],
             "MaxIdleConns": 20,
@@ -63,7 +63,7 @@ Before attempting to use an existing database, ensure your database will accept 
             "ConnMaxIdleTimeMilliseconds": 300000,
             "MaxOpenConns": 300,
             "Trace": false,
-            "AtRestEncryptKey": "x85qyzyufe7aoh9a7upbyq6jrf5yas1r",
+            "AtRestEncryptKey": "",
             "QueryTimeout": 30,
             "DisableDatabaseSearch": false,
             "MigrationsStatementTimeoutSeconds": 100000,


### PR DESCRIPTION
#### Summary
The docs might be a bit verbose, just tried to give solid examples.

The existing database portion requires a workaround of setting the `InstanceEngine` to `aurora-mysql` to prevent a create command from running - https://github.com/mattermost/mattermost-load-test-ng/blob/2a982ad15971f9166f5c33d1d7263aa57baf7ad8/deployment/terraform/create.go#L387

I'm going to add another related PR to see if I can make that cancel early, same as when it encounters `aurora-mysql` in the string.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45947.
