### PR TITLE
MM-53644: Prevent panic when a metric value is not present

### DIFF
--- a/loadtest/report/output.go
+++ b/loadtest/report/output.go
@@ -250,8 +250,22 @@ func plot(metric, prefix, fileName string, others []labelValues, baseLabel strin
 func sortKeys(m map[model.LabelValue]avgp99, t sortByType, desc bool) []model.LabelValue {
 	var labels []model.LabelValue
 	for key := range m {
+		// We ignore if either the avg or p99 value is missing.
+		// This can happen sometimes if avg has a metric but there is no p99 metric
+		// because other metrics are too prominent.
+		switch t {
+		case sortByAvg:
+			if len(m[key][0]) == 0 {
+				continue
+			}
+		case sortByP99:
+			if len(m[key][1]) == 0 {
+				continue
+			}
+		}
 		labels = append(labels, key)
 	}
+
 	sort.Slice(labels, func(i, j int) bool {
 		if desc {
 			i, j = j, i

--- a/loadtest/report/output_test.go
+++ b/loadtest/report/output_test.go
@@ -16,8 +16,7 @@ func TestSortKeys(t *testing.T) {
 	require.NotPanics(t, func() {
 		sortKeys(map[model.LabelValue]avgp99{
 			"store_metric": [2][]diff{
-				{
-				},
+				{},
 				{
 					{
 						base:         time.Second,
@@ -59,8 +58,7 @@ func TestSortKeys(t *testing.T) {
 						deltaPercent: 100,
 					},
 				},
-				{
-				},
+				{},
 			},
 			"another_metric": [2][]diff{
 				{

--- a/loadtest/report/output_test.go
+++ b/loadtest/report/output_test.go
@@ -12,6 +12,78 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSortKeys(t *testing.T) {
+	require.NotPanics(t, func() {
+		sortKeys(map[model.LabelValue]avgp99{
+			"store_metric": [2][]diff{
+				{
+				},
+				{
+					{
+						base:         time.Second,
+						actual:       2 * time.Second,
+						delta:        1 * time.Second,
+						deltaPercent: 100,
+					},
+				},
+			},
+			"another_metric": [2][]diff{
+				{
+					{
+						base:         time.Millisecond,
+						actual:       2 * time.Millisecond,
+						delta:        1 * time.Millisecond,
+						deltaPercent: 100,
+					},
+				},
+				{
+					{
+						base:         time.Second,
+						actual:       2 * time.Second,
+						delta:        1 * time.Second,
+						deltaPercent: 100,
+					},
+				},
+			},
+		}, sortByAvg, true)
+	})
+
+	require.NotPanics(t, func() {
+		sortKeys(map[model.LabelValue]avgp99{
+			"store_metric": [2][]diff{
+				{
+					{
+						base:         time.Millisecond,
+						actual:       2 * time.Millisecond,
+						delta:        1 * time.Millisecond,
+						deltaPercent: 100,
+					},
+				},
+				{
+				},
+			},
+			"another_metric": [2][]diff{
+				{
+					{
+						base:         time.Millisecond,
+						actual:       2 * time.Millisecond,
+						delta:        1 * time.Millisecond,
+						deltaPercent: 100,
+					},
+				},
+				{
+					{
+						base:         time.Second,
+						actual:       2 * time.Second,
+						delta:        1 * time.Second,
+						deltaPercent: 100,
+					},
+				},
+			},
+		}, sortByP99, true)
+	})
+}
+
 func TestPrintSummary(t *testing.T) {
 	f, err := os.CreateTemp("", "output")
 	require.Nil(t, err)


### PR DESCRIPTION
Sometimes it can happen that a p99 value for a corresponding avg metric
is not there. We need to handle that case.

https://mattermost.atlassian.net/browse/MM-53644
