### PR TITLE
MM-50356: Avoid a nil pointer dereference if RoundTrip fails

### DIFF
--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -72,7 +72,11 @@ type ueTransport struct {
 func (t *ueTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	startTime := time.Now()
 	resp, err := t.transport.RoundTrip(req)
-	t.ue.observeHTTPRequestTimes(req.URL.Path, req.Method, resp.StatusCode, time.Since(startTime).Seconds())
+	var statusCode int
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	t.ue.observeHTTPRequestTimes(req.URL.Path, req.Method, statusCode, time.Since(startTime).Seconds())
 	if os.IsTimeout(err) {
 		t.ue.incHTTPTimeouts(req.URL.Path, req.Method)
 	}


### PR DESCRIPTION
#### Summary

Although @agnivade has already fixed this in the latest commit of [this open PR](https://github.com/mattermost/mattermost-load-test-ng/pull/544), I wanted to open this to discuss separately.

There are two alternatives to solve this:
1. What this commit does: use 0 as statusCode when RoundTrip fails. This gives more information to the metric, since 0 is not a valid HTTP status code, which informs that RoundTrip failed. However, if the users don't know this bit, seeing a 0 there in the metric data can be confusing.
2. Observe the metric only if t.transport.RoundTrip(req) finishes successfully. This avoids the confusion with a 0 statusCode, but it also skips all failing round trips, which most probably fail because of a timeout, which are useful to see in the metric.

I think having some potential confusion is better than skipping some data points, so I opted for one. Thoughts?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50356
