### PR TITLE
MM-49682: Move admin user creation right after server setup

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -157,12 +157,6 @@ func (t *Terraform) Create(initData bool) error {
 				return fmt.Errorf("could not modify default_search_text_config: %w", err)
 			}
 		}
-
-		if initData {
-			if err := t.createAdminUser(extAgent); err != nil {
-				return fmt.Errorf("could not create admin user: %w", err)
-			}
-		}
 	}
 
 	if t.output.HasAppServers() {
@@ -182,6 +176,12 @@ func (t *Terraform) Create(initData bool) error {
 			return fmt.Errorf("error whiling pinging server: %w", err)
 		}
 
+	}
+
+	if t.output.HasDB() && initData {
+		if err := t.createAdminUser(extAgent); err != nil {
+			return fmt.Errorf("could not create admin user: %w", err)
+		}
 	}
 
 	if err := t.setupLoadtestAgents(extAgent, initData); err != nil {


### PR DESCRIPTION
#### Summary
PR #535 inverted the order of server creation and admin user creation, so that the deployer was trying to create the user without having set up the server, and hence failed.

As an aside: we should start thinking about setting up some E2E tests; something as simple as "run deployment create and make sure that the server is up" would have prevented this. The thing is: I'm not sure what's the best way to do this without burning money on AWS every time we run CI.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49682

