### PR TITLE
MM-52331: Automate dump ingestion for normal deployments

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -26,7 +26,22 @@ func RunCreateCmdF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create terraform engine: %w", err)
 	}
-	return t.Create(true)
+
+	// If DBDumpURI is not set, we seed data. Otherwise,
+	// we just load the dump.
+	initData := config.DBDumpURI == ""
+	err = t.Create(initData)
+	if err != nil {
+		return fmt.Errorf("failed to create terraform env: %w", err)
+	}
+
+	if !initData {
+		err = t.IngestDump()
+		if err != nil {
+			return fmt.Errorf("failed to create ingest dump: %w", err)
+		}
+	}
+	return nil
 }
 
 func RunDestroyCmdF(cmd *cobra.Command, args []string) error {

--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -6,11 +6,10 @@ package comparison
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
@@ -41,33 +40,6 @@ func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpConf
 		mlog.Error(err.Error())
 	}
 	return err
-}
-
-// provisionURL takes a URL pointing to a file to be provisioned.
-func provisionURL(client *ssh.Client, url string, filename string) error {
-	filePrefix := "file://"
-	if strings.HasPrefix(url, filePrefix) {
-		// upload file from local filesystem
-		path := strings.TrimPrefix(url, filePrefix)
-		info, err := os.Stat(path)
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("build file %s has to be a regular file", path)
-		}
-		if out, err := client.UploadFile(path, "/home/ubuntu/"+filename, false); err != nil {
-			return fmt.Errorf("error uploading build: %w %s", err, out)
-		}
-	} else {
-		// download build file from URL
-		cmd := fmt.Sprintf("wget -O %s %s", filename, url)
-		if out, err := client.RunCommand(cmd); err != nil {
-			return fmt.Errorf("failed to run cmd %q: %w %s", cmd, err, out)
-		}
-	}
-
-	return nil
 }
 
 // provisionFiles loads the provided build and (optionally) db dump files
