### PR TITLE
MM-51097: Revert improvement to HTTPRequestTimes metric

### DIFF
--- a/loadtest/user/userentity/metrics.go
+++ b/loadtest/user/userentity/metrics.go
@@ -31,13 +31,9 @@ func (ue *UserEntity) incHTTPErrors(path, method string, status int) {
 	}
 }
 
-func (ue *UserEntity) observeHTTPRequestTimes(path, method string, status int, elapsed float64) {
+func (ue *UserEntity) observeHTTPRequestTimes(elapsed float64) {
 	if ue.metrics != nil {
-		ue.metrics.HTTPRequestTimes.With(prometheus.Labels{
-			"path":        path,
-			"method":      method,
-			"status_code": strconv.Itoa(status),
-		}).Observe(elapsed)
+		ue.metrics.HTTPRequestTimes.Observe(elapsed)
 	}
 }
 

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -72,11 +72,7 @@ type ueTransport struct {
 func (t *ueTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	startTime := time.Now()
 	resp, err := t.transport.RoundTrip(req)
-	var statusCode int
-	if resp != nil {
-		statusCode = resp.StatusCode
-	}
-	t.ue.observeHTTPRequestTimes(req.URL.Path, req.Method, statusCode, time.Since(startTime).Seconds())
+	t.ue.observeHTTPRequestTimes(req.URL.Path, req.Method, resp.StatusCode, time.Since(startTime).Seconds())
 	if os.IsTimeout(err) {
 		t.ue.incHTTPTimeouts(req.URL.Path, req.Method)
 	}

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -72,7 +72,7 @@ type ueTransport struct {
 func (t *ueTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	startTime := time.Now()
 	resp, err := t.transport.RoundTrip(req)
-	t.ue.observeHTTPRequestTimes(req.URL.Path, req.Method, resp.StatusCode, time.Since(startTime).Seconds())
+	t.ue.observeHTTPRequestTimes(time.Since(startTime).Seconds())
 	if os.IsTimeout(err) {
 		t.ue.incHTTPTimeouts(req.URL.Path, req.Method)
 	}

--- a/performance/metrics.go
+++ b/performance/metrics.go
@@ -17,7 +17,7 @@ const (
 )
 
 type UserEntityMetrics struct {
-	HTTPRequestTimes     *prometheus.HistogramVec
+	HTTPRequestTimes     prometheus.Histogram
 	HTTPErrors           *prometheus.CounterVec
 	HTTPTimeouts         *prometheus.CounterVec
 	WebSocketConnections prometheus.Gauge
@@ -32,13 +32,12 @@ func NewMetrics() *Metrics {
 	var m Metrics
 	m.registry = prometheus.NewRegistry()
 
-	m.ueMetrics.HTTPRequestTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	m.ueMetrics.HTTPRequestTimes = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: metricsNamespace,
 		Subsystem: metricsSubSystemHTTP,
 		Name:      "request_time",
 		Help:      "The time taken to execute client requests.",
-	},
-		[]string{"path", "method", "status_code"})
+	})
 	m.registry.MustRegister(m.ueMetrics.HTTPRequestTimes)
 
 	m.ueMetrics.HTTPErrors = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
#### Summary
v1.8.0 showed a strange behaviour when logging new users in to the instance, as they were added more slowly than in previous versions. See a case of a bad commit (b56daa5):
![image](https://user-images.githubusercontent.com/3924815/225270557-f1b909a4-4ee9-4141-9021-c47ab4e0a1d8.png)
and compare against the normal behaviour in a good commit (c0a7983).
![image](https://user-images.githubusercontent.com/3924815/225270651-99f80daa-159c-4177-92f1-d2ec76aa0bb0.png)
Both screenshots cover a time window of 20 minutes.

The issue was isolated to the changes in #537, which added more info to the HTTPRequestTimes metric; namely: the path, method and status code of the request. This resulted in:
- A very large set of data for Prometheus to handle (see #550 for a consequence of that), which ended up crashing the metrics server.
- The malfunctioning of the coordinator, which based the logging in and out the users on the metrics, which were broken.

This PR reverts the original PR #537 and the subsequent bug fix #558. With these changes, the graph is normal again:
![image](https://user-images.githubusercontent.com/3924815/225271819-a89ae86e-227f-4003-a664-43806634ad01.png)

I will release a v1.8.1 with only this PR to unblock current efforts and we can revisit the need of the additional info in the HTTPRequestTimes metric in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51097

