### PR TITLE
Change the server's package from v6 to v8

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/performance"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 func writeAgentResponse(w http.ResponseWriter, status int, resp *client.AgentResponse) {

--- a/api/server.go
+++ b/api/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/performance"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // api keeps track of the load-test API server state.

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 
 	"github.com/mattermost/mattermost-load-test-ng/api"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
@@ -19,7 +19,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ltapi/main.go
+++ b/cmd/ltapi/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/api"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/metricswatcher/config/config.go
+++ b/cmd/metricswatcher/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/metricswatcher/healthcheck.go
+++ b/cmd/metricswatcher/healthcheck.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/cmd/metricswatcher/prometheushealthcheck"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 func healthcheck(errChan chan error, configuration *config.MetricsWatcherConfiguration) {

--- a/cmd/metricswatcher/main.go
+++ b/cmd/metricswatcher/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/mattermost/mattermost-load-test-ng/cmd/metricswatcher/config"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/metricswatcher/metrics.go
+++ b/cmd/metricswatcher/metrics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/cmd/metricswatcher/config"
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 func checkMetrics(errChan chan error, config *config.MetricsWatcherConfiguration) {

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 type deploymentConfig struct {

--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpConfig *deploymentConfig) error) error {

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 func (c *Comparison) getLoadTestsCount() int {

--- a/comparison/output.go
+++ b/comparison/output.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/report"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // DeploymentInfo holds information regarding a deployment.

--- a/coordinator/cluster/cluster.go
+++ b/coordinator/cluster/cluster.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // LoadAgentCluster is the object holding information about all the load-test

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // Coordinator is the object used to coordinate a cluster of

--- a/coordinator/performance/monitor.go
+++ b/coordinator/performance/monitor.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance/prometheus"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 type Monitor struct {

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 func (t *Terraform) generateLoadtestAgentConfig() (*loadtest.Config, error) {

--- a/deployment/terraform/coordinator.go
+++ b/deployment/terraform/coordinator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simplecontroller"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // StartCoordinator starts the coordinator in the current load-test deployment.

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -18,9 +18,9 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/assets"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
-	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/server/config"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/config"
+	"github.com/mattermost/mattermost-server/server/v8/model"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 const cmdExecTimeoutMinutes = 30

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // Destroy destroys the created load-test environment.

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -17,7 +17,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // Config returns the deployment config associated with the Terraform instance.

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 const (

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
-	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/server/channels/utils"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/channels/utils"
+	"github.com/mattermost/mattermost-server/server/v8/model"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 type uploadInfo struct {

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -52,7 +52,7 @@ This is a list of common steps needed when adding new or missing load-test cover
 If the added feature has new client (as in [`model/client4.go`](https://github.com/mattermost/mattermost-server/blob/master/model/client4.go)) additions, you should update the `mattermost-server` dependency so that the new methods can be used from within the load-test packages.
 
 ```sh
-go get -u github.com/mattermost/mattermost-server/v6/@COMMIT_HASH
+go get -u github.com/mattermost/mattermost-server/server/v8/@COMMIT_HASH
 go mod tidy
 ```
 

--- a/docs/load-test-how-to-use.md
+++ b/docs/load-test-how-to-use.md
@@ -94,7 +94,7 @@ Even without the framework, a general load-test workflow in the cloud will be si
 After all the code changes:
  - [Add tests](https://github.com/mattermost/mattermost-load-test-ng/blob/master/docs/coverage.md#testing) if required. 
  - Run `make check-style`.
- - `go get -u github.com/mattermost/mattermost-server/v6@<commit-hash-in-master>` && `go mod tidy`
+ - `go get -u github.com/mattermost/mattermost-server/server/v8@<commit-hash-in-master>` && `go mod tidy`
  - Create the PR.
 
 #### Note:

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/mattermost/ldap v3.0.4+incompatible // indirect
-	github.com/mattermost/mattermost-server/v6 v6.0.0-20230411080029-50aabf6b933b
+	github.com/mattermost/mattermost-server/server/v8 v8.0.0-20230426132502-ac35bdff6859
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.42.0
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
 	github.com/valyala/fasthttp v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -894,8 +894,8 @@ github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
 github.com/mattermost/logr/v2 v2.0.16 h1:jnePX4cPskC3WDFvUardh/xZfxNdsFXbEERJQ1kUEDE=
 github.com/mattermost/logr/v2 v2.0.16/go.mod h1:1dm/YhTpozsqANXxo5Pi5zYLBsal2xY0pX+JZNbzYJY=
-github.com/mattermost/mattermost-server/v6 v6.0.0-20230411080029-50aabf6b933b h1:rknnij23w1myj85OF0HJwp6EZIdD+hnU0fAwHfeD7oI=
-github.com/mattermost/mattermost-server/v6 v6.0.0-20230411080029-50aabf6b933b/go.mod h1:dnI3hIzIzqn5id2sYzGUmZ8FpiqysKBYEBZ4RyiDn/A=
+github.com/mattermost/mattermost-server/server/v8 v8.0.0-20230426132502-ac35bdff6859 h1:QlN+D0HT3zZEvVE8Ev7zV9Z3gNu61v3t3Rlzq5lwUF8=
+github.com/mattermost/mattermost-server/server/v8 v8.0.0-20230426132502-ac35bdff6859/go.mod h1:qJZpqW4/sM+WORGy9KMbra8GP1Zhdq8YunBQPbD2b7g=
 github.com/mattermost/morph v1.0.5-0.20221115094356-4c18a75b1f5e h1:VfNz+fvJ3DxOlALM22Eea8ONp5jHrybKBCcCtDPVlss=
 github.com/mattermost/morph v1.0.5-0.20221115094356-4c18a75b1f5e/go.mod h1:xo0ljDknTpPxEdhhrUdwhLCexIsYyDKS6b41HqG8wGU=
 github.com/mattermost/squirrel v0.2.0 h1:8ZWeyf+MWQ2cL7hu9REZgLtz2IJi51qqZEovI3T3TT8=
@@ -1164,8 +1164,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -1581,7 +1581,7 @@ golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.5.0 h1:HuArIo48skDwlrvM3sEdHXElYslAMsf3KwRkkW4MC4s=
+golang.org/x/oauth2 v0.7.0 h1:qe6s0zUXlPX80/dITx3440hWZ7GwMwgDDyrSGTPJG/g=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // UserActionResponse is a structure containing information about the result

--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 type userAction struct {

--- a/loadtest/control/simplecontroller/actions.go
+++ b/loadtest/control/simplecontroller/actions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 type UserAction struct {

--- a/loadtest/control/simplecontroller/websocket.go
+++ b/loadtest/control/simplecontroller/websocket.go
@@ -6,7 +6,7 @@ package simplecontroller
 import (
 	"sync"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // wsEventHandler listens for WebSocket events to be handled.

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -18,7 +18,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 type userAction struct {

--- a/loadtest/control/simulcontroller/websocket.go
+++ b/loadtest/control/simulcontroller/websocket.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // wsEventHandler listens for WebSocket events to be handled.

--- a/loadtest/loadtest.go
+++ b/loadtest/loadtest.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 const (

--- a/loadtest/report/output.go
+++ b/loadtest/report/output.go
@@ -15,7 +15,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 	"github.com/prometheus/common/model"
 )
 

--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 var (

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // MemStore is a simple implementation of MutableUserStore

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 
 	"github.com/stretchr/testify/require"
 )

--- a/loadtest/store/memstore/utils.go
+++ b/loadtest/store/memstore/utils.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 func restorePrivateData(old, new *model.User) {

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -4,7 +4,7 @@
 package store
 
 import (
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // SelectionType is the selection parameter for a store entity.

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // TestUserSuffixRegexp matches the numerical suffix of test usernames,

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // SignUp signs up the user with the given credentials.

--- a/loadtest/user/userentity/graphql.go
+++ b/loadtest/user/userentity/graphql.go
@@ -3,7 +3,7 @@
 
 package userentity
 
-import "github.com/mattermost/mattermost-server/v6/model"
+import "github.com/mattermost/mattermost-server/server/v8/model"
 
 type gqlRole struct {
 	ID            string   `json:"id"`

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/performance"
 
 	"github.com/gocolly/colly/v2"
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 // UserEntity is an implementation of the User interface

--- a/loadtest/user/userentity/user_test.go
+++ b/loadtest/user/userentity/user_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 	"github.com/stretchr/testify/require"
 )
 

--- a/loadtest/user/userentity/utils.go
+++ b/loadtest/user/userentity/utils.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 )
 
 const (

--- a/loadtest/user/userentity/utils_test.go
+++ b/loadtest/user/userentity/utils_test.go
@@ -6,7 +6,7 @@ package userentity
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/loadtest/user/userentity/websocket.go
+++ b/loadtest/user/userentity/websocket.go
@@ -12,8 +12,8 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/websocket"
 
-	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/model"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 const (

--- a/loadtest/user/websocket/client.go
+++ b/loadtest/user/websocket/client.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/model"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 
 	"github.com/gorilla/websocket"
 	"github.com/vmihailenco/msgpack/v5"

--- a/loadtest/user/websocket/client_test.go
+++ b/loadtest/user/websocket/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"

--- a/loadtest/utils.go
+++ b/loadtest/utils.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 
-	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/server/v8/model"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 )

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,9 +6,9 @@ package logger
 import (
 	"strings"
 
-	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/server/config"
-	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
+	"github.com/mattermost/mattermost-server/server/v8/config"
+	"github.com/mattermost/mattermost-server/server/v8/model"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
 // Settings holds information used to initialize a new logger.


### PR DESCRIPTION
#### Summary
Now that the server module has been changed to v8.0, we need to update the packages we use in this repo as well to access the latest API client.

#### Ticket Link
N/A

