### PR TITLE
feat: added application readiness timeout option to te deployer

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -42,6 +42,7 @@
   "MattermostDownloadURL": "https://latest.mattermost.com/mattermost-enterprise-linux",
   "MattermostLicenseFile": "",
   "MattermostConfigPatchFile": "",
+  "MattermostPingTimeoutSeconds": 30,
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -60,6 +60,8 @@ type Config struct {
 	// Optional path to a partial Mattermost config file to be applied as patch during
 	// app server deployment.
 	MattermostConfigPatchFile string `default:""`
+	// Timeout for the ping command to check if the Mattermost instance is ready (in seconds)
+	MattermostPingTimeoutSeconds int `default:"30"`
 	// Mattermost instance sysadmin e-mail.
 	AdminEmail string `default:"sysadmin@sample.mattermost.com" validate:"email"`
 	// Mattermost instance sysadmin user name.

--- a/docs/deployer_config.md
+++ b/docs/deployer_config.md
@@ -224,6 +224,12 @@ The location of the Mattermost Enterprise Edition license file.
 
 An optional path to a partial Mattermost config file to be applied as patch during app server deployment.
 
+## MattermostPingTimeoutSeconds
+
+*int*
+
+The timmeout (in seconds) to wait for an stable Mattermost installation after provisioning.
+
 ## AdminEmail
 
 *string*


### PR DESCRIPTION
#### Summary

In my first usage with the deployer I kept reaching timeouts on the Mattermost installation after the infrastructure was deployed, maybe due to only having one application instance.

I've added a new configuration parameter to set the timeout for the ping handler that checks for the application to be running correctly so I don't need to edit the timeout in code.

#### Ticket Link

--

