### PR TITLE
MM-52932: Improve mem utilization of agents

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -363,11 +363,12 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 			Password:     password,
 		}
 		store, err := memstore.New(&memstore.Config{
-			MaxStoredPosts:          500,
-			MaxStoredUsers:          1000,
-			MaxStoredChannelMembers: 1000,
-			MaxStoredStatuses:       1000,
-			MaxStoredThreads:        500,
+			MaxStoredPosts:          250,
+			MaxStoredUsers:          500,
+			MaxStoredChannelMembers: 500,
+			MaxStoredStatuses:       500,
+			MaxStoredThreads:        250,
+			MaxStoredReactions:      10,
 		})
 		if err != nil {
 			return nil, err

--- a/loadtest/store/memstore/config.go
+++ b/loadtest/store/memstore/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	MaxStoredChannelMembers int // The maximum number of channel members to be stored.
 	MaxStoredStatuses       int // The maximum number of statuses to be stored.
 	MaxStoredThreads        int // The maximum number of statuses to be stored.
+	MaxStoredReactions      int // The maximum number of reactions to be stored.
 }
 
 // IsValid checks whether a Config is valid or not.
@@ -49,4 +50,5 @@ func (c *Config) SetDefaults() {
 	c.MaxStoredChannelMembers = 100
 	c.MaxStoredStatuses = 100
 	c.MaxStoredThreads = 100
+	c.MaxStoredReactions = 10
 }

--- a/loadtest/store/memstore/cqueue.go
+++ b/loadtest/store/memstore/cqueue.go
@@ -8,40 +8,33 @@ import (
 )
 
 // CQueue is a basic implementation of a circular queue of fixed size.
