### PR TITLE
Bump version to v1.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ else
 ifeq ($(BRANCH_EXISTS), 0)
 	@echo "Error: branch ${BRANCH_NAME} already exists"
 else
+	@echo $(NEXT_VER) | grep -Eq ^v[0-9]+\.[0-9]+\.[0-9]+$ || echo "The next version, '$(NEXT_VER)' is not of the form vMAJOR.MINOR.PATCH" && exit 1
 	git checkout -b $(BRANCH_NAME) origin/master
 	@echo "Applying changes"
 	@for file in $(shell grep -rPl --include="*.go" --include="*.json" $(MATCH)); do \

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -45,7 +45,7 @@
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",
-  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/1.8.0/mattermost-load-test-ng-1.8.0-linux-amd64.tar.gz",
+  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.8.0/mattermost-load-test-ng-v1.8.0-linux-amd64.tar.gz",
   "LogSettings": {
     "EnableConsole": true,
     "ConsoleLevel": "INFO",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	// URL from where to download load-test-ng binaries and configuration files.
 	// The configuration files provided in the package will be overridden in
 	// the deployment process.
-	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/1.8.0/mattermost-load-test-ng-1.8.0-linux-amd64.tar.gz" validate:"url"`
+	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.8.0/mattermost-load-test-ng-v1.8.0-linux-amd64.tar.gz" validate:"url"`
 	ElasticSearchSettings ElasticSearchSettings
 	JobServerSettings     JobServerSettings
 	LogSettings           logger.Settings


### PR DESCRIPTION
#### Summary
Forgot the `v` :facepalm:

Added a quick check in the Makefile rule so that it doesn't happen again. The error looks like:

```
> NEXT_VER=1.9.0 make prepare-release
The next version, '1.9.0' is not of the form vMAJOR.MINOR.PATCH
make: *** [Makefile:110: prepare-release] Error 1
```

#### Ticket Link
--