@@ -101,13 +73,13 @@ func provisionFiles(t *terraform.Terraform, dpConfig *deploymentConfig, baseBuil
 	for _, client := range clients {
 		for id, ltConfig := range dpConfig.loadTests {
 			if ltConfig.DBDumpURL != "" {
-				if err := provisionURL(client, ltConfig.DBDumpURL, ltConfig.getDumpFilename(id)); err != nil {
+				if err := deployment.ProvisionURL(client, ltConfig.DBDumpURL, ltConfig.getDumpFilename(id)); err != nil {
 					return err
 				}
 			}
 		}
 		for _, url := range []string{baseBuildURL, newBuildURL} {
-			if err := provisionURL(client, url, filepath.Base(url)); err != nil {
+			if err := deployment.ProvisionURL(client, url, filepath.Base(url)); err != nil {
 				return err
 			}
 		}

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/coordinator"
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
@@ -108,73 +109,9 @@ func runUnboundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Confi
 	}
 }
 
-type cmd struct {
-	msg     string
-	value   string
-	clients []*ssh.Client
-}
-
 type localCmd struct {
 	msg   string
 	value []string
-}
-
-type dbSettings struct {
-	UserName string
-	Password string
-	DBName   string
-	Host     string
-	Engine   string
-}
-
-// buildLoadDBDumpCmds returns a slice of commands that, when piped, feed the
-// provided DB dump file into the database, replacing first the old IPs found
-// in the posts that contain a permalink with the new IP. Something like:
-//
-//	zcat dbdump.sql
-//	sed -r -e 's/old_ip_1/new_ip' -e 's/old_ip_2/new_ip'
-//	mysql/psql connection_details
-func buildLoadDBDumpCmds(dumpFilename string, newIP string, permalinkIPsToReplace []string, dbInfo dbSettings) ([]string, error) {
-	zcatCmd := fmt.Sprintf("zcat %s", dumpFilename)
-
-	var replacements []string
-	for _, oldIP := range permalinkIPsToReplace {
-		// Let's build the match and replace parts of a sed command: 's/match/replace/g'
-		// First, the match. We want to match anything of the form
-		//    54.126.54.26:8065/debitis-1/pl/
-		// where the IP is exactly the old one, the port is optional and arbitrary and the
-		// team name is the pattern defined by the server's function model.IsValidTeamname
-		validTeamName := `[a-z0-9]+([a-z0-9-]+|(__)?)[a-z0-9]+`
-		escapedOldIP := strings.ReplaceAll(oldIP, ".", "\\.")
-		match := escapedOldIP + `(:[0-9]+)?\/(` + validTeamName + `)\/pl\/`
-		// Now, the replace. We need to replace this with the same thing, only changing the
-		// IP with the new one and hard-coding the port to 8065, but maintaining the team
-		// name (hence the second group match, \2)
-		replace := newIP + `:8065\/\2\/pl\/`
-		// We can build the whole command now and add it to the list of replacements
-		sedRegex := fmt.Sprintf(`'s/%s/%s/g'`, match, replace)
-		replacements = append(replacements, sedRegex)
-	}
-	var sedCmd string
-	if len(replacements) > 0 {
-		sedCmd = strings.Join(append([]string{"sed -r"}, replacements...), " -e ")
-	}
-
-	var dbCmd string
-	switch dbInfo.Engine {
-	case "aurora-postgresql":
-		dbCmd = fmt.Sprintf("psql 'postgres://%[1]s:%[2]s@%[3]s/%[4]s?sslmode=disable'", dbInfo.UserName, dbInfo.Password, dbInfo.Host, dbInfo.DBName)
-	case "aurora-mysql":
-		dbCmd = fmt.Sprintf("mysql -h %[1]s -u %[2]s -p%[3]s %[4]s", dbInfo.Host, dbInfo.UserName, dbInfo.Password, dbInfo.DBName)
-	default:
-		return []string{}, fmt.Errorf("invalid db engine %s", dbInfo.Engine)
-	}
-
-	if sedCmd != "" {
-		return []string{zcatCmd, sedCmd, dbCmd}, nil
-	}
-
-	return []string{zcatCmd, dbCmd}, nil
 }
 
 func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename string, s3BucketURI string, permalinkIPsToReplace []string, cancelCh <-chan struct{}) error {
@@ -210,28 +147,28 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		appClients[i] = client
 	}
 
-	stopCmd := cmd{
-		msg:     "Stopping app servers",
-		value:   "sudo systemctl stop mattermost",
-		clients: appClients,
+	stopCmd := deployment.Cmd{
+		Msg:     "Stopping app servers",
+		Value:   "sudo systemctl stop mattermost",
+		Clients: appClients,
 	}
 
 	buildFileName := filepath.Base(buildCfg.URL)
-	installCmd := cmd{
-		msg:     "Installing app",
-		value:   fmt.Sprintf("cd /home/ubuntu && tar xzf %s && cp /opt/mattermost/config/config.json . && sudo rm -rf /opt/mattermost && sudo mv mattermost /opt/ && mv config.json /opt/mattermost/config/", buildFileName),
-		clients: appClients,
+	installCmd := deployment.Cmd{
+		Msg:     "Installing app",
+		Value:   fmt.Sprintf("cd /home/ubuntu && tar xzf %s && cp /opt/mattermost/config/config.json . && sudo rm -rf /opt/mattermost && sudo mv mattermost /opt/ && mv config.json /opt/mattermost/config/", buildFileName),
+		Clients: appClients,
 	}
 
 	dbName := dpConfig.DBName()
-	resetCmd := cmd{
-		msg:     "Resetting database",
-		clients: []*ssh.Client{appClients[0]},
+	resetCmd := deployment.Cmd{
+		Msg:     "Resetting database",
+		Clients: []*ssh.Client{appClients[0]},
 	}
 	switch dpConfig.TerraformDBSettings.InstanceEngine {
 	case "aurora-postgresql":
 		sqlConnParams := fmt.Sprintf("-U %s -h %s %s", dpConfig.TerraformDBSettings.UserName, tfOutput.DBWriter(), dbName)
-		resetCmd.value = strings.Join([]string{
+		resetCmd.Value = strings.Join([]string{
 			fmt.Sprintf("export PGPASSWORD='%s'", dpConfig.TerraformDBSettings.Password),
 			fmt.Sprintf("dropdb %s", sqlConnParams),
 			fmt.Sprintf("createdb %s", sqlConnParams),
@@ -239,39 +176,39 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		}, " && ")
 	case "aurora-mysql":
 		subCmd := fmt.Sprintf("mysqladmin -h %s -u %s -p%s -f", tfOutput.DBWriter(), dpConfig.TerraformDBSettings.UserName, dpConfig.TerraformDBSettings.Password)
-		resetCmd.value = fmt.Sprintf("%s drop %s && %s create %s", subCmd, dbName, subCmd, dbName)
+		resetCmd.Value = fmt.Sprintf("%s drop %s && %s create %s", subCmd, dbName, subCmd, dbName)
 	default:
 		return fmt.Errorf("invalid db engine %s", dpConfig.TerraformDBSettings.InstanceEngine)
 	}
 
-	startCmd := cmd{
-		msg:     "Restarting app server",
-		value:   "sudo systemctl start mattermost && until $(curl -sSf http://localhost:8065 --output /dev/null); do sleep 1; done;",
-		clients: appClients,
+	startCmd := deployment.Cmd{
+		Msg:     "Restarting app server",
+		Value:   "sudo systemctl start mattermost && until $(curl -sSf http://localhost:8065 --output /dev/null); do sleep 1; done;",
+		Clients: appClients,
 	}
 
 	// do init process
 	mmctlPath := "/opt/mattermost/bin/mmctl"
-	createAdminCmd := cmd{
-		msg: "Creating sysadmin",
-		value: fmt.Sprintf("%s user create --email %s --username %s --password '%s' --system-admin --local || true",
+	createAdminCmd := deployment.Cmd{
+		Msg: "Creating sysadmin",
+		Value: fmt.Sprintf("%s user create --email %s --username %s --password '%s' --system-admin --local || true",
 			mmctlPath, dpConfig.AdminEmail, dpConfig.AdminUsername, dpConfig.AdminPassword),
-		clients: []*ssh.Client{appClients[0]},
+		Clients: []*ssh.Client{appClients[0]},
 	}
-	initDataCmd := cmd{
-		msg:     "Initializing data",
-		value:   fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' > /dev/null 2>&1", tfOutput.Agents[0].Tags.Name),
-		clients: []*ssh.Client{agentClient},
-	}
-
-	cmds := []cmd{stopCmd, installCmd, resetCmd}
-
-	loadDBDumpCmd := cmd{
-		msg:     "Loading DB dump",
-		clients: []*ssh.Client{appClients[0]},
+	initDataCmd := deployment.Cmd{
+		Msg:     "Initializing data",
+		Value:   fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' > /dev/null 2>&1", tfOutput.Agents[0].Tags.Name),
+		Clients: []*ssh.Client{agentClient},
 	}
 
-	dbCmds, err := buildLoadDBDumpCmds(dumpFilename, tfOutput.Instances[0].PublicIP, permalinkIPsToReplace, dbSettings{
+	cmds := []deployment.Cmd{stopCmd, installCmd, resetCmd}
+
+	loadDBDumpCmd := deployment.Cmd{
+		Msg:     "Loading DB dump",
+		Clients: []*ssh.Client{appClients[0]},
+	}
+
+	dbCmds, err := deployment.BuildLoadDBDumpCmds(dumpFilename, tfOutput.Instances[0].PublicIP, permalinkIPsToReplace, deployment.DBSettings{
 		UserName: dpConfig.TerraformDBSettings.UserName,
 		Password: dpConfig.TerraformDBSettings.Password,
 		DBName:   dbName,
@@ -282,7 +219,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		return fmt.Errorf("error building commands for loading DB dump: %w", err)
 	}
 
-	loadDBDumpCmd.value = strings.Join(dbCmds, " | ")
+	loadDBDumpCmd.Value = strings.Join(dbCmds, " | ")
 
 	resetBucketCmds := []localCmd{}
 	if s3BucketURI != "" && tfOutput.HasS3Bucket() {
@@ -322,16 +259,16 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 	}()
 
 	for _, c := range cmds {
-		mlog.Info(c.msg)
-		for _, client := range c.clients {
+		mlog.Info(c.Msg)
+		for _, client := range c.Clients {
 			select {
 			case <-cancelCh:
 				mlog.Info("cancelling load-test init")
 				return errors.New("canceled")
 			default:
 			}
-			if out, err := client.RunCommand(c.value); err != nil {
-				return fmt.Errorf("failed to run cmd %q: %w %s", c.value, err, out)
+			if out, err := client.RunCommand(c.Value); err != nil {
+				return fmt.Errorf("failed to run cmd %q: %w %s", c.Value, err, out)
 			}
 		}
 	}

--- a/comparison/loadtest_test.go
+++ b/comparison/loadtest_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,7 +14,7 @@ func TestBuildLoadDBDumpCmd(t *testing.T) {
 		newIP := "192.168.1.1"
 		oldIPs := []string{}
 
-		cmds, err := buildLoadDBDumpCmds("dbfilename", newIP, oldIPs, dbSettings{
+		cmds, err := deployment.BuildLoadDBDumpCmds("dbfilename", newIP, oldIPs, deployment.DBSettings{
 			UserName: "mmuser",
 			Password: "mostest",
 			DBName:   "mattermost",
@@ -32,7 +33,7 @@ func TestBuildLoadDBDumpCmd(t *testing.T) {
 		newIP := "192.168.1.1"
 		oldIPs := []string{"54.78.456.5", "56.78.98.1"}
 
-		cmds, err := buildLoadDBDumpCmds("dbfilename", newIP, oldIPs, dbSettings{
+		cmds, err := deployment.BuildLoadDBDumpCmds("dbfilename", newIP, oldIPs, deployment.DBSettings{
 			UserName: "mmuser",
 			Password: "mostest",
 			DBName:   "mattermost",

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -25,6 +25,8 @@
   "SSHPublicKey": "~/.ssh/id_rsa.pub",
   "TerraformStateDir" : "/var/lib/mattermost-load-test-ng",
   "S3BucketDumpURI" : "",
+  "DBDumpURI": "",
+  "PermalinkIPsToReplace": [],
   "TerraformDBSettings": {
     "InstanceCount": 1,
     "InstanceEngine": "aurora-postgresql",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	// The file is expected to be gzip compressed.
 	// This can also point to a local file if prefixed with "file://".
 	// In such case, the dump file will be uploaded to the app servers.
-	DBDumpURI       string `default:""`
+	DBDumpURI string `default:""`
 	// An optional list of IPs present in the posts from the DB dump
 	// that contain permalinks to other posts. These IPs are replaced,
 	// when ingesting the dump into the database, in every post that

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -79,6 +79,11 @@ type Config struct {
 	TerraformStateDir string `default:"/var/lib/mattermost-load-test-ng" validate:"notempty"`
 	// URI of an S3 bucket whose contents are copied to the bucket created in the deployment
 	S3BucketDumpURI string `default:"" validate:"s3uri"`
+	// An optional URI to a MM server database dump file
+	// to be loaded before running the load-test.
+	// The file is expected to be gzip compressed.
+	// This can also point to a local file if prefixed with "file://".
+	// In such case, the dump file will be uploaded to the app servers.
 	DBDumpURI       string `default:""`
 	// An optional list of IPs present in the posts from the DB dump
 	// that contain permalinks to other posts. These IPs are replaced,

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -79,6 +79,13 @@ type Config struct {
 	TerraformStateDir string `default:"/var/lib/mattermost-load-test-ng" validate:"notempty"`
 	// URI of an S3 bucket whose contents are copied to the bucket created in the deployment
 	S3BucketDumpURI string `default:"" validate:"s3uri"`
+	DBDumpURI       string `default:""`
+	// An optional list of IPs present in the posts from the DB dump
+	// that contain permalinks to other posts. These IPs are replaced,
+	// when ingesting the dump into the database, in every post that
+	// uses them with the public IP of the first app instance, so that
+	// the permalinks are valid in the new deployment.
+	PermalinkIPsToReplace []string `validate:"each:ip"`
 }
 
 // TerraformDBSettings contains the necessary data

--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package terraform
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
+	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
+	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
+)
+
+func (t *Terraform) IngestDump() error {
+	output, err := t.Output()
+	if err != nil {
+		return err
+	}
+
+	extAgent, err := ssh.NewAgent()
+	if err != nil {
+		return err
+	}
+
+	if len(output.Instances) < 1 {
+		return fmt.Errorf("no app instances deployed")
+	}
+
+	appClients := make([]*ssh.Client, len(output.Instances))
+	for i, instance := range output.Instances {
+		client, err := extAgent.NewClient(instance.PublicIP)
+		if err != nil {
+			return fmt.Errorf("error in getting ssh connection %w", err)
+		}
+		defer client.Close()
+		appClients[i] = client
+	}
+
+	dumpURI := t.config.DBDumpURI
+	fileName := filepath.Base(dumpURI)
+	mlog.Info("Provisioning dump file", mlog.String("uri", dumpURI))
+	if err := deployment.ProvisionURL(appClients[0], dumpURI, fileName); err != nil {
+		return err
+	}
+
+	// stop
+	// reset
+	// load dump
+	// start
+
+	stopCmd := deployment.Cmd{
+		Msg:     "Stopping app servers",
+		Value:   "sudo systemctl stop mattermost",
+		Clients: appClients,
+	}
+
+	resetCmd, err := getResetCmd(t.config, output, appClients)
+	if err != nil {
+		return fmt.Errorf("error building reset cmd: %w", err)
+	}
+
+	loadDBDumpCmd := deployment.Cmd{
+		Msg:     "Loading DB dump",
+		Clients: []*ssh.Client{appClients[0]},
+	}
+
+	dbCmds, err := deployment.BuildLoadDBDumpCmds(fileName, output.Instances[0].PublicIP, t.config.PermalinkIPsToReplace, deployment.DBSettings{
+		UserName: t.config.TerraformDBSettings.UserName,
+		Password: t.config.TerraformDBSettings.Password,
+		DBName:   t.config.DBName(),
+		Host:     output.DBWriter(),
+		Engine:   t.config.TerraformDBSettings.InstanceEngine,
+	})
+	if err != nil {
+		return fmt.Errorf("error building commands for loading DB dump: %w", err)
+	}
+	loadDBDumpCmd.Value = strings.Join(dbCmds, " | ")
+
+	startCmd := deployment.Cmd{
+		Msg:     "Restarting app server",
+		Value:   "sudo systemctl start mattermost && until $(curl -sSf http://localhost:8065 --output /dev/null); do sleep 1; done;",
+		Clients: appClients,
+	}
+
+	for _, c := range []deployment.Cmd{stopCmd, resetCmd, loadDBDumpCmd, startCmd} {
+		mlog.Info(c.Msg)
+		for _, client := range c.Clients {
+			mlog.Debug("Running cmd", mlog.String("cmd", c.Value))
+			if out, err := client.RunCommand(c.Value); err != nil {
+				return fmt.Errorf("failed to run cmd %q: %w %s", c.Value, err, out)
+			}
+		}
+	}
+
+	return nil
+}
+
+func getResetCmd(config *deployment.Config, output *Output, appClients []*ssh.Client) (deployment.Cmd, error) {
+	dbName := config.DBName()
+	resetCmd := deployment.Cmd{
+		Msg:     "Resetting database",
+		Clients: []*ssh.Client{appClients[0]},
+	}
+	switch config.TerraformDBSettings.InstanceEngine {
+	case "aurora-postgresql":
+		sqlConnParams := fmt.Sprintf("-U %s -h %s %s", config.TerraformDBSettings.UserName, output.DBWriter(), dbName)
+		resetCmd.Value = strings.Join([]string{
+			fmt.Sprintf("export PGPASSWORD='%s'", config.TerraformDBSettings.Password),
+			fmt.Sprintf("dropdb %s", sqlConnParams),
+			fmt.Sprintf("createdb %s", sqlConnParams),
+			fmt.Sprintf("psql %s -c 'ALTER DATABASE %s SET default_text_search_config TO \"pg_catalog.english\"'", sqlConnParams, dbName),
+		}, " && ")
+	case "aurora-mysql":
+		subCmd := fmt.Sprintf("mysqladmin -h %s -u %s -p%s -f", output.DBWriter(), config.TerraformDBSettings.UserName, config.TerraformDBSettings.Password)
+		resetCmd.Value = fmt.Sprintf("%s drop %s && %s create %s", subCmd, dbName, subCmd, dbName)
+	default:
+		return deployment.Cmd{}, fmt.Errorf("invalid db engine %s", config.TerraformDBSettings.InstanceEngine)
+	}
+
+	return resetCmd, nil
+}

--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -13,6 +13,9 @@ import (
 	"github.com/mattermost/mattermost-server/server/v8/platform/shared/mlog"
 )
 
+// IngestDump works on an already deployed terraform setup and restores
+// the DB dump file to the Mattermost server. It uses the deployment config
+// for the dump URI.
 func (t *Terraform) IngestDump() error {
 	output, err := t.Output()
 	if err != nil {

--- a/deployment/utils.go
+++ b/deployment/utils.go
@@ -26,6 +26,8 @@ type DBSettings struct {
 }
 
 // ProvisionURL takes a URL pointing to a file to be provisioned.
+// It works on both local files prefixed with file:// or remote files.
+// In case of local files, they are uploaded to the server.
 func ProvisionURL(client *ssh.Client, url, filename string) error {
 	filePrefix := "file://"
 	if strings.HasPrefix(url, filePrefix) {

--- a/deployment/utils.go
+++ b/deployment/utils.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package deployment
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
+)
+
+type Cmd struct {
+	Msg     string
+	Value   string
+	Clients []*ssh.Client
+}
+
+type DBSettings struct {
+	UserName string
+	Password string
+	DBName   string
+	Host     string
+	Engine   string
+}
+
+// ProvisionURL takes a URL pointing to a file to be provisioned.
+func ProvisionURL(client *ssh.Client, url, filename string) error {
+	filePrefix := "file://"
+	if strings.HasPrefix(url, filePrefix) {
+		// upload file from local filesystem
+		path := strings.TrimPrefix(url, filePrefix)
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("build file %s has to be a regular file", path)
+		}
+		if out, err := client.UploadFile(path, "/home/ubuntu/"+filename, false); err != nil {
+			return fmt.Errorf("error uploading build: %w %s", err, out)
+		}
+	} else {
+		// download build file from URL
+		cmd := fmt.Sprintf("wget -O %s %s", filename, url)
+		if out, err := client.RunCommand(cmd); err != nil {
+			return fmt.Errorf("failed to run cmd %q: %w %s", cmd, err, out)
+		}
+	}
+
+	return nil
+}
+
+// BuildLoadDBDumpCmds returns a slice of commands that, when piped, feed the
+// provided DB dump file into the database, replacing first the old IPs found
+// in the posts that contain a permalink with the new IP. Something like:
+//
+//	zcat dbdump.sql
+//	sed -r -e 's/old_ip_1/new_ip' -e 's/old_ip_2/new_ip'
+//	mysql/psql connection_details
+func BuildLoadDBDumpCmds(dumpFilename string, newIP string, permalinkIPsToReplace []string, dbInfo DBSettings) ([]string, error) {
+	zcatCmd := fmt.Sprintf("zcat %s", dumpFilename)
+
+	var replacements []string
+	for _, oldIP := range permalinkIPsToReplace {
+		// Let's build the match and replace parts of a sed command: 's/match/replace/g'
+		// First, the match. We want to match anything of the form
+		//    54.126.54.26:8065/debitis-1/pl/
+		// where the IP is exactly the old one, the port is optional and arbitrary and the
+		// team name is the pattern defined by the server's function model.IsValidTeamname
+		validTeamName := `[a-z0-9]+([a-z0-9-]+|(__)?)[a-z0-9]+`
+		escapedOldIP := strings.ReplaceAll(oldIP, ".", "\\.")
+		match := escapedOldIP + `(:[0-9]+)?\/(` + validTeamName + `)\/pl\/`
+		// Now, the replace. We need to replace this with the same thing, only changing the
+		// IP with the new one and hard-coding the port to 8065, but maintaining the team
+		// name (hence the second group match, \2)
+		replace := newIP + `:8065\/\2\/pl\/`
+		// We can build the whole command now and add it to the list of replacements
+		sedRegex := fmt.Sprintf(`'s/%s/%s/g'`, match, replace)
+		replacements = append(replacements, sedRegex)
+	}
+	var sedCmd string
+	if len(replacements) > 0 {
+		sedCmd = strings.Join(append([]string{"sed -r"}, replacements...), " -e ")
+	}
+
+	var dbCmd string
+	switch dbInfo.Engine {
+	case "aurora-postgresql":
+		dbCmd = fmt.Sprintf("psql 'postgres://%[1]s:%[2]s@%[3]s/%[4]s?sslmode=disable'", dbInfo.UserName, dbInfo.Password, dbInfo.Host, dbInfo.DBName)
+	case "aurora-mysql":
+		dbCmd = fmt.Sprintf("mysql -h %[1]s -u %[2]s -p%[3]s %[4]s", dbInfo.Host, dbInfo.UserName, dbInfo.Password, dbInfo.DBName)
+	default:
+		return []string{}, fmt.Errorf("invalid db engine %s", dbInfo.Engine)
+	}
+
+	if sedCmd != "" {
+		return []string{zcatCmd, sedCmd, dbCmd}, nil
+	}
+
+	return []string{zcatCmd, dbCmd}, nil
+}

--- a/docs/deployer_config.md
+++ b/docs/deployer_config.md
@@ -338,3 +338,23 @@ URI pointing to an S3 bucket: something of the form `s3://bucket-name/optional-s
 The contents of this bucket will be copied to the bucket created in the deployment, using `aws s3 cp`. This command is ran locally, so having the AWS CLI installed is required.
 If no bucket is created in the deployment (see [`AppInstanceCount`](#AppInstanceCount) for more information), this value is ignored.
 If a bucket is created in the deployment but this value is empty, the created bucket will not be pre-populated with any data.
+
+## S3BucketDumpURI
+
+*string*
+
+An optional URI to a MM server database dump file
+to be loaded before running the load-test.
+The file is expected to be gzip compressed.
+This can also point to a local file if prefixed with "file://".
+In such case, the dump file will be uploaded to the app servers.
+
+## PermalinkIPsToReplace
+
+*string*
+
+An optional list of IPs present in the posts from the DB dump
+that contain permalinks to other posts. These IPs are replaced,
+when ingesting the dump into the database, in every post that
+uses them with the public IP of the first app instance, so that
+the permalinks are valid in the new deployment.

--- a/loadtest/utils.go
+++ b/loadtest/utils.go
@@ -7,11 +7,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity"
 
 	"github.com/mattermost/mattermost-server/server/v8/model"
-
-	"github.com/mattermost/mattermost-load-test-ng/loadtest/control"
 )
 
 func pickRate(config UserControllerConfiguration) (float64, error) {


### PR DESCRIPTION
I moved some of the common code under deployment. There's
still slight repetition but it's only at a high level.

I wanted to have some level of freedom in case the workflow
changes between a deployment run and a comparison run. That's
why I refactored only the low-level plumbing.

https://mattermost.atlassian.net/browse/MM-52331