-type CQueue struct {
-	data  []interface{}      // The backing data slice.
-	newEl func() interface{} // The factory function used to allocate space for new elements.
-	size  int                // The maximum size (capacity) of the backing data slice.
-	next  int                // The index of the next element to return on a call to Get().
+type CQueue[T any] struct {
+	data []*T // The backing data slice.
+	size int  // The maximum size (capacity) of the backing data slice.
+	next int  // The index of the next element to return on a call to Get().
 }
 
 // NewCQueue creates and returns a pointer to a queue of the given size.
-// The passed newEl parameter is a function used to allocate an element if data
-// for it is not yet present in the queue.
-func NewCQueue(size int, newEl func() interface{}) (*CQueue, error) {
+func NewCQueue[T any](size int) (*CQueue[T], error) {
 	if size <= 0 {
 		return nil, errors.New("size should be > 0")
 	}
-	if newEl == nil {
-		return nil, errors.New("new should not be nil")
-	}
-	q := &CQueue{
-		data:  make([]interface{}, 0, size),
-		newEl: newEl,
-		size:  size,
-		next:  0,
+	q := &CQueue[T]{
+		data: make([]*T, 0, size),
+		size: size,
+		next: 0,
 	}
 	return q, nil
 }
 
 // Get returns a pointer to the next element in the queue.
 // In case this is nil, data for it will be allocated before returning.
-func (q *CQueue) Get() interface{} {
+func (q *CQueue[T]) Get() *T {
 	if q.next == len(q.data) {
 		q.data = append(q.data, nil)
 	}
 	if q.data[q.next] == nil {
-		q.data[q.next] = q.newEl()
+		q.data[q.next] = new(T)
 	}
 	el := q.data[q.next]
 	q.next++
@@ -52,6 +45,6 @@ func (q *CQueue) Get() interface{} {
 }
 
 // Reset re-initializes the queue to be reused.
-func (q *CQueue) Reset() {
+func (q *CQueue[T]) Reset() {
 	q.next = 0
 }

--- a/loadtest/store/memstore/cqueue_test.go
+++ b/loadtest/store/memstore/cqueue_test.go
@@ -13,40 +13,32 @@ import (
 func TestCQueue(t *testing.T) {
 
 	t.Run("new failing", func(t *testing.T) {
-		q, err := NewCQueue(0, nil)
-		require.Nil(t, q)
-		require.Error(t, err)
-
-		q, err = NewCQueue(10, nil)
+		q, err := NewCQueue[string](0)
 		require.Nil(t, q)
 		require.Error(t, err)
 	})
 
 	t.Run("new succeeding", func(t *testing.T) {
-		q, err := NewCQueue(10, func() interface{} {
-			return new(string)
-		})
+		q, err := NewCQueue[string](10)
 		require.NotNil(t, q)
 		require.NoError(t, err)
 	})
 
 	t.Run("get", func(t *testing.T) {
-		q, err := NewCQueue(10, func() interface{} {
-			return new(string)
-		})
+		q, err := NewCQueue[string](10)
 		require.NotNil(t, q)
 		require.NoError(t, err)
 
 		var ptrs []*string
 		for i := 0; i < 10; i++ {
-			s := q.Get().(*string)
+			s := q.Get()
 			require.NotNil(t, s)
 			*s = fmt.Sprintf("test%d", i)
 			ptrs = append(ptrs, s)
 		}
 
 		for i := 0; i < 10; i++ {
-			s := q.Get().(*string)
+			s := q.Get()
 			require.NotNil(t, s)
 			require.Equal(t, fmt.Sprintf("test%d", i), *s)
 			require.Equal(t, ptrs[i], s)
@@ -54,15 +46,13 @@ func TestCQueue(t *testing.T) {
 	})
 
 	t.Run("reset", func(t *testing.T) {
-		q, err := NewCQueue(10, func() interface{} {
-			return new(string)
-		})
+		q, err := NewCQueue[string](10)
 		require.NotNil(t, q)
 		require.NoError(t, err)
 
 		var first *string
 		for i := 0; i < 5; i++ {
-			s := q.Get().(*string)
+			s := q.Get()
 			require.NotNil(t, s)
 			if i == 0 {
 				first = s
@@ -71,7 +61,7 @@ func TestCQueue(t *testing.T) {
 		}
 
 		q.Reset()
-		s := q.Get().(*string)
+		s := q.Get()
 		require.Equal(t, first, s)
 		require.Equal(t, "test0", *s)
 	})

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -23,18 +23,19 @@ type MemStore struct {
 	clientConfig        map[string]string
 	emojis              []*model.Emoji
 	posts               map[string]*model.Post
-	postsQueue          *CQueue
+	postsQueue          *CQueue[model.Post]
 	teams               map[string]*model.Team
 	channels            map[string]*model.Channel
 	channelStats        map[string]*model.ChannelStats
 	channelMembers      map[string]map[string]*model.ChannelMember
-	channelMembersQueue *CQueue
+	channelMembersQueue *CQueue[model.ChannelMember]
 	teamMembers         map[string]map[string]*model.TeamMember
 	users               map[string]*model.User
-	usersQueue          *CQueue
+	usersQueue          *CQueue[model.User]
 	statuses            map[string]*model.Status
-	statusesQueue       *CQueue
+	statusesQueue       *CQueue[model.Status]
 	reactions           map[string][]*model.Reaction
+	reactionsQueue      *CQueue[model.Reaction]
 	roles               map[string]*model.Role
 	license             map[string]string
 	currentChannel      *model.Channel
@@ -43,7 +44,7 @@ type MemStore struct {
 	profileImages       map[string]bool
 	serverVersion       string
 	threads             map[string]*model.ThreadResponse
-	threadsQueue        *CQueue
+	threadsQueue        *CQueue[model.ThreadResponse]
 	sidebarCategories   map[string]map[string]*model.SidebarCategoryWithChannels
 }
 
@@ -77,82 +78,82 @@ func (s *MemStore) Clear() {
 	defer s.lock.Unlock()
 	s.preferences = nil
 	s.config = nil
+	// Wiping out the slice entries.
+	for i := range s.emojis {
+		s.emojis[i] = nil
+	}
 	s.emojis = []*model.Emoji{}
+	clearMap(s.posts)
 	s.posts = map[string]*model.Post{}
+	clearMap(s.clientConfig)
 	s.clientConfig = map[string]string{}
 	s.postsQueue.Reset()
+	clearMap(s.teams)
 	s.teams = map[string]*model.Team{}
+	clearMap(s.channels)
 	s.channels = map[string]*model.Channel{}
 	channelStats := map[string]*model.ChannelStats{}
 	if s.currentChannel != nil && s.channelStats[s.currentChannel.Id] != nil {
 		channelStats[s.currentChannel.Id] = s.channelStats[s.currentChannel.Id]
 	}
 	s.channelStats = channelStats
+	clearMap(s.channelMembers)
 	s.channelMembers = map[string]map[string]*model.ChannelMember{}
 	s.channelMembersQueue.Reset()
+	clearMap(s.teamMembers)
 	s.teamMembers = map[string]map[string]*model.TeamMember{}
+	clearMap(s.users)
 	s.users = map[string]*model.User{}
 	s.usersQueue.Reset()
+	clearMap(s.statuses)
 	s.statuses = map[string]*model.Status{}
 	s.statusesQueue.Reset()
+	clearMap(s.reactions)
 	s.reactions = map[string][]*model.Reaction{}
+	s.reactionsQueue.Reset()
+	clearMap(s.roles)
 	s.roles = map[string]*model.Role{}
+	clearMap(s.license)
 	s.license = map[string]string{}
+	clearMap(s.channelViews)
 	s.channelViews = map[string]int64{}
+	clearMap(s.threads)
 	s.threads = map[string]*model.ThreadResponse{}
 	s.threadsQueue.Reset()
+	clearMap(s.sidebarCategories)
 	s.sidebarCategories = map[string]map[string]*model.SidebarCategoryWithChannels{}
 }
 
 func (s *MemStore) setupQueues(config *Config) error {
-	setups := []struct {
-		size  int
-		newEl func() interface{}
-		ptr   **CQueue
-	}{
-		{
-			config.MaxStoredPosts,
-			func() interface{} {
-				return new(model.Post)
-			},
-			&s.postsQueue,
-		},
-		{
-			config.MaxStoredUsers,
-			func() interface{} {
-				return new(model.User)
-			},
-			&s.usersQueue,
-		},
-		{
-			config.MaxStoredChannelMembers,
-			func() interface{} {
-				return new(model.ChannelMember)
-			},
-			&s.channelMembersQueue,
-		},
-		{
-			config.MaxStoredStatuses,
-			func() interface{} {
-				return new(model.Status)
-			},
-			&s.statusesQueue,
-		},
-		{
-			config.MaxStoredThreads,
-			func() interface{} {
-				return new(model.ThreadResponse)
-			},
-			&s.threadsQueue,
-		},
+	var err error
+	s.postsQueue, err = NewCQueue[model.Post](config.MaxStoredPosts)
+	if err != nil {
+		return fmt.Errorf("memstore: queue creation failed %w", err)
 	}
 
-	for _, setup := range setups {
-		queue, err := NewCQueue(setup.size, setup.newEl)
-		if err != nil {
-			return fmt.Errorf("memstore: queue creation failed %w", err)
-		}
-		*setup.ptr = queue
+	s.usersQueue, err = NewCQueue[model.User](config.MaxStoredUsers)
+	if err != nil {
+		return fmt.Errorf("memstore: queue creation failed %w", err)
+	}
+
+	s.channelMembersQueue, err = NewCQueue[model.ChannelMember](config.MaxStoredChannelMembers)
+	if err != nil {
+		return fmt.Errorf("memstore: queue creation failed %w", err)
+	}
+
+	s.statusesQueue, err = NewCQueue[model.Status](config.MaxStoredStatuses)
+	if err != nil {
+		return fmt.Errorf("memstore: queue creation failed %w", err)
+	}
+
+	s.threadsQueue, err = NewCQueue[model.ThreadResponse](config.MaxStoredThreads)
+	if err != nil {
+		return fmt.Errorf("memstore: queue creation failed %w", err)
+	}
+
+	s.reactionsQueue, err = NewCQueue[model.Reaction](config.MaxStoredReactions)
+	if err != nil {
+		return fmt.Errorf("memstore: queue creation failed %w", err)
 	}
 
 	return nil
@@ -393,7 +394,7 @@ func (s *MemStore) SetPost(post *model.Post) error {
 	// We get an element from the queue and check if we have it in the map and
 	// if it points to the same memory location. If so, we delete it since it means the queue is full.
 	// This is done to keep the data pointed by the map consistent with the data stored in the queue.
-	p := s.postsQueue.Get().(*model.Post)
+	p := s.postsQueue.Get()
 	if pp, ok := s.posts[p.Id]; ok && pp == p {
 		delete(s.posts, p.Id)
 	}
@@ -638,7 +639,7 @@ func (s *MemStore) SetChannelMembers(channelMembers model.ChannelMembers) error 
 		// We get an element from the queue and check if we have it in the map and
 		// if it points to the same memory location. If so, we delete it since it means the queue is full.
 		// This is done to keep the data pointed by the map consistent with the data stored in the queue.
-		c := s.channelMembersQueue.Get().(*model.ChannelMember)
+		c := s.channelMembersQueue.Get()
 		if s.channelMembers[c.ChannelId] != nil {
 			if cc, ok := s.channelMembers[c.ChannelId][c.UserId]; ok && cc == c {
 				delete(s.channelMembers[c.ChannelId], c.UserId)
@@ -683,7 +684,7 @@ func (s *MemStore) SetChannelMember(channelId string, channelMember *model.Chann
 	// We get an element from the queue and check if we have it in the map and
 	// if it points to the same memory location. If so, we delete it since it means the queue is full.
 	// This is done to keep the data pointed by the map consistent with the data stored in the queue.
-	cm := s.channelMembersQueue.Get().(*model.ChannelMember)
+	cm := s.channelMembersQueue.Get()
 	if s.channelMembers[cm.ChannelId] != nil {
 		if cc, ok := s.channelMembers[cm.ChannelId][cm.UserId]; ok && cc == cm {
 			delete(s.channelMembers[cm.ChannelId], cm.UserId)
@@ -775,21 +776,22 @@ func (s *MemStore) SetEmojis(emoji []*model.Emoji) error {
 	return nil
 }
 
-// SetReactions stores the given reactions for the specified post.
-func (s *MemStore) SetReactions(postId string, reactions []*model.Reaction) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.reactions[postId] = reactions
-	return nil
-}
-
 // SetReaction stores the given reaction.
 func (s *MemStore) SetReaction(reaction *model.Reaction) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.reactions[reaction.PostId] = append(s.reactions[reaction.PostId], reaction)
+	// We get an element from the queue and check if we have it in the map and
+	// if it points to the same memory location. If so, we delete it since it means the queue is full.
+	// This is done to keep the data pointed by the map consistent with the data stored in the queue.
+	r := s.reactionsQueue.Get()
+	if rs, ok := s.reactions[r.PostId]; ok && rs[len(s.reactions[r.PostId])-1] == r {
+		rs[len(s.reactions[r.PostId])-1] = nil
+		s.reactions[r.PostId] = rs[:len(rs)-1]
+	}
+
+	*r = *reaction
+	s.reactions[r.PostId] = append(s.reactions[r.PostId], r)
 
 	return nil
 }
@@ -799,7 +801,7 @@ func (s *MemStore) Reactions(postId string) ([]model.Reaction, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	var reactions []model.Reaction
+	reactions := make([]model.Reaction, 0, len(s.reactions))
 	for _, reaction := range s.reactions[postId] {
 		reactions = append(reactions, *reaction)
 	}
@@ -820,6 +822,7 @@ func (s *MemStore) DeleteReaction(reaction *model.Reaction) (bool, error) {
 	for i, r := range reactions {
 		if *r == *reaction {
 			reactions[i] = reactions[len(reactions)-1]
+			reactions[len(reactions)-1] = nil // Allow element to be garbage collected.
 			s.reactions[reaction.PostId] = reactions[:len(reactions)-1]
 			return true, nil
 		}
@@ -853,7 +856,7 @@ func (s *MemStore) SetUsers(users []*model.User) error {
 		// We get an element from the queue and check if we have it in the map and
 		// if it points to the same memory location. If so, we delete it since it means the queue is full.
 		// This is done to keep the data pointed by the map consistent with the data stored in the queue.
-		u := s.usersQueue.Get().(*model.User)
+		u := s.usersQueue.Get()
 		if uu, ok := s.users[u.Id]; ok && uu == u {
 			delete(s.users, u.Id)
 		}
@@ -901,7 +904,7 @@ func (s *MemStore) SetStatus(userId string, status *model.Status) error {
 	// We get an element from the queue and check if we have it in the map and
 	// if it points to the same memory location. If so, we delete it since it means the queue is full.
 	// This is done to keep the data pointed by the map consistent with the data stored in the queue.
-	st := s.statusesQueue.Get().(*model.Status)
+	st := s.statusesQueue.Get()
 	if ss, ok := s.statuses[st.UserId]; ok && ss == st {
 		delete(s.statuses, st.UserId)
 	}
@@ -999,7 +1002,7 @@ func (s *MemStore) SetThread(thread *model.ThreadResponse) error {
 	// We get an element from the queue and check if we have it in the map and
 	// if it points to the same memory location. If so, we delete it since it means the queue is full.
 	// This is done to keep the data pointed by the map consistent with the data stored in the queue.
-	t := s.threadsQueue.Get().(*model.ThreadResponse)
+	t := s.threadsQueue.Get()
 	if tt, ok := s.threads[t.PostId]; ok && tt == t {
 		delete(s.threads, t.PostId)
 	}

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -347,23 +347,6 @@ func TestCurrentChannel(t *testing.T) {
 }
 
 func TestReactions(t *testing.T) {
-	t.Run("SetReactions", func(t *testing.T) {
-		s := newStore(t)
-		postId := model.NewId()
-		userId := model.NewId()
-		emojiName := "testemoji"
-		reaction := &model.Reaction{
-			UserId:    userId,
-			PostId:    postId,
-			EmojiName: emojiName,
-		}
-		err := s.SetReactions(postId, []*model.Reaction{reaction})
-		require.NoError(t, err)
-		reactions, err := s.Reactions(postId)
-		require.NoError(t, err)
-		require.Equal(t, *reaction, reactions[0])
-	})
-
 	t.Run("SetReaction", func(t *testing.T) {
 		s := newStore(t)
 		postId := model.NewId()
@@ -401,28 +384,23 @@ func TestReactions(t *testing.T) {
 				PostId:    postId,
 				EmojiName: emojiName,
 			}
-		}
 
-		err := s.SetReactions(postId, reactions)
-		require.NoError(t, err)
+			err := s.SetReaction(reactions[i])
+			require.NoError(t, err)
+		}
 
 		ok, err := s.DeleteReaction(r1)
 		require.NoError(t, err)
 		require.False(t, ok)
 
-		reactions[4] = r1
-
-		err = s.SetReactions(postId, reactions)
-		require.NoError(t, err)
-
-		ok, err = s.DeleteReaction(r1)
+		ok, err = s.DeleteReaction(reactions[0])
 		require.NoError(t, err)
 		require.True(t, ok)
 
 		storedReactions, err := s.Reactions(postId)
 		require.NoError(t, err)
 		require.Len(t, storedReactions, 9)
-		require.NotContains(t, storedReactions, *r1)
+		require.NotContains(t, storedReactions, *reactions[0])
 	})
 }
 

--- a/loadtest/store/memstore/utils.go
+++ b/loadtest/store/memstore/utils.go
@@ -67,3 +67,11 @@ func SetRandomSeed() int64 {
 	rand.Seed(seed)
 	return seed
 }
+
+// clearMap wipes off the map entries.
+// This code pattern is specially optimized by the compiler to be fast.
+func clearMap[K comparable, V any](m map[K]V) {
+	for k := range m {
+		delete(m, k)
+	}
+}

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -169,8 +169,6 @@ type MutableUserStore interface {
 	SetPosts(posts []*model.Post) error
 
 	// reactions
-	// SetReactions stores the given reactions for the specified post.
-	SetReactions(postId string, reactions []*model.Reaction) error
 	// SetReaction stores the given reaction.
 	SetReaction(reaction *model.Reaction) error
 	// DeleteReaction deletes the given reaction.

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -247,8 +247,6 @@ type User interface {
 	SaveReaction(reaction *model.Reaction) error
 	// DeleteReaction deletes the given reaction.
 	DeleteReaction(reaction *model.Reaction) error
-	// GetReactions fetches and stores reactions to the specified post.
-	GetReactions(postId string) error
 
 	// plugins
 	// GetWebappPlugins fetches webapp plugins.

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -982,16 +982,6 @@ func (ue *UserEntity) GetEmojiImage(emojiId string) error {
 	return nil
 }
 
-// GetReactions fetches and stores reactions to the specified post.
-func (ue *UserEntity) GetReactions(postId string) error {
-	reactions, _, err := ue.client.GetReactions(postId)
-	if err != nil {
-		return err
-	}
-
-	return ue.store.SetReactions(postId, reactions)
-}
-
 // SaveReaction stores the given reaction.
 func (ue *UserEntity) SaveReaction(reaction *model.Reaction) error {
 	r, _, err := ue.client.SaveReaction(reaction)


### PR DESCRIPTION
- Tune down queue sizes
- Properly clear off maps and slices during memstore clear.
- Add reaction queue as well.
- Improve Cqueue implementation to be generic.

https://mattermost.atlassian.net/browse/MM-52932
