### PR TITLE
Reduce number of calls to GetPostsForChannel

### DIFF
--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -401,21 +401,10 @@ func (c *GenController) joinChannel(u user.User) control.UserActionResponse {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
 		resp = control.UserActionResponse{Info: fmt.Sprintf("joined channel %s", channelID)}
-	}
 
-	team, err := u.Store().RandomTeam(store.SelectMemberOf)
-	if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-	channel, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf)
-	if errors.Is(err, memstore.ErrChannelStoreEmpty) {
-		return control.UserActionResponse{Info: "no channels in store"}
-	} else if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	if err := c.user.GetPostsForChannel(channel.Id, 0, 60, collapsedThreads); err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
+		if err := c.user.GetPostsForChannel(channelID, 0, 60, collapsedThreads); err != nil {
+			return control.UserActionResponse{Err: control.NewUserError(err)}
+		}
 	}
 
 	return resp


### PR DESCRIPTION
The problem with using a random channel would be that
there is a probability of the same channel coming up
again and we would unnecessarily make the GetPostsForChannel
call again for the same channel.

This was costly and would waste resources. Instead, we just
get the posts for the channel we just joined. This way
we don't get posts for the same channel again.
