### PR TITLE
MM-53154: Add getPosts action

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 require (
 	github.com/graph-gophers/graphql-go v1.5.1-0.20230110080634-edea822f558a
 	github.com/vmihailenco/msgpack/v5 v5.3.5
+	github.com/wiggin77/merror v1.0.4
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 )
 
 require (
@@ -99,7 +101,6 @@ require (
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/wiggin77/merror v1.0.4 // indirect
 	github.com/wiggin77/srslog v1.0.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1442,6 +1442,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -533,3 +533,23 @@ func (c *GenController) followThread(u user.User) (res control.UserActionRespons
 
 	return control.UserActionResponse{Info: fmt.Sprintf("followed thread %s", threadId)}
 }
+
+func (c *GenController) getPosts(u user.User) (res control.UserActionResponse) {
+	team, err := u.Store().RandomTeam(store.SelectMemberOf)
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+	channel, err := u.Store().RandomChannel(team.Id, store.SelectMemberOf)
+	if errors.Is(err, memstore.ErrChannelStoreEmpty) {
+		return control.UserActionResponse{Warn: "no channels in store"}
+	} else if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	collapsedThreads := false
+	if err := c.user.GetPostsForChannel(channel.Id, 0, 200, collapsedThreads); err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	return control.UserActionResponse{Info: fmt.Sprintf("got posts for channel %q", channel.Id)}
+}

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -192,6 +192,13 @@ func (c *GenController) Run() {
 			frequency:  int(c.config.NumFollowedThreads),
 			idleTimeMs: 1000,
 		},
+		// This action does not generate data, but is needed for all other actions
+		// to have data to work with
+		"getPosts": {
+			run:        c.getPosts,
+			frequency:  100,
+			idleTimeMs: 1000,
+		},
 	}
 
 	c.runActions(actions, func() bool {

--- a/loadtest/control/gencontroller/controller.go
+++ b/loadtest/control/gencontroller/controller.go
@@ -196,7 +196,7 @@ func (c *GenController) Run() {
 		// to have data to work with
 		"getPosts": {
 			run:        c.getPosts,
-			frequency:  100,
+			frequency:  int(max(100, c.config.NumPosts/1000)),
 			idleTimeMs: 1000,
 		},
 	}

--- a/loadtest/control/gencontroller/utils.go
+++ b/loadtest/control/gencontroller/utils.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
+	"golang.org/x/exp/constraints"
 )
 
 // pickAction randomly selects an action from a map of userAction with
@@ -94,4 +95,11 @@ func chooseChannel(dist []ChannelMemberDistribution, idx int, u user.User) (stri
 
 		return channelID, nil
 	}
+}
+
+func max[T constraints.Ordered](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
#### Summary
Add a simple `1getPosts` action in the gencontroller that retrieves the first 200 posts of a random channel the user is a member of.

The frequency is set to 100, which is quite low, unless the number of channels or posts configured is even lower. Not sure if we should be too concerned about that, I'm open to discussing it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53154