### PR TITLE
Update setPostReminder with accurate frequencies

### DIFF
--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -170,7 +170,7 @@ func (c *SimulController) Run() {
 		},
 		{
 			run:       c.createPostReminder,
-			frequency: 0.1,
+			frequency: 0.002,
 		},
 		{
 			run:       editPost,


### PR DESCRIPTION
Now that it's deployed on community we can find the correct frequency.

Calculated by following: https://github.com/mattermost/mattermost-load-test-ng/blob/master/docs/coverage-frequency.md

