### PR TITLE
MM-52110: Avoid requesting the config at the same time for all users

### DIFF
--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -58,6 +58,11 @@ func Login(u user.User) UserActionResponse {
 		return UserActionResponse{Err: NewUserError(err)}
 	}
 
+	// Populate user config
+	if err := u.GetClientConfig(); err != nil {
+		return UserActionResponse{Err: NewUserError(err)}
+	}
+
 	// Populate teams and channels.
 	teamIds, err := u.GetAllTeams(0, 100)
 	if err != nil {

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -77,7 +77,7 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 	}
 
 	var resp control.UserActionResponse
-	if c.isGQLEnabled {
+	if c.featureFlags.GraphQLEnabled {
 		resp = control.ReloadGQL(c.user)
 	} else {
 		resp = control.Reload(c.user)
@@ -96,7 +96,7 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 		return c.switchTeam(c.user)
 	}
 
-	if resp := loadTeam(c.user, team, c.isGQLEnabled); resp.Err != nil {
+	if resp := loadTeam(c.user, team, c.featureFlags.GraphQLEnabled); resp.Err != nil {
 		return resp
 	}
 
@@ -274,7 +274,7 @@ func (c *SimulController) switchTeam(u user.User) control.UserActionResponse {
 
 	c.status <- c.newInfoStatus(fmt.Sprintf("switched to team %s", team.Id))
 
-	if resp := loadTeam(u, &team, c.isGQLEnabled); resp.Err != nil {
+	if resp := loadTeam(u, &team, c.featureFlags.GraphQLEnabled); resp.Err != nil {
 		return resp
 	}
 


### PR DESCRIPTION
#### Summary
#544 introduced GraphQL, and with it a way to detect whether it was enabled in the server. In order to do this, the agents need to retrieve the client config, but this was not done in the usual flow of the actions, but as soon as `Run()` was called, even before login. This created lots of requests to the config endpoint at the exact same, clogging the server and making the client request times go over the roof. This, in turn, made the coordinator decrease the users, never reaching more than 150-200 users. Something like:

![image](https://user-images.githubusercontent.com/3924815/232107368-60e8608c-2605-4759-bc8c-5d47ec9cc154.png)

I fixed this by retrieving the client config during the login action, storing it in the user's memstore. This is then used to populate a featureFlags struct---that contains just the GraphQLEnabled flag--- in the simulcontroller, which can be later read by the actions.

This is how four tests look like after the fix (note that the client times never go above 1s, while they easily reached the 10s timeout before):

![image](https://user-images.githubusercontent.com/3924815/232107648-52f4460c-cdaa-4c84-afb7-f094032bd4ec.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52110