### PR TITLE
MM-52956: Add coverage to gencontroller

### DIFF
--- a/config/gencontroller.sample.json
+++ b/config/gencontroller.sample.json
@@ -8,6 +8,7 @@
   "PercentUrgentPosts": 0.001,
   "NumPostReminders": 200,
   "NumSidebarCategories": 200,
+  "NumFollowedThreads": 200,
   "PercentPublicChannels": 0.2,
   "PercentPrivateChannels": 0.1,
   "PercentDirectChannels": 0.6,

--- a/config/gencontroller.sample.json
+++ b/config/gencontroller.sample.json
@@ -7,6 +7,7 @@
   "PercentRepliesInLongThreads": 0.05,
   "PercentUrgentPosts": 0.001,
   "NumPostReminders": 200,
+  "NumSidebarCategories": 200,
   "PercentPublicChannels": 0.2,
   "PercentPrivateChannels": 0.1,
   "PercentDirectChannels": 0.6,

--- a/config/gencontroller.sample.json
+++ b/config/gencontroller.sample.json
@@ -6,6 +6,7 @@
   "PercentReplies": 0.5,
   "PercentRepliesInLongThreads": 0.05,
   "PercentUrgentPosts": 0.001,
+  "NumPostReminders": 200,
   "PercentPublicChannels": 0.2,
   "PercentPrivateChannels": 0.1,
   "PercentDirectChannels": 0.6,

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -83,6 +83,16 @@ func Login(u user.User) UserActionResponse {
 	return UserActionResponse{Info: "logged in"}
 }
 
