### PR TITLE
Merge createPost and createPostReply

### DIFF
--- a/config/simulcontroller.sample.json
+++ b/config/simulcontroller.sample.json
@@ -1,4 +1,6 @@
 {
   "MinIdleTimeMs": 1000,
-  "AvgIdleTimeMs": 20000
+  "AvgIdleTimeMs": 20000,
+  "PercentUrgentPosts": 0.001,
+  "PercentReplies": 0.85
 }

--- a/loadtest/control/simplecontroller/controller.go
+++ b/loadtest/control/simplecontroller/controller.go
@@ -166,7 +166,6 @@ func (c *SimpleController) createActions(definitions []actionDefinition) error {
 		"CreateDirectChannel":  control.CreateDirectChannel,
 		"CreateGroupChannel":   control.CreateGroupChannel,
 		"CreatePost":           control.CreatePost,
-		"CreatePostReply":      control.CreatePostReply,
 		"CreatePrivateChannel": control.CreatePrivateChannel,
 		"CreatePublicChannel":  control.CreatePublicChannel,
 		"GetPinnedPosts":       control.GetPinnedPosts,

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -682,57 +682,6 @@ func editPost(u user.User) control.UserActionResponse {
 	return control.UserActionResponse{Info: fmt.Sprintf("post edited, id %v", postId)}
 }
 
-func (c *SimulController) createPostReply(u user.User) control.UserActionResponse {
-	channel, err := u.Store().CurrentChannel()
-	if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	var rootId string
-	post, err := u.Store().RandomPostForChannel(channel.Id)
-	if errors.Is(err, memstore.ErrPostNotFound) {
-		return control.UserActionResponse{Info: fmt.Sprintf("no posts found in channel %v", channel.Id)}
-	} else if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	if post.RootId != "" {
-		rootId = post.RootId
-	} else {
-		rootId = post.Id
-	}
-
-	if err := sendTypingEventIfEnabled(u, channel.Id); err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	message, err := createMessage(u, channel, true)
-	if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	reply := &model.Post{
-		Message:   message,
-		ChannelId: channel.Id,
-		CreateAt:  time.Now().Unix() * 1000,
-		RootId:    rootId,
-	}
-
-	// 2% of the times post will have files attached.
-	if rand.Float64() < 0.02 {
-		if err := c.attachFilesToPost(u, reply); err != nil {
-			return control.UserActionResponse{Err: control.NewUserError(err)}
-		}
-	}
-
-	replyId, err := u.CreatePost(reply)
-	if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	return control.UserActionResponse{Info: fmt.Sprintf("post reply created, id %v", replyId)}
-}
-
 func (c *SimulController) createPost(u user.User) control.UserActionResponse {
 	channel, err := u.Store().CurrentChannel()
 	if err != nil {
@@ -743,7 +692,12 @@ func (c *SimulController) createPost(u user.User) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	message, err := createMessage(u, channel, false)
+	// Select the post characteristics
+	isReply := rand.Float64() < c.config.PercentReplies
+	isUrgent := !isReply && (rand.Float64() < c.config.PercentUrgentPosts)
+	hasFilesAttached := rand.Float64() < 0.02
+
+	message, err := createMessage(u, channel, isReply)
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
@@ -754,14 +708,33 @@ func (c *SimulController) createPost(u user.User) control.UserActionResponse {
 		CreateAt:  time.Now().Unix() * 1000,
 	}
 
-	// 2% of the times post will have files attached.
-	if rand.Float64() < 0.02 {
+	if isReply {
+		var rootId string
+		randomPost, err := u.Store().RandomPostForChannel(channel.Id)
+		if errors.Is(err, memstore.ErrPostNotFound) {
+			return control.UserActionResponse{Info: fmt.Sprintf("no posts found in channel %v", channel.Id)}
+		} else if err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
+
+		// Get the ID of the post to which the randomPost replies to,
+		// or the ID of the randomPost itself if it's a root post
+		if randomPost.RootId != "" {
+			rootId = randomPost.RootId
+		} else {
+			rootId = randomPost.Id
+		}
+
+		post.RootId = rootId
+	}
+
+	if hasFilesAttached {
 		if err := c.attachFilesToPost(u, post); err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 	}
 
-	if rand.Float64() < c.config.PercentUrgentPosts {
+	if isUrgent {
 		post.Metadata = &model.PostMetadata{}
 		post.Metadata.Priority = &model.PostPriority{
 			Priority:                model.NewString("urgent"),

--- a/loadtest/control/simulcontroller/config.go
+++ b/loadtest/control/simulcontroller/config.go
@@ -16,8 +16,10 @@ type Config struct {
 	// will wait between actions.
 	AvgIdleTimeMs int `default:"20000" validate:"range:($MinIdleTimeMs,]"`
 
-	// The percentage of post that are marked as urgent
+	// The percentage of root posts that are marked as urgent
 	PercentUrgentPosts float64 `default:"0.001" validate:"range:[0,1]"`
+	// The percentage of all posts that are replies
+	PercentReplies float64 `default:"0.85" validate:"range:[0,1]"`
 }
 
 // ReadConfig reads the configuration file from the given string. If the string

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -127,10 +127,6 @@ func (c *SimulController) Run() {
 			frequency: 1.5,
 		},
 		{
-			run:       c.createPostReply,
-			frequency: 0.5,
-		},
-		{
 			run:       c.joinChannel,
 			frequency: 0.8,
 		},


### PR DESCRIPTION
#### Summary
Action frequencies are computed against the `createPost` action: when possible, the [methodology](https://github.com/mattermost/mattermost-load-test-ng/blob/master/docs/coverage-frequency.md) is to compare the new API endpoint representing the new action against the `createPost` API endpoint; as the frequency of the `createPost` action is known, it's just a matter of multiplying that frequency by the ratio computed.

When reviewing the frequencies for https://mattermost.atlassian.net/browse/MM-50247, I realized that there is an imprecision in such methodology: the `createPost` **endpoint** does not represent the `createPost` **action**, as the endpoint is used for both creating root posts and for creating replies. Thus, it represents both the `createPost` and `createPostReply` actions. This makes the current frequency computation methodology invalid.

There are two solutions to this: we either change the methodology or the action:
1. Change the methodology to split the frequency of the `createPost` endpoint into `createPost` and `createPostReply` actions, according to the percentage of replies vs root posts in Community. This is possible, but I think it makes the computation more confusing, and if we go down this road, every time we add an action that creates a slightly different post, we'll have to change this computation.
2. Change how we tackle the `createPost` action, considering the posting of a message as a single action, regardless of the adjectives we give to the post. Inside such action, we would let the post be a reply, or an urgent action, or a post with persistent notifications, according to the percentages of such posts in Community over time.

I think 2. is the best solution here, and the one implemented in this PR. Specifically, I think it's better prepared for the future, as we will keep adding different properties to posts: instead of creating a single action for every nuance in how we send a post, we keep one action and decide its properties inside it under a `if rand.Float64() < c.PercentagePropertyX`. Note that this is how we already decide whether to attach files to a post or whether it's an urgent post.

In any case, I'm open to suggestions. I haven't tested this already, but the code is ready to review. Let me know your thoughts.

#### Ticket Link
--