### PR TITLE
Use locally installed golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ DIST_PATH=$(DIST_ROOT)/$(DIST_VER)
 STATUS=$(shell git diff-index --quiet HEAD --; echo $$?)
 
 GOBIN=$(PWD)/bin
+# We need to export GOBIN to allow it to be set
+# for processes spawned from the Makefile
+export GOBIN ?= $(PWD)/bin
+
 PATH=$(shell printenv PATH):$(GOBIN)
 
 AGENT=$(GOBIN)/ltagent
@@ -81,7 +85,7 @@ golangci-lint:
 	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 	@echo Running golangci-lint
-	golangci-lint run ./...
+	$(GOBIN)/golangci-lint run ./...
 
 test: ## Run all tests.
 	$(GO) test -v -mod=readonly -failfast -race ./...


### PR DESCRIPTION
#### Summary

It's been a while :) 

@coltoneshaw was having [some troubles](https://community.mattermost.com/core/pl/9iheekun8instro73reuafgquw) when building and it turns out we were not using the `golangci-lint` version we are installing but pointing to a system wide one most likely.
