### PR TITLE
Sleep 200-500 ms after adding user to team

### DIFF
--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -465,6 +465,7 @@ func (c *GenController) joinAllTeams(u user.User) control.UserActionResponse {
 		if err := u.AddTeamMember(team.Id, userId); err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}
+		time.Sleep(200*time.Millisecond + time.Duration(rand.Intn(300))*time.Millisecond)
 		if err := u.GetChannelsForTeam(team.Id, true); err != nil {
 			return control.UserActionResponse{Err: control.NewUserError(err)}
 		}


### PR DESCRIPTION
#### Summary
There seems to be a data race in HA environments between adding a user to a member and asking for the channels in that team. We introduce a sleep (from 200 to 500 milliseconds) between those two calls to let the cluster catch up and avoid the read-after-write issue.

#### Ticket Link

