### PR TITLE
Fix crash in memstore

### DIFF
--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -242,7 +242,9 @@ func (s *MemStore) RandomPost(st store.SelectionType) (model.Post, error) {
 			}
 
 			channel := s.channels[p.ChannelId]
-
+			if channel == nil {
+				continue
+			}
 			if (currChanId == channel.Id) && isSelectionType(st, store.SelectNotCurrent) {
 				continue
 			}


### PR DESCRIPTION
If a post gets created in a channel which is not loaded
in the store, then RandomPost can crash.

Added a nil check to prevent that.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xebc250]

goroutine 151 [running]:
github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore.(*MemStore).RandomPost(_, _)
        /home/agniva/mattermost/mattermost-load-test-ng/loadtest/store/memstore/random.go:247 +0x530
github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller.(*GenController).createReply(0xc0005301c0, {0x1503378, 0xc0005b8240})
        /home/agniva/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller/actions.go:329 +0x5a8
github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller.(*GenController).runActions(0xc0005301c0, 0xc0001439d0?, 0xc000f79920)
        /home/agniva/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller/controller.go:231 +0x78
github.com/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller.(*GenController).Run(0xc0005301c0)
        /home/agniva/mattermost/mattermost-load-test-ng/loadtest/control/gencontroller/controller.go:209 +0x1325
github.com/mattermost/mattermost-load-test-ng/loadtest.(*LoadTester).addUser.func1()
        /home/agniva/mattermost/mattermost-load-test-ng/loadtest/loadtest.go:131 +0x22
created by github.com/mattermost/mattermost-load-test-ng/loadtest.(*LoadTester).addUser
        /home/agniva/mattermost/mattermost-load-test-ng/loadtest/loadtest.go:130 +0x38b
exit status 2
```
