### PR TITLE
Store FF in MemStore

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -84,7 +84,7 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 	}
 
 	var resp control.UserActionResponse
-	if c.featureFlags.GraphQLEnabled {
+	if c.user.Store().FeatureFlags()["GraphQL"] {
 		resp = control.ReloadGQL(c.user)
 	} else {
 		resp = control.Reload(c.user)
@@ -103,7 +103,7 @@ func (c *SimulController) reload(full bool) control.UserActionResponse {
 		return c.switchTeam(c.user)
 	}
 
-	if resp := loadTeam(c.user, team, c.featureFlags.GraphQLEnabled); resp.Err != nil {
+	if resp := loadTeam(c.user, team, c.user.Store().FeatureFlags()["GraphQL"]); resp.Err != nil {
 		return resp
 	}
 
@@ -281,7 +281,7 @@ func (c *SimulController) switchTeam(u user.User) control.UserActionResponse {
 
 	c.status <- c.newInfoStatus(fmt.Sprintf("switched to team %s", team.Id))
 
-	if resp := loadTeam(u, &team, c.featureFlags.GraphQLEnabled); resp.Err != nil {
+	if resp := loadTeam(u, &team, c.user.Store().FeatureFlags()["GraphQL"]); resp.Err != nil {
 		return resp
 	}
 

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -219,11 +219,6 @@ type SimulController struct {
 	connectedFlag      int32           // indicates that the controller is connected
 	wg                 *sync.WaitGroup // to keep the track of every goroutine created by the controller
 	serverVersion      string          // stores the current server version
-	featureFlags       featureFlags    // stores the server's feature flags
-}
-
-type featureFlags struct {
-	GraphQLEnabled bool
 }
 
 // New creates and initializes a new SimulController with given parameters.
@@ -304,14 +299,10 @@ func (c *SimulController) Run() {
 		}
 	}
 
-	// Populate the server feature flags struct
-	clientCfg := c.user.Store().ClientConfig()
-	if len(clientCfg) == 0 {
+	// Make sure client config has been set.
+	if len(c.user.Store().ClientConfig()) == 0 {
 		c.sendFailStatus("the login init action should have populated the user config, but it is empty")
 		return
-	}
-	c.featureFlags = featureFlags{
-		GraphQLEnabled: c.user.Store().ClientConfig()["FeatureFlagGraphQL"] == "true",
 	}
 
 	var action *userAction

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -236,7 +236,7 @@ func (s *MemStore) SetClientConfig(config map[string]string) {
 	defer s.lock.Unlock()
 	s.clientConfig = config
 
-	// Popule FF
+	// Populate FF
 	ffPrefix := "FeatureFlag"
 	s.featureFlags = map[string]bool{}
 	for k, v := range s.clientConfig {

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -239,6 +239,8 @@ func (s *MemStore) SetClientConfig(config map[string]string) {
 	// Populate FF
 	s.featureFlags = map[string]bool{}
 	for k, v := range s.clientConfig {
+		// We avoid an extra call to strings.HasPrefix by checking the returned length.
+		// If the prefix matches then the returned string must be shorter.
 		if ffKey := strings.TrimPrefix(k, "FeatureFlag"); len(ffKey) < len(k) {
 			v, err := strconv.ParseBool(v)
 			if err != nil {

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +48,7 @@ type MemStore struct {
 	threads             map[string]*model.ThreadResponse
 	threadsQueue        *CQueue[model.ThreadResponse]
 	sidebarCategories   map[string]map[string]*model.SidebarCategoryWithChannels
+	featureFlags        map[string]bool
 }
 
 // New returns a new instance of MemStore with the given config.
@@ -199,11 +202,18 @@ func (s *MemStore) Password() string {
 	return s.user.Password
 }
 
-// ClientConfig  returns the limited server configuration settings for user.
+// ClientConfig returns the limited server configuration settings for user.
 func (s *MemStore) ClientConfig() map[string]string {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.clientConfig
+}
+
+// FeatureFlags returns a map of the features flags stored in the client config.
+func (s *MemStore) FeatureFlags() map[string]bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.featureFlags
 }
 
 // Config returns the server configuration settings.
@@ -225,6 +235,19 @@ func (s *MemStore) SetClientConfig(config map[string]string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.clientConfig = config
+
+	// Popule FF
+	ffPrefix := "FeatureFlag"
+	s.featureFlags = map[string]bool{}
+	for k, v := range s.clientConfig {
+		if strings.HasPrefix(k, ffPrefix) {
+			v, err := strconv.ParseBool(v)
+			if err != nil {
+				continue
+			}
+			s.featureFlags[strings.TrimPrefix(k, ffPrefix)] = v
+		}
+	}
 }
 
 // User returns the stored user.

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -237,15 +237,14 @@ func (s *MemStore) SetClientConfig(config map[string]string) {
 	s.clientConfig = config
 
 	// Populate FF
-	ffPrefix := "FeatureFlag"
 	s.featureFlags = map[string]bool{}
 	for k, v := range s.clientConfig {
-		if strings.HasPrefix(k, ffPrefix) {
+		if ffKey := strings.TrimPrefix(k, "FeatureFlag"); len(ffKey) < len(k) {
 			v, err := strconv.ParseBool(v)
 			if err != nil {
 				continue
 			}
-			s.featureFlags[strings.TrimPrefix(k, ffPrefix)] = v
+			s.featureFlags[ffKey] = v
 		}
 	}
 }

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -39,6 +39,8 @@ type UserStore interface {
 	Config() model.Config
 	// ClientConfig returns the partial server configuration settings for logged in user.
 	ClientConfig() map[string]string
+	// FeatureFlags returns a map of the features flags stored in the client config.
+	FeatureFlags() map[string]bool
 	// Channel returns the channel for the given channelId.
 	Channel(channelId string) (*model.Channel, error)
 	// Channels returns the channels for a team.


### PR DESCRIPTION
#### Summary

Unrelated to the current effort but while working on https://mattermost.atlassian.net/browse/MM-53825 I noticed we were storing FF in the controller which seems a bit odd. I moved that to the `MemStore` and added some basic parsing so that all existing boolean flags should get loaded automatically. Ideally we'd rely on `model.FeatureFlags` but the way flags are returned through the client config makes it hard without resorting to hardcodes  or `reflect` usage.
