### PR TITLE
MM-49581: Add path, method and code to HTTPRequestTimes

### DIFF
--- a/loadtest/user/userentity/metrics.go
+++ b/loadtest/user/userentity/metrics.go
@@ -31,9 +31,13 @@ func (ue *UserEntity) incHTTPErrors(path, method string, status int) {
 	}
 }
 
-func (ue *UserEntity) observeHTTPRequestTimes(elapsed float64) {
+func (ue *UserEntity) observeHTTPRequestTimes(path, method string, status int, elapsed float64) {
 	if ue.metrics != nil {
-		ue.metrics.HTTPRequestTimes.Observe(elapsed)
+		ue.metrics.HTTPRequestTimes.With(prometheus.Labels{
+			"path":        path,
+			"method":      method,
+			"status_code": strconv.Itoa(status),
+		}).Observe(elapsed)
 	}
 }
 

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -72,7 +72,7 @@ type ueTransport struct {
 func (t *ueTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	startTime := time.Now()
 	resp, err := t.transport.RoundTrip(req)
-	t.ue.observeHTTPRequestTimes(time.Since(startTime).Seconds())
+	t.ue.observeHTTPRequestTimes(req.URL.Path, req.Method, resp.StatusCode, time.Since(startTime).Seconds())
 	if os.IsTimeout(err) {
 		t.ue.incHTTPTimeouts(req.URL.Path, req.Method)
 	}

--- a/performance/metrics.go
+++ b/performance/metrics.go
@@ -17,7 +17,7 @@ const (
 )
 
 type UserEntityMetrics struct {
-	HTTPRequestTimes     prometheus.Histogram
+	HTTPRequestTimes     *prometheus.HistogramVec
 	HTTPErrors           *prometheus.CounterVec
 	HTTPTimeouts         *prometheus.CounterVec
 	WebSocketConnections prometheus.Gauge
@@ -32,12 +32,13 @@ func NewMetrics() *Metrics {
 	var m Metrics
 	m.registry = prometheus.NewRegistry()
 
-	m.ueMetrics.HTTPRequestTimes = prometheus.NewHistogram(prometheus.HistogramOpts{
+	m.ueMetrics.HTTPRequestTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metricsNamespace,
 		Subsystem: metricsSubSystemHTTP,
 		Name:      "request_time",
 		Help:      "The time taken to execute client requests.",
-	})
+	},
+		[]string{"path", "method", "status_code"})
 	m.registry.MustRegister(m.ueMetrics.HTTPRequestTimes)
 
 	m.ueMetrics.HTTPErrors = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
#### Summary
The `loadtest_http_request_time_{sum,count,bucket}` metric is right now a `prometheus.Histogram`, so it doesn't have labels. This PR converts it to a `prometheus.HistogramVec`, and adds three labels to it:
1. Request path
2. Request method
3. Request status code

The observation of the time itself is unchanged, this PR only adds those dimensions.

This is always useful, but in this metric may be even more, since one of the main queries used by the coordinator to decrease users and eventually stop the tests uses this specific metric. Having some more fine-grained information there will help us analyze the results of the load-tests in more detail.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49581