### PR TITLE
Remove build-windows dependency on build rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ assets: ## Generate the assets. Install go-bindata if needed.
 	go generate ./...
 	go fmt ./...
 
-build: assets build-linux build-windows build-osx ## Generate the assets and build the binary for all platforms.
+build: assets build-linux build-osx ## Generate the assets and build the binary for all platforms.
 
 
 install: ## Build and install for the current platform.


### PR DESCRIPTION
#### Summary
The `build-windows` rule was removed on #523, but we forgot to remove it from the list of dependencies for `build`. I guess I've been using `make package` and `make test` to test changes, and until now I had not run `make build` :shrug: 

#### Ticket Link
--