### PR TITLE
Let deployments be made with zero agents

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	// Type of the EC2 instance for app.
 	AppInstanceType string `default:"c5.xlarge" validate:"notempty"`
 	// Number of agents, first agent and coordinator will share the same instance.
-	AgentInstanceCount int `default:"2" validate:"range:[1,)"`
+	AgentInstanceCount int `default:"2" validate:"range:[0,)"`
 	// Type of the EC2 instance for agent.
 	AgentInstanceType string `default:"c5.xlarge" validate:"notempty"`
 	// Logs the command output (stdout & stderr) to home directory.

--- a/deployment/terraform/info.go
+++ b/deployment/terraform/info.go
@@ -47,9 +47,9 @@ func displayInfo(output *Output) {
 		for _, agent := range output.Agents {
 			fmt.Println("- " + agent.Tags.Name + ": " + agent.PublicIP)
 		}
-	}
 
-	fmt.Println("Coordinator: " + output.Agents[0].PublicIP)
+		fmt.Println("Coordinator: " + output.Agents[0].PublicIP)
+	}
 
 	if output.HasMetrics() {
 		fmt.Println("Grafana URL: http://" + output.MetricsServer.PublicIP + ":3000")

--- a/deployment/terraform/info.go
+++ b/deployment/terraform/info.go
@@ -20,11 +20,6 @@ func (t *Terraform) Info() error {
 }
 
 func displayInfo(output *Output) {
-	if len(output.Agents) == 0 {
-		fmt.Println("No active deployment found.")
-		return
-	}
-
 	fmt.Println("==================================================")
 	fmt.Println("Deployment information:")
 
@@ -47,10 +42,13 @@ func displayInfo(output *Output) {
 		}
 	}
 
-	fmt.Println("Load Agent(s):")
-	for _, agent := range output.Agents {
-		fmt.Println("- " + agent.Tags.Name + ": " + agent.PublicIP)
+	if output.HasAgents() {
+		fmt.Println("Load Agent(s):")
+		for _, agent := range output.Agents {
+			fmt.Println("- " + agent.Tags.Name + ": " + agent.PublicIP)
+		}
 	}
+
 	fmt.Println("Coordinator: " + output.Agents[0].PublicIP)
 
 	if output.HasMetrics() {

--- a/deployment/terraform/output.go
+++ b/deployment/terraform/output.go
@@ -177,6 +177,11 @@ func (o *Output) HasAppServers() bool {
 	return len(o.Instances) > 0
 }
 
+// HasAgents returns whether a deployment includes agent instances.
+func (o *Output) HasAgents() bool {
+	return len(o.Agents) > 0
+}
+
 // HasMetrics returns whether a deployment includes the metrics instance.
 func (o *Output) HasMetrics() bool {
 	return o.MetricsServer.PrivateIP != ""


### PR DESCRIPTION
Sometimes, we just need a server only setup
to test out something. Or we may already have
an agent cluster and just want to deploy a
server side setup.
