### PR TITLE
MM-52961: Set CurrentChannel properly in genController

### DIFF
--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -222,8 +222,14 @@ func (c *GenController) createReply(u user.User) control.UserActionResponse {
 
 	var rootId string
 	var channelId string
-	channel, err := u.Store().CurrentChannel()
+	team, err := u.Store().RandomTeam(store.SelectMemberOf)
 	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+	channel, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf)
+	if errors.Is(err, memstore.ErrChannelStoreEmpty) {
+		return control.UserActionResponse{Info: "no channels in store"}
+	} else if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -334,27 +340,6 @@ func (c *GenController) joinChannel(u user.User) control.UserActionResponse {
 	}
 
 	return resp
-}
-
-// switchChannel is a slightly different action than simulController's
-// where we just set the currentChannel to be able to reply to posts.
-func (c *GenController) switchChannel(u user.User) control.UserActionResponse {
-	team, err := u.Store().RandomTeam(store.SelectMemberOf)
-	if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-	channel, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf)
-	if errors.Is(err, memstore.ErrChannelStoreEmpty) {
-		return control.UserActionResponse{Info: "no channels in store"}
-	} else if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	if err := u.SetCurrentChannel(&channel); err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	return control.UserActionResponse{Info: fmt.Sprintf("switched to channel %s", channel.Id)}
 }
 
 func (c *GenController) joinTeam(u user.User) control.UserActionResponse {

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -81,6 +81,7 @@ func (c *GenController) Run() {
 		control.Login,
 		c.createTeam,
 		c.joinTeam,
+		c.switchChannel,
 		c.joinChannel,
 	}
 

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -117,6 +117,11 @@ func (c *GenController) Run() {
 			frequency:  1000,
 			idleTimeMs: 0,
 		},
+		"switchChannel": {
+			run:        c.switchChannel,
+			frequency:  1000,
+			idleTimeMs: 1000,
+		},
 		"createPublicChannel": {
 			run:        c.createPublicChannel,
 			frequency:  int(math.Ceil(float64(c.config.NumChannels) * c.config.PercentPublicChannels)),

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -81,7 +81,6 @@ func (c *GenController) Run() {
 		control.Login,
 		c.createTeam,
 		c.joinTeam,
-		c.switchChannel,
 		c.joinChannel,
 	}
 
@@ -117,11 +116,6 @@ func (c *GenController) Run() {
 			run:        c.joinChannel,
 			frequency:  1000,
 			idleTimeMs: 0,
-		},
-		"switchChannel": {
-			run:        c.switchChannel,
-			frequency:  1000,
-			idleTimeMs: 1000,
 		},
 		"createPublicChannel": {
 			run:        c.createPublicChannel,


### PR DESCRIPTION
The createReply action depended on the currentChannel being set.
Without that, it was throwing an error of channel not found.
So we add a custom switchChannel action to achieve that.

https://mattermost.atlassian.net/browse/MM-52961