+func GetPreferences(u user.User) UserActionResponse {
+	// Getting preferences.
+	err := u.GetPreferences()
+	if err != nil {
+		return UserActionResponse{Err: NewUserError(err)}
+	}
+
+	return UserActionResponse{Info: "preferences set"}
+}
+
 // Logout disconnects the user from the server and logs out from the server.
 func Logout(u user.User) UserActionResponse {
 	err := u.Disconnect()

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -886,6 +886,10 @@ func CollapsedThreadsEnabled(u user.User) (bool, UserActionResponse) {
 		return false, UserActionResponse{}
 	}
 
+	if u.Store().ClientConfig()["CollapsedThreads"] == model.CollapsedThreadsAlwaysOn {
+		return true, UserActionResponse{}
+	}
+
 	collapsedThreads := u.Store().ClientConfig()["CollapsedThreads"] == model.CollapsedThreadsDefaultOn
 	prefs, err := u.Store().Preferences()
 	if err != nil {

--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -180,7 +180,7 @@ func (c *GenController) createPost(u user.User) control.UserActionResponse {
 	}
 
 	// Select the post characteristics
-	shouldLongThread := shouldMakeLongRunningThread((channel.Id))
+	shouldLongThread := shouldMakeLongRunningThread(channel.Id)
 	isUrgent := rand.Float64() < c.config.PercentUrgentPosts
 	hasFilesAttached := rand.Float64() < 0.02
 
@@ -219,6 +219,7 @@ func (c *GenController) createPost(u user.User) control.UserActionResponse {
 		st.dec("posts")
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
+
 	if shouldLongThread {
 		st.setLongRunningThread(postId, channel.Id, channel.TeamId)
 	}

--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -33,7 +33,7 @@ func logout(u user.User) control.UserActionResponse {
 }
 
 func (c *GenController) createTeam(u user.User) control.UserActionResponse {
-	if !st.inc("teams", c.config.NumTeams) {
+	if !st.inc(StateTargetTeams, c.config.NumTeams) {
 		return control.UserActionResponse{Info: "target number of teams reached"}
 	}
 
@@ -45,7 +45,7 @@ func (c *GenController) createTeam(u user.User) control.UserActionResponse {
 	team.DisplayName = team.Name
 	id, err := u.CreateTeam(team)
 	if err != nil {
-		st.dec("teams")
+		st.dec(StateTargetTeams)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -53,13 +53,13 @@ func (c *GenController) createTeam(u user.User) control.UserActionResponse {
 }
 
 func (c *GenController) createPublicChannel(u user.User) control.UserActionResponse {
-	if !st.inc("channels", c.config.NumChannels) {
+	if !st.inc(StateTargetChannels, c.config.NumChannels) {
 		return control.UserActionResponse{Info: "target number of channels reached"}
 	}
 
 	team, err := u.Store().RandomTeam(store.SelectMemberOf)
 	if err != nil {
-		st.dec("channels")
+		st.dec(StateTargetChannels)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -72,7 +72,7 @@ func (c *GenController) createPublicChannel(u user.User) control.UserActionRespo
 	channelId, err := u.CreateChannel(channel)
 
 	if err != nil {
-		st.dec("channels")
+		st.dec(StateTargetChannels)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -80,13 +80,13 @@ func (c *GenController) createPublicChannel(u user.User) control.UserActionRespo
 }
 
 func (c *GenController) createPrivateChannel(u user.User) control.UserActionResponse {
-	if !st.inc("channels", c.config.NumChannels) {
+	if !st.inc(StateTargetChannels, c.config.NumChannels) {
 		return control.UserActionResponse{Info: "target number of channels reached"}
 	}
 
 	team, err := u.Store().RandomTeam(store.SelectMemberOf)
 	if err != nil {
-		st.dec("channels")
+		st.dec(StateTargetChannels)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -99,7 +99,7 @@ func (c *GenController) createPrivateChannel(u user.User) control.UserActionResp
 	channelId, err := u.CreateChannel(channel)
 
 	if err != nil {
-		st.dec("channels")
+		st.dec(StateTargetChannels)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -161,21 +161,21 @@ func (c *GenController) createGroupChannel(u user.User) control.UserActionRespon
 }
 
 func (c *GenController) createPost(u user.User) control.UserActionResponse {
-	if !st.inc("posts", c.config.NumPosts) {
+	if !st.inc(StateTargetPosts, c.config.NumPosts) {
 		return control.UserActionResponse{Info: "target number of posts reached"}
 	}
 
 	team, err := u.Store().RandomTeam(store.SelectMemberOf)
 	if err != nil {
-		st.dec("posts")
+		st.dec(StateTargetPosts)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 	channel, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf)
 	if errors.Is(err, memstore.ErrChannelStoreEmpty) {
-		st.dec("posts")
+		st.dec(StateTargetPosts)
 		return control.UserActionResponse{Info: "no channels in store"}
 	} else if err != nil {
-		st.dec("posts")
+		st.dec(StateTargetPosts)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -216,7 +216,7 @@ func (c *GenController) createPost(u user.User) control.UserActionResponse {
 
 	postId, err := u.CreatePost(post)
 	if err != nil {
-		st.dec("posts")
+		st.dec(StateTargetPosts)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -227,25 +227,25 @@ func (c *GenController) createPost(u user.User) control.UserActionResponse {
 }
 
 func (c *GenController) createPostReminder(u user.User) control.UserActionResponse {
-	if !st.inc("postreminders", c.config.NumPostReminders) {
+	if !st.inc(StateTargetPostReminders, c.config.NumPostReminders) {
 		return control.UserActionResponse{Info: "target number of post reminders reached"}
 	}
 
 	team, err := u.Store().RandomTeam(store.SelectMemberOf)
 	if err != nil {
-		st.dec("postreminders")
+		st.dec(StateTargetPostReminders)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
 	ch, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf)
 	if err != nil {
-		st.dec("postreminders")
+		st.dec(StateTargetPostReminders)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
 	post, err := u.Store().RandomPostForChannel(ch.Id)
 	if err != nil {
-		st.dec("postreminders")
+		st.dec(StateTargetPostReminders)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -253,7 +253,7 @@ func (c *GenController) createPostReminder(u user.User) control.UserActionRespon
 	// Probably there's no need to randomize this yet.
 	err = u.CreatePostReminder(u.Store().Id(), post.Id, time.Now().Add(10*time.Minute).Unix())
 	if err != nil {
-		st.dec("postreminders")
+		st.dec(StateTargetPostReminders)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -261,7 +261,7 @@ func (c *GenController) createPostReminder(u user.User) control.UserActionRespon
 }
 
 func (c *GenController) createReply(u user.User) control.UserActionResponse {
-	if !st.inc("posts", c.config.NumPosts) {
+	if !st.inc(StateTargetPosts, c.config.NumPosts) {
 		return control.UserActionResponse{Info: "target number of posts reached"}
 	}
 
@@ -288,7 +288,7 @@ func (c *GenController) createReply(u user.User) control.UserActionResponse {
 	if rootId == "" {
 		root, err := u.Store().RandomPost()
 		if err != nil {
-			st.dec("posts")
+			st.dec(StateTargetPosts)
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 		channelId = root.ChannelId
@@ -310,7 +310,7 @@ func (c *GenController) createReply(u user.User) control.UserActionResponse {
 		RootId:    rootId,
 	})
 	if err != nil {
-		st.dec("posts")
+		st.dec(StateTargetPosts)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
@@ -318,17 +318,17 @@ func (c *GenController) createReply(u user.User) control.UserActionResponse {
 }
 
 func (c *GenController) addReaction(u user.User) control.UserActionResponse {
-	if !st.inc("reactions", c.config.NumReactions) {
+	if !st.inc(StateTargetReactions, c.config.NumReactions) {
 		return control.UserActionResponse{Info: "target number of reactions reached"}
 	}
 
 	postsIds, err := u.Store().PostsIdsSince(time.Now().Add(-10*time.Second).Unix() * 1000)
 	if err != nil {
-		st.dec("reactions")
+		st.dec(StateTargetReactions)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 	if len(postsIds) == 0 {
-		st.dec("reactions")
+		st.dec(StateTargetReactions)
 		return control.UserActionResponse{Info: "no posts to add reaction to"}
 	}
 
@@ -341,20 +341,20 @@ func (c *GenController) addReaction(u user.User) control.UserActionResponse {
 
 	reactions, err := u.Store().Reactions(postId)
 	if err != nil {
-		st.dec("reactions")
+		st.dec(StateTargetReactions)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 	for i := 0; i < len(reactions); i++ {
 		if reaction.UserId == reactions[i].UserId &&
 			reaction.EmojiName == reactions[i].EmojiName {
-			st.dec("reactions")
+			st.dec(StateTargetReactions)
 			return control.UserActionResponse{Info: "reaction already added"}
 		}
 	}
 
 	err = u.SaveReaction(reaction)
 	if err != nil {
-		st.dec("reactions")
+		st.dec(StateTargetReactions)
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 

--- a/loadtest/control/gencontroller/config.go
+++ b/loadtest/control/gencontroller/config.go
@@ -23,10 +23,12 @@ type Config struct {
 	NumReactions int64 `default:"200" validate:"range:[0,]"`
 	// The percentage of replies to be created.
 	PercentReplies float64 `default:"0.5" validate:"range:[0,1]"`
-	// The percentage of replies that should be in long threads
+	// The percentage of replies that should be in long threads.
 	PercentRepliesInLongThreads float64 `default:"0.05" validate:"range:[0,1]"`
-	// The percentage of post that are marked as urgent
+	// The percentage of post that are marked as urgent.
 	PercentUrgentPosts float64 `default:"0.001" validate:"range:[0,1]"`
+	// The target number of post reminders to be created.
+	NumPostReminders int64 `default:"200" validate:"range:[0,]"`
 
 	// Percentages of channels to be created, grouped by type.
 	// The total sum of these values must be equal to 1.

--- a/loadtest/control/gencontroller/config.go
+++ b/loadtest/control/gencontroller/config.go
@@ -21,18 +21,18 @@ type Config struct {
 	NumPosts int64 `default:"1000" validate:"range:[0,]"`
 	// The target number of reactions to be created.
 	NumReactions int64 `default:"200" validate:"range:[0,]"`
-	// The percentage of replies to be created.
-	PercentReplies float64 `default:"0.5" validate:"range:[0,1]"`
-	// The percentage of replies that should be in long threads.
-	PercentRepliesInLongThreads float64 `default:"0.05" validate:"range:[0,1]"`
-	// The percentage of post that are marked as urgent.
-	PercentUrgentPosts float64 `default:"0.001" validate:"range:[0,1]"`
 	// The target number of post reminders to be created.
 	NumPostReminders int64 `default:"200" validate:"range:[0,]"`
 	// The target number of sidebar categories to be created.
 	NumSidebarCategories int64 `default:"10" validate:"range:[0,]"`
 	// The target number of threads to follow.
 	NumFollowedThreads int64 `default:"10" validate:"range:[0,]"`
+	// The percentage of replies to be created.
+	PercentReplies float64 `default:"0.5" validate:"range:[0,1]"`
+	// The percentage of replies that should be in long threads.
+	PercentRepliesInLongThreads float64 `default:"0.05" validate:"range:[0,1]"`
+	// The percentage of post that are marked as urgent.
+	PercentUrgentPosts float64 `default:"0.001" validate:"range:[0,1]"`
 
 	// Percentages of channels to be created, grouped by type.
 	// The total sum of these values must be equal to 1.

--- a/loadtest/control/gencontroller/config.go
+++ b/loadtest/control/gencontroller/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	PercentUrgentPosts float64 `default:"0.001" validate:"range:[0,1]"`
 	// The target number of post reminders to be created.
 	NumPostReminders int64 `default:"200" validate:"range:[0,]"`
+	// The target number of sidebar categories to be created.
+	NumSidebarCategories int64 `default:"10" validate:"range:[0,]"`
 
 	// Percentages of channels to be created, grouped by type.
 	// The total sum of these values must be equal to 1.

--- a/loadtest/control/gencontroller/config.go
+++ b/loadtest/control/gencontroller/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	NumPostReminders int64 `default:"200" validate:"range:[0,]"`
 	// The target number of sidebar categories to be created.
 	NumSidebarCategories int64 `default:"10" validate:"range:[0,]"`
+	// The target number of threads to follow.
+	NumFollowedThreads int64 `default:"10" validate:"range:[0,]"`
 
 	// Percentages of channels to be created, grouped by type.
 	// The total sum of these values must be equal to 1.

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -71,7 +71,8 @@ func (c *GenController) Run() {
 		return st.get("teams") >= c.config.NumTeams &&
 			st.get("channels") >= c.config.NumChannels &&
 			st.get("posts") >= c.config.NumPosts &&
-			st.get("reactions") >= c.config.NumReactions
+			st.get("reactions") >= c.config.NumReactions &&
+			st.get("postreminders") >= c.config.NumPostReminders
 	}
 
 	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
@@ -142,6 +143,11 @@ func (c *GenController) Run() {
 			frequency:  int(math.Ceil(float64(c.config.NumPosts) * (1 - c.config.PercentReplies))),
 			idleTimeMs: 1000,
 		},
+		"createPostReminder": {
+			run:        c.createPostReminder,
+			frequency:  int(c.config.NumPostReminders),
+			idleTimeMs: 1000,
+		},
 		"createReply": {
 			run:        c.createReply,
 			frequency:  int(math.Ceil(float64(c.config.NumPosts) * c.config.PercentReplies)),
@@ -186,6 +192,10 @@ func (c *GenController) Run() {
 
 		if st.get("reactions") >= c.config.NumReactions {
 			delete(actions, "addReaction")
+		}
+
+		if st.get("postreminders") >= c.config.NumPostReminders {
+			delete(actions, "createPostReminder")
 		}
 
 		idleTime := time.Duration(math.Round(float64(action.idleTimeMs) * c.rate))

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -68,11 +68,11 @@ func (c *GenController) Run() {
 	}()
 
 	done := func() bool {
-		return st.get("teams") >= c.config.NumTeams &&
-			st.get("channels") >= c.config.NumChannels &&
-			st.get("posts") >= c.config.NumPosts &&
-			st.get("reactions") >= c.config.NumReactions &&
-			st.get("postreminders") >= c.config.NumPostReminders
+		return st.get(StateTargetTeams) >= c.config.NumTeams &&
+			st.get(StateTargetChannels) >= c.config.NumChannels &&
+			st.get(StateTargetPosts) >= c.config.NumPosts &&
+			st.get(StateTargetReactions) >= c.config.NumReactions &&
+			st.get(StateTargetPostReminders) >= c.config.NumPostReminders
 	}
 
 	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
@@ -178,23 +178,23 @@ func (c *GenController) Run() {
 			return
 		}
 
-		if st.get("channels") >= c.config.NumChannels {
+		if st.get(StateTargetChannels) >= c.config.NumChannels {
 			delete(actions, "createPublicChannel")
 			delete(actions, "createPrivateChannel")
 			delete(actions, "createDirectChannel")
 			delete(actions, "createGroupChannel")
 		}
 
-		if st.get("posts") >= c.config.NumPosts {
+		if st.get(StateTargetPosts) >= c.config.NumPosts {
 			delete(actions, "createPost")
 			delete(actions, "createReply")
 		}
 
-		if st.get("reactions") >= c.config.NumReactions {
+		if st.get(StateTargetReactions) >= c.config.NumReactions {
 			delete(actions, "addReaction")
 		}
 
-		if st.get("postreminders") >= c.config.NumPostReminders {
+		if st.get(StateTargetPostReminders) >= c.config.NumPostReminders {
 			delete(actions, "createPostReminder")
 		}
 

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -72,7 +72,8 @@ func (c *GenController) Run() {
 			st.get(StateTargetChannels) >= c.config.NumChannels &&
 			st.get(StateTargetPosts) >= c.config.NumPosts &&
 			st.get(StateTargetReactions) >= c.config.NumReactions &&
-			st.get(StateTargetPostReminders) >= c.config.NumPostReminders
+			st.get(StateTargetPostReminders) >= c.config.NumPostReminders &&
+			st.get(StateTargetSidebarCategories) >= c.config.NumSidebarCategories
 	}
 
 	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
@@ -158,6 +159,11 @@ func (c *GenController) Run() {
 			frequency:  int(c.config.NumReactions),
 			idleTimeMs: 1000,
 		},
+		"createSidebarCategory": {
+			run:        c.createSidebarCategory,
+			frequency:  int(c.config.NumSidebarCategories),
+			idleTimeMs: 1000,
+		},
 	}
 
 	for {
@@ -196,6 +202,10 @@ func (c *GenController) Run() {
 
 		if st.get(StateTargetPostReminders) >= c.config.NumPostReminders {
 			delete(actions, "createPostReminder")
+		}
+
+		if st.get(StateTargetSidebarCategories) >= c.config.NumSidebarCategories {
+			delete(actions, "createSidebarCategory")
 		}
 
 		idleTime := time.Duration(math.Round(float64(action.idleTimeMs) * c.rate))

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -82,6 +82,7 @@ func (c *GenController) Run() {
 	initActions := []control.UserAction{
 		control.SignUp,
 		control.Login,
+		control.GetPreferences,
 		c.createTeam,
 		c.joinTeam,
 		c.joinChannel,

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -73,7 +73,8 @@ func (c *GenController) Run() {
 			st.get(StateTargetPosts) >= c.config.NumPosts &&
 			st.get(StateTargetReactions) >= c.config.NumReactions &&
 			st.get(StateTargetPostReminders) >= c.config.NumPostReminders &&
-			st.get(StateTargetSidebarCategories) >= c.config.NumSidebarCategories
+			st.get(StateTargetSidebarCategories) >= c.config.NumSidebarCategories &&
+			st.get(StateTargetFollowedThreads) >= c.config.NumFollowedThreads
 	}
 
 	c.status <- control.UserStatus{ControllerId: c.id, User: c.user, Info: "user started", Code: control.USER_STATUS_STARTED}
@@ -164,6 +165,11 @@ func (c *GenController) Run() {
 			frequency:  int(c.config.NumSidebarCategories),
 			idleTimeMs: 1000,
 		},
+		"followThread": {
+			run:        c.followThread,
+			frequency:  int(c.config.NumFollowedThreads),
+			idleTimeMs: 1000,
+		},
 	}
 
 	for {
@@ -206,6 +212,10 @@ func (c *GenController) Run() {
 
 		if st.get(StateTargetSidebarCategories) >= c.config.NumSidebarCategories {
 			delete(actions, "createSidebarCategory")
+		}
+
+		if st.get(StateTargetFollowedThreads) >= c.config.NumFollowedThreads {
+			delete(actions, "followThread")
 		}
 
 		idleTime := time.Duration(math.Round(float64(action.idleTimeMs) * c.rate))

--- a/loadtest/control/gencontroller/state.go
+++ b/loadtest/control/gencontroller/state.go
@@ -25,10 +25,11 @@ var st *state
 func init() {
 	st = &state{
 		targets: map[string]int64{
-			"teams":     0,
-			"channels":  0,
-			"posts":     0,
-			"reactions": 0,
+			"teams":         0,
+			"channels":      0,
+			"posts":         0,
+			"reactions":     0,
+			"postreminders": 0,
 		},
 		longRunningThreads: make(map[string]*ThreadInfo),
 	}

--- a/loadtest/control/gencontroller/state.go
+++ b/loadtest/control/gencontroller/state.go
@@ -22,14 +22,22 @@ type ThreadInfo struct {
 
 var st *state
 
+const (
+	StateTargetTeams         = "teams"
+	StateTargetChannels      = "channels"
+	StateTargetPosts         = "posts"
+	StateTargetReactions     = "reactions"
+	StateTargetPostReminders = "postreminders"
+)
+
 func init() {
 	st = &state{
 		targets: map[string]int64{
-			"teams":         0,
-			"channels":      0,
-			"posts":         0,
-			"reactions":     0,
-			"postreminders": 0,
+			StateTargetTeams:         0,
+			StateTargetChannels:      0,
+			StateTargetPosts:         0,
+			StateTargetReactions:     0,
+			StateTargetPostReminders: 0,
 		},
 		longRunningThreads: make(map[string]*ThreadInfo),
 	}

--- a/loadtest/control/gencontroller/state.go
+++ b/loadtest/control/gencontroller/state.go
@@ -23,21 +23,23 @@ type ThreadInfo struct {
 var st *state
 
 const (
-	StateTargetTeams         = "teams"
-	StateTargetChannels      = "channels"
-	StateTargetPosts         = "posts"
-	StateTargetReactions     = "reactions"
-	StateTargetPostReminders = "postreminders"
+	StateTargetTeams             = "teams"
+	StateTargetChannels          = "channels"
+	StateTargetPosts             = "posts"
+	StateTargetReactions         = "reactions"
+	StateTargetPostReminders     = "postreminders"
+	StateTargetSidebarCategories = "sidebarcategories"
 )
 
 func init() {
 	st = &state{
 		targets: map[string]int64{
-			StateTargetTeams:         0,
-			StateTargetChannels:      0,
-			StateTargetPosts:         0,
-			StateTargetReactions:     0,
-			StateTargetPostReminders: 0,
+			StateTargetTeams:             0,
+			StateTargetChannels:          0,
+			StateTargetPosts:             0,
+			StateTargetReactions:         0,
+			StateTargetPostReminders:     0,
+			StateTargetSidebarCategories: 0,
 		},
 		longRunningThreads: make(map[string]*ThreadInfo),
 	}

--- a/loadtest/control/gencontroller/utils.go
+++ b/loadtest/control/gencontroller/utils.go
@@ -41,7 +41,7 @@ func shouldMakeLongRunningThread(channelId string) bool {
 		return false
 	}
 	// one long running thread per channel
-	if len(st.getLongRunningThreadsInChannel(channelId)) > 0 {
+	if len(st.getLongRunningThreadsInChannel(channelId)) > 1 {
 		return false
 	}
 	return true

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -760,7 +759,7 @@ func (c *SimulController) createPost(u user.User) control.UserActionResponse {
 	}
 
 	if hasFilesAttached {
-		if err := c.attachFilesToPost(u, post); err != nil {
+		if err := control.AttachFilesToPost(u, post); err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 	}
@@ -780,52 +779,6 @@ func (c *SimulController) createPost(u user.User) control.UserActionResponse {
 	}
 
 	return control.UserActionResponse{Info: fmt.Sprintf("post created, id %v", postId)}
-}
-
-func (c *SimulController) attachFilesToPost(u user.User, post *model.Post) error {
-	type file struct {
-		data   []byte
-		upload bool
-	}
-	filenames := []string{"test_upload.png", "test_upload.jpg", "test_upload.mp4"}
-	files := make(map[string]*file, len(filenames))
-
-	for _, filename := range filenames {
-		files[filename] = &file{
-			data:   control.MustAsset(filename),
-			upload: rand.Intn(2) == 0,
-		}
-	}
-
-	// We make sure at least one file gets uploaded.
-	files[filenames[rand.Intn(len(filenames))]].upload = true
-
-	var wg sync.WaitGroup
-	fileIds := make(chan string, len(files))
-	for filename, file := range files {
-		if !file.upload {
-			continue
-		}
-		wg.Add(1)
-		go func(filename string, data []byte) {
-			defer wg.Done()
-			resp, err := u.UploadFile(data, post.ChannelId, filename)
-			if err != nil {
-				c.status <- c.newErrorStatus(err)
-				return
-			}
-			c.status <- c.newInfoStatus(fmt.Sprintf("file uploaded, id %v", resp.FileInfos[0].Id))
-			fileIds <- resp.FileInfos[0].Id
-		}(filename, file.data)
-	}
-
-	wg.Wait()
-	numFiles := len(fileIds)
-	for i := 0; i < numFiles; i++ {
-		post.FileIds = append(post.FileIds, <-fileIds)
-	}
-
-	return nil
 }
 
 func (c *SimulController) addReaction(u user.User) control.UserActionResponse {

--- a/loadtest/control/utils.go
+++ b/loadtest/control/utils.go
@@ -13,9 +13,13 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
+	"github.com/mattermost/mattermost-server/server/v8/model"
+	"github.com/wiggin77/merror"
 )
 
 type PostsSearchOpts struct {
@@ -260,4 +264,61 @@ func IsVersionSupported(version, serverVersionString string) (bool, error) {
 	}
 
 	return v.LTE(sv), nil
+}
+
+// AttachFilesToPost uploads at least one file on behalf of the user, attaching
+// all uploaded files to the post.
+func AttachFilesToPost(u user.User, post *model.Post) error {
+	type file struct {
+		data   []byte
+		upload bool
+	}
+	filenames := []string{"test_upload.png", "test_upload.jpg", "test_upload.mp4"}
+	files := make(map[string]*file, len(filenames))
+
+	for _, filename := range filenames {
+		files[filename] = &file{
+			data:   MustAsset(filename),
+			upload: rand.Intn(2) == 0,
+		}
+	}
+
+	// We make sure at least one file gets uploaded.
+	files[filenames[rand.Intn(len(filenames))]].upload = true
+
+	var wg sync.WaitGroup
+	fileIdsChan := make(chan string, len(files))
+	errChan := make(chan error, len(files))
+	for filename, file := range files {
+		if !file.upload {
+			continue
+		}
+		wg.Add(1)
+		go func(filename string, data []byte) {
+			defer wg.Done()
+			resp, err := u.UploadFile(data, post.ChannelId, filename)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			fileIdsChan <- resp.FileInfos[0].Id
+		}(filename, file.data)
+	}
+
+	wg.Wait()
+	close(fileIdsChan)
+	close(errChan)
+
+	// Attach all successfully uploaded files
+	for fileId := range fileIdsChan {
+		post.FileIds = append(post.FileIds, fileId)
+	}
+
+	// Collect all errors
+	merr := merror.New()
+	for err := range errChan {
+		merr.Append(err)
+	}
+
+	return merr.ErrorOrNil()
 }


### PR DESCRIPTION
#### Summary

This PR adds missing feature coverage to `gencontroller`, and fixes a bug I identified in the way with the CRT check.

- Modified actions:
  - Added file attachments to posts in `createPost`
  - Bumped number of long running threads per channel to 2
- New actions: 
  - `createPostReminder`
  - `createSidebarCategory`
  - `followThread`
- Fixes:
  - Fixed a bug in the logic that checks whether CRT is enabled: we were not checking about the always on case.
  - Added an init action to get users preferences. I added this before discovering the actual CRT bug, but I still think it's a good addition, since preferences are definitely not retrieved in this controller, which can cause some bugs in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52956

