### PR TITLE
MM-40056: Don't use sed if there are no IPs to replace

### DIFF
--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -156,7 +156,10 @@ func buildLoadDBDumpCmds(dumpFilename string, newIP string, permalinkIPsToReplac
 		sedRegex := fmt.Sprintf(`'s/%s/%s/g'`, match, replace)
 		replacements = append(replacements, sedRegex)
 	}
-	sedCmd := strings.Join(append([]string{"sed -r"}, replacements...), " -e ")
+	var sedCmd string
+	if len(replacements) > 0 {
+		sedCmd = strings.Join(append([]string{"sed -r"}, replacements...), " -e ")
+	}
 
 	var dbCmd string
 	switch dbInfo.Engine {
@@ -166,6 +169,10 @@ func buildLoadDBDumpCmds(dumpFilename string, newIP string, permalinkIPsToReplac
 		dbCmd = fmt.Sprintf("mysql -h %[1]s -u %[2]s -p%[3]s %[4]s", dbInfo.Host, dbInfo.UserName, dbInfo.Password, dbInfo.DBName)
 	default:
 		return []string{}, fmt.Errorf("invalid db engine %s", dbInfo.Engine)
+	}
+
+	if sedCmd == "" {
+		return []string{zcatCmd, dbCmd}, nil
 	}
 
 	return []string{zcatCmd, sedCmd, dbCmd}, nil

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -171,11 +171,11 @@ func buildLoadDBDumpCmds(dumpFilename string, newIP string, permalinkIPsToReplac
 		return []string{}, fmt.Errorf("invalid db engine %s", dbInfo.Engine)
 	}
 
-	if sedCmd == "" {
-		return []string{zcatCmd, dbCmd}, nil
+	if sedCmd != "" {
+		return []string{zcatCmd, sedCmd, dbCmd}, nil
 	}
 
-	return []string{zcatCmd, sedCmd, dbCmd}, nil
+	return []string{zcatCmd, dbCmd}, nil
 }
 
 func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename string, s3BucketURI string, permalinkIPsToReplace []string, cancelCh <-chan struct{}) error {

--- a/comparison/loadtest_test.go
+++ b/comparison/loadtest_test.go
@@ -9,40 +9,61 @@ import (
 )
 
 func TestBuildLoadDBDumpCmd(t *testing.T) {
-	newIP := "192.168.1.1"
-	oldIPs := []string{"54.78.456.5", "56.78.98.1"}
+	t.Run("without permalink IPs to replace", func(t *testing.T) {
+		newIP := "192.168.1.1"
+		oldIPs := []string{}
 
-	cmds, err := buildLoadDBDumpCmds("dbfilename", newIP, oldIPs, dbSettings{
-		UserName: "mmuser",
-		Password: "mostest",
-		DBName:   "mattermost",
-		Host:     "test-db-0.c0gzspkyf2r5.us-east-1.rds.amazonaws.com",
-		Engine:   "aurora-postgresql",
+		cmds, err := buildLoadDBDumpCmds("dbfilename", newIP, oldIPs, dbSettings{
+			UserName: "mmuser",
+			Password: "mostest",
+			DBName:   "mattermost",
+			Host:     "test-db-0.c0gzspkyf2r5.us-east-1.rds.amazonaws.com",
+			Engine:   "aurora-postgresql",
+		})
+		require.NoError(t, err)
+
+		// Check the slice contains only two commands: zcat and psql
+		require.Len(t, cmds, 2)
+		require.True(t, strings.HasPrefix(cmds[0], "zcat"))
+		require.True(t, strings.HasPrefix(cmds[1], "psql"))
 	})
-	require.NoError(t, err)
 
-	// Pre-flight check: the slice should contain three commands: zcat, sed and psql
-	require.Len(t, cmds, 3)
-	require.True(t, strings.HasPrefix(cmds[0], "zcat"))
-	require.True(t, strings.HasPrefix(cmds[1], "sed"))
-	require.True(t, strings.HasPrefix(cmds[2], "psql"))
+	t.Run("with permalink IPs to replace", func(t *testing.T) {
+		newIP := "192.168.1.1"
+		oldIPs := []string{"54.78.456.5", "56.78.98.1"}
 
-	// Check that the old IPs are indeed replaced and unrelated IPs are kept
-	input := "54.78.456.5:8065/teamname/pl/id1 56.78.98.1/anotherteam/pl/id2 11.22.33.4/teamname/pl/id3"
-	expectedOutput := "192.168.1.1:8065/teamname/pl/id1 192.168.1.1:8065/anotherteam/pl/id2 11.22.33.4/teamname/pl/id3"
-	// We need to remove the single quotes here for the command to work with
-	// os/exec (in the actual code, it is sent through ssh and they're needed).
-	// We also need to split the binary name and the arguments to pass everything
-	// to exec.Command
-	binaryWithArguments := strings.Split(strings.ReplaceAll(cmds[1], "'", ""), " ")
-	binaryName := binaryWithArguments[0]
-	arguments := binaryWithArguments[1:]
-	sedCmd := exec.Command(binaryName, arguments...)
+		cmds, err := buildLoadDBDumpCmds("dbfilename", newIP, oldIPs, dbSettings{
+			UserName: "mmuser",
+			Password: "mostest",
+			DBName:   "mattermost",
+			Host:     "test-db-0.c0gzspkyf2r5.us-east-1.rds.amazonaws.com",
+			Engine:   "aurora-postgresql",
+		})
+		require.NoError(t, err)
 
-	// Send the input string to the sed command and compare the output against
-	// the expected one
-	sedCmd.Stdin = strings.NewReader(input)
-	stdout, err := sedCmd.Output()
-	require.NoError(t, err)
-	require.Equal(t, expectedOutput, string(stdout))
+		// Pre-flight check: the slice should contain three commands: zcat, sed and psql
+		require.Len(t, cmds, 3)
+		require.True(t, strings.HasPrefix(cmds[0], "zcat"))
+		require.True(t, strings.HasPrefix(cmds[1], "sed"))
+		require.True(t, strings.HasPrefix(cmds[2], "psql"))
+
+		// Check that the old IPs are indeed replaced and unrelated IPs are kept
+		input := "54.78.456.5:8065/teamname/pl/id1 56.78.98.1/anotherteam/pl/id2 11.22.33.4/teamname/pl/id3"
+		expectedOutput := "192.168.1.1:8065/teamname/pl/id1 192.168.1.1:8065/anotherteam/pl/id2 11.22.33.4/teamname/pl/id3"
+		// We need to remove the single quotes here for the command to work with
+		// os/exec (in the actual code, it is sent through ssh and they're needed).
+		// We also need to split the binary name and the arguments to pass everything
+		// to exec.Command
+		binaryWithArguments := strings.Split(strings.ReplaceAll(cmds[1], "'", ""), " ")
+		binaryName := binaryWithArguments[0]
+		arguments := binaryWithArguments[1:]
+		sedCmd := exec.Command(binaryName, arguments...)
+
+		// Send the input string to the sed command and compare the output against
+		// the expected one
+		sedCmd.Stdin = strings.NewReader(input)
+		stdout, err := sedCmd.Output()
+		require.NoError(t, err)
+		require.Equal(t, expectedOutput, string(stdout))
+	})
 }


### PR DESCRIPTION
#### Summary
#536 introduced a bug that caused the loading of the DB dump to fail when `PermalinkIPsToReplace` is empty, since the resulting `sed` command was malformed. These changes skip the `sed` command altogether when there is nothing to  replace.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50046
