### PR TITLE
Basic fixes from the action frequencies analysis

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -18,7 +18,7 @@ User=ubuntu
 Group=ubuntu
 LimitNOFILE=49152
 Environment=MM_FEATUREFLAGS_POSTPRIORITY=true
-Environment=MM_FEATUREFLAGS_GRAPHQL=true
+Environment=MM_FEATUREFLAGS_GRAPHQL=false
 
 [Install]
 WantedBy=multi-user.target

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -76,6 +76,13 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 		}
 	}
 
+	// A full reload always calls GET /api/v4/users?page=0&per_page=100,
+	// regardless of GraphQL enabled or not
+	_, err := c.user.GetUsers(0, 100)
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
 	var resp control.UserActionResponse
 	if c.featureFlags.GraphQLEnabled {
 		resp = control.ReloadGQL(c.user)


### PR DESCRIPTION
#### Summary
Disabling GraphQL and adding the call to `/users` that the webapp performs on reload. This was used in the base test used to compare frequencies with the cloud customer. See https://community.mattermost.com/private-core/pl/1w83qxzgd7rijbqedmns9fprnc

#### Ticket Link
--