### PR TITLE
MM-47263: Empty S3 bucket with AWS CLI on destroy

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -553,6 +553,10 @@ func (t *Terraform) preFlightCheck() error {
 		return fmt.Errorf("failed when checking terraform version: %w", err)
 	}
 
+	if err := checkAWSCLI(t.Config().AWSProfile); err != nil {
+		return fmt.Errorf("failed when checking AWS CLI: %w", err)
+	}
+
 	if !t.initialized {
 		if err := t.init(); err != nil {
 			return err

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -3,11 +3,38 @@
 
 package terraform
 
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
 // Destroy destroys the created load-test environment.
 func (t *Terraform) Destroy() error {
 	if err := t.preFlightCheck(); err != nil {
 		return err
 	}
+
+	// Empty the S3 bucket concurrently with the main terraform destroy command
+	// to ensure that it is properly destroyed (https://mattermost.atlassian.net/browse/MM-47263)
+	emptyBucketCtx, emptyBucketCancel := context.WithCancel(context.Background())
+	defer emptyBucketCancel()
+	emptyBucketErrCh := make(chan error, 1)
+	go func() {
+		if t.output.HasS3Bucket() {
+			mlog.Info("emptying S3 bucket s3://" + t.output.S3Bucket.Id)
+			emptyS3BucketArgs := []string{"--profile", t.Config().AWSProfile, "s3", "rm", "s3://" + t.output.S3Bucket.Id, "--recursive"}
+			if err := exec.CommandContext(emptyBucketCtx, "aws", emptyS3BucketArgs...).Run(); err != nil {
+				emptyBucketErrCh <- fmt.Errorf("failed to run local cmd \"aws %s\": %w", strings.Join(emptyS3BucketArgs, " "), err)
+				return
+			}
+			mlog.Info("emptied S3 bucket s3://" + t.output.S3Bucket.Id)
+		}
+		emptyBucketErrCh <- nil
+	}()
 
 	var params []string
 	params = append(params, "destroy")
@@ -18,6 +45,15 @@ func (t *Terraform) Destroy() error {
 
 	if err := t.runCommand(nil, params...); err != nil {
 		return err
+	}
+
+	// Make sure that the empty bucket command has finished and check for any
+	// possible errors. The check may be redundant, since if we're already
+	// here, it means that the terraform destroy has finished successfullly, so
+	// the S3 command should have finished as well. Better safe than sorry, though.
+	err := <-emptyBucketErrCh
+	if err != nil {
+		return fmt.Errorf("failed to empty s3://%s: %w", t.output.S3Bucket.Id, err)
 	}
 
 	return t.loadOutput()

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -18,8 +18,15 @@ func (t *Terraform) Destroy() error {
 		return err
 	}
 
+	// We need to load the output to check whether the deployment has an S3
+	// bucket to destroy
+	if err := t.loadOutput(); err != nil {
+		return err
+	}
+
 	// Empty the S3 bucket concurrently with the main terraform destroy command
-	// to ensure that it is properly destroyed (https://mattermost.atlassian.net/browse/MM-47263)
+	// to ensure that it is properly destroyed
+	// See https://mattermost.atlassian.net/browse/MM-47263
 	emptyBucketCtx, emptyBucketCancel := context.WithCancel(context.Background())
 	defer emptyBucketCancel()
 	emptyBucketErrCh := make(chan error, 1)

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -118,3 +118,14 @@ func checkTerraformVersion() error {
 
 	return nil
 }
+
+// checkAWSCLI checks that the aws command is available in the system, and that
+// the profile that will be used is correctly configured
+func checkAWSCLI(profile string) error {
+	cmd := exec.Command("aws", "configure", "list", "--profile", profile)
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("the AWS CLI is either not installed or the configured profile %q is not stored in the credentials; error: %w", profile, err)
+	}
+	return nil
+}


### PR DESCRIPTION
#### Summary
This bug is a funny one, since it's not reproducible at all. I've seen it in the wild at some point after bumping to Terraform v1 (much less than before, but this may be just luck), although for me it usually was fixed with a second run of `deployment destroy`. However, it's been reported at least once that this happened even after three executions of `deployment destroy`, which always timed out at the 30-minute mark with only the S3 bucket left to destroy. The only solution that has consistently worked for each and every instance of this bug was to manually empty the S3 bucket, even while the `deployment destroy` command was executing: that is, running `aws --profile mm-loadtest s3 rm s3://bucket.id` concurrently with the destroy.

So that's what this PR does: it adds some defense code to run the `aws` command concurrently with the destroy. The third commit also adds a check to validate as soon as possible that the `aws` command is available in the system, so we can fail early if it's not there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47263