### PR TITLE
[MM-53823] Review getUsers call

### DIFF
--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -533,7 +533,7 @@ func CreatePrivateChannel(u user.User) UserActionResponse {
 	channelId, err := u.CreateChannel(&model.Channel{
 		Name:   model.NewId(),
 		TeamId: team.Id,
-		Type:   "P",
+		Type:   model.ChannelTypePrivate,
 	})
 
 	if err != nil {

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -734,7 +734,7 @@ func Reload(u user.User) UserActionResponse {
 		case p.Category == model.PreferenceCategoryDirectChannelShow:
 			userIds = append(userIds, p.Name)
 		case p.Category == model.PreferenceCategoryGroupChannelShow:
-			if err := u.GetUsersInChannel(p.Name, 0, 8); err != nil {
+			if _, err := u.GetUsersInChannel(p.Name, 0, 8); err != nil {
 				return UserActionResponse{Err: NewUserError(err)}
 			}
 		}
@@ -906,7 +906,7 @@ func ReloadGQL(u user.User) UserActionResponse {
 		case p.Category == model.PreferenceCategoryDirectChannelShow:
 			userIds = append(userIds, p.Name)
 		case p.Category == "group_channel_show":
-			if err := u.GetUsersInChannel(p.Name, 0, 8); err != nil {
+			if _, err := u.GetUsersInChannel(p.Name, 0, 8); err != nil {
 				return UserActionResponse{Err: NewUserError(err)}
 			}
 		}

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -733,7 +733,7 @@ func Reload(u user.User) UserActionResponse {
 		switch {
 		case p.Category == model.PreferenceCategoryDirectChannelShow:
 			userIds = append(userIds, p.Name)
-		case p.Category == "group_channel_show":
+		case p.Category == model.PreferenceCategoryGroupChannelShow:
 			if err := u.GetUsersInChannel(p.Name, 0, 8); err != nil {
 				return UserActionResponse{Err: NewUserError(err)}
 			}

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1237,18 +1237,39 @@ func searchGroupChannels(u user.User) control.UserActionResponse {
 }
 
 func openAddMembersDialog(u user.User, teamId, channelId string) ([]string, control.UserActionResponse) {
-	// This is a series of calls made by the webapp client
-	// when opening the `Add Members` dialog.
-	if err := u.GetUsersInChannel(channelId, 0, 50); err != nil {
+	if err := u.GetTeamStats(teamId); err != nil {
 		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	ids, err := u.GetUsersNotInChannel(teamId, channelId, 0, 100)
+	inChannelIds, err := u.GetUsersInChannel(channelId, 0, 50)
 	if err != nil {
 		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	return ids, control.UserActionResponse{}
+	notInChannelIds, err := u.GetUsersNotInChannel(teamId, channelId, 0, 100)
+	if err != nil {
+		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	if err := u.GetUsersStatusesByIds(inChannelIds); err != nil {
+		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	if err := u.GetUsersStatusesByIds(notInChannelIds); err != nil {
+		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	// NOTE: the call to ViewChannel is really a side effect and not properly part of this action.
+	// Its trigger is the handleBlur() function in the team controller.
+	collapsedThreads, resp := control.CollapsedThreadsEnabled(u)
+	if resp.Err != nil {
+		return nil, resp
+	}
+	if _, err := u.ViewChannel(&model.ChannelView{ChannelId: channelId, CollapsedThreadsSupported: collapsedThreads}); err != nil {
+		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	return notInChannelIds, control.UserActionResponse{}
 }
 
 func createPublicChannel(u user.User) control.UserActionResponse {
@@ -1272,7 +1293,7 @@ func createPublicChannel(u user.User) control.UserActionResponse {
 		return resp
 	}
 
-	// TODO: figure out if it makes sense to add users the the newly created
+	// TODO: figure out if it makes sense to add users to the newly created
 	// channel following some heuristics.
 
 	return control.UserActionResponse{Info: fmt.Sprintf("public channel created, id %v", channelId)}

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -201,6 +201,10 @@ func (c *SimulController) joinTeam(u user.User) control.UserActionResponse {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
+	if _, err := c.user.GetUsers(0, 100); err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
 	team, err := u.Store().RandomTeam(store.SelectNotMemberOf)
 	if errors.Is(err, memstore.ErrTeamStoreEmpty) {
 		c.status <- c.newInfoStatus("no team to join")
@@ -473,7 +477,7 @@ func viewChannel(u user.User, channel *model.Channel) control.UserActionResponse
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
 		category := map[model.ChannelType]string{
 			model.ChannelTypeDirect: model.PreferenceCategoryDirectChannelShow,
-			model.ChannelTypeGroup:  "group_channel_show",
+			model.ChannelTypeGroup:  model.PreferenceCategoryGroupChannelShow,
 		}
 
 		// We need to update the user's preferences so that
@@ -1132,7 +1136,7 @@ func searchPosts(u user.User) control.UserActionResponse {
 			if len(users) == 1 {
 				return control.UserActionResponse{Err: errors.New("found")}
 			}
-			return control.UserActionResponse{}
+			return control.UserActionResponse{Info: "emulated user typing users"}
 		})
 	}
 
@@ -1150,7 +1154,7 @@ func searchPosts(u user.User) control.UserActionResponse {
 			if len(channels) == 1 {
 				return control.UserActionResponse{Err: errors.New("found")}
 			}
-			return control.UserActionResponse{}
+			return control.UserActionResponse{Info: "emulated user typing channels"}
 		})
 	}
 
@@ -1232,6 +1236,48 @@ func searchGroupChannels(u user.User) control.UserActionResponse {
 	})
 }
 
+func openAddMembersDialog(u user.User, teamId, channelId string) ([]string, control.UserActionResponse) {
+	// This is a series of calls made by the webapp client
+	// when opening the `Add Members` dialog.
+	if err := u.GetUsersInChannel(channelId, 0, 50); err != nil {
+		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	ids, err := u.GetUsersNotInChannel(teamId, channelId, 0, 100)
+	if err != nil {
+		return nil, control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	return ids, control.UserActionResponse{}
+}
+
+func createPublicChannel(u user.User) control.UserActionResponse {
+	team, err := u.Store().RandomTeam(store.SelectMemberOf)
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	channelName := model.NewId()
+	channelId, err := u.CreateChannel(&model.Channel{
+		Name:        channelName,
+		DisplayName: "Channel " + channelName,
+		TeamId:      team.Id,
+		Type:        model.ChannelTypeOpen,
+	})
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	if _, resp := openAddMembersDialog(u, team.Id, channelId); resp.Err != nil {
+		return resp
+	}
+
+	// TODO: figure out if it makes sense to add users the the newly created
+	// channel following some heuristics.
+
+	return control.UserActionResponse{Info: fmt.Sprintf("public channel created, id %v", channelId)}
+}
+
 func createPrivateChannel(u user.User) control.UserActionResponse {
 	team, err := u.Store().RandomTeam(store.SelectMemberOf)
 	if err != nil {
@@ -1243,25 +1289,15 @@ func createPrivateChannel(u user.User) control.UserActionResponse {
 		Name:        channelName,
 		DisplayName: "Channel " + channelName,
 		TeamId:      team.Id,
-		Type:        "P",
+		Type:        model.ChannelTypePrivate,
 	})
 	if err != nil {
 		return control.UserActionResponse{Err: control.NewUserError(err)}
 	}
 
-	// This is a series of calls made by the webapp client
-	// when opening the `Add Members` dialog.
-	if err := u.GetUsersInChannel(channelId, 0, 100); err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	if err := u.GetChannelMembers(channelId, 0, 50); err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	}
-
-	ids, err := u.GetUsersNotInChannel(team.Id, channelId, 0, 100)
-	if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
+	ids, resp := openAddMembersDialog(u, team.Id, channelId)
+	if resp.Err != nil {
+		return resp
 	}
 
 	// we pick up to 4 users to add to the channel.

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -139,7 +139,7 @@ func getActionList(c *SimulController) []userAction {
 		},
 		{
 			name:      "CreatePublicChannel",
-			run:       control.CreatePublicChannel,
+			run:       createPublicChannel,
 			frequency: 0.0001,
 		},
 		{
@@ -314,7 +314,7 @@ func (c *SimulController) Run() {
 		if resp := initActions[i].run(c.user); resp.Err != nil {
 			c.status <- c.newErrorStatus(resp.Err)
 			i--
-		} else {
+		} else if resp.Info != "" {
 			c.status <- c.newInfoStatus(resp.Info)
 		}
 	}
@@ -371,7 +371,7 @@ func (c *SimulController) runAction(action *userAction) {
 
 	if resp := action.run(c.user); resp.Err != nil {
 		c.status <- c.newErrorStatus(resp.Err)
-	} else {
+	} else if resp.Info != "" {
 		c.status <- c.newInfoStatus(resp.Info)
 	}
 }

--- a/loadtest/control/simulcontroller/websocket.go
+++ b/loadtest/control/simulcontroller/websocket.go
@@ -36,17 +36,12 @@ func (c *SimulController) wsEventHandler(wg *sync.WaitGroup) {
 				break
 			}
 
-			ch, _ := c.user.Store().Channel(post.ChannelId)
-			if ch != nil {
+			cm, _ := c.user.Store().ChannelMember(post.ChannelId, c.user.Store().Id())
+			if cm.UserId != "" {
 				break
 			}
 
-			c.status <- c.newInfoStatus(fmt.Sprintf("channel for post missing from store, fetching: %q", post.ChannelId))
-
-			if err := c.user.GetChannel(post.ChannelId); err != nil {
-				c.status <- c.newErrorStatus(fmt.Errorf("GetChannel failed: %w", err))
-				break
-			}
+			c.status <- c.newInfoStatus(fmt.Sprintf("channel member for post's channel missing from store, fetching: %q", post.ChannelId))
 
 			if err := c.user.GetChannelMember(post.ChannelId, c.user.Store().Id()); err != nil {
 				c.status <- c.newErrorStatus(fmt.Errorf("GetChannelMember failed: %w", err))

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -86,7 +86,8 @@ type User interface {
 	// GetUsersStatusesByIds fetches and stores statuses for the specified users.
 	GetUsersStatusesByIds(userIds []string) error
 	// GetUsersInChannel fetches and stores users in the specified channel.
-	GetUsersInChannel(channelId string, page, perPage int) error
+	// Returns a list of ids of the users.
+	GetUsersInChannel(channelId string, page, perPage int) ([]string, error)
 	// GetUsers fetches and stores all users. It returns a list of those users' ids.
 	GetUsers(page, perPage int) ([]string, error)
 	// GetUsersNotInChannel returns a list of user ids not in a given channel.

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -776,18 +776,24 @@ func (ue *UserEntity) GetUsersStatusesByIds(userIds []string) error {
 	return nil
 }
 
-// GetUsersInChannel fetches and stores users in the specified channel.
-func (ue *UserEntity) GetUsersInChannel(channelId string, page, perPage int) error {
+// GetUsersInChannel fetches and stores users in the specified channel. Returns
+// a list of ids of the users.
+func (ue *UserEntity) GetUsersInChannel(channelId string, page, perPage int) ([]string, error) {
 	if len(channelId) == 0 {
-		return errors.New("userentity: channelId should not be empty")
+		return nil, errors.New("userentity: channelId should not be empty")
 	}
 
 	users, _, err := ue.client.GetUsersInChannel(context.Background(), channelId, page, perPage, "")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return ue.store.SetUsers(users)
+	userIds := make([]string, len(users))
+	for i := range users {
+		userIds[i] = users[i].Id
+	}
+
+	return userIds, ue.store.SetUsers(users)
 }
 
 // GetUsers fetches and stores all users. It returns a list of those users' ids.


### PR DESCRIPTION
#### Summary

PR reviews some of the use of the `getUsers` call. This is a particularly complex endpoint given that it maps to several client calls depending on the query string passed to it. Some examples:

- `getProfiles`
- `getProfilesInTeam`
- `getProfilesNotInTeam`
- `getProfilesWithoutTeam`
- `getProfilesInChannel`
- `getProfilesInGroupChannels`
- `getProfilesNotInChannel`
- `getProfilesInGroup`
- `getProfilesNotInGroup`

Moreover, there are certain actions that we don't currently have coverage for that would cause additional calls. Some notes I collected so far from this investigation:

- Bumping the reload action frequency will also increase this one so it may get us closer to our target rate "for free".
- Adding users to channels.
  - We do a bit of this when creating channels but we don't really have an action to add users to channel, such in the case we at mention someone that's not in a channel. Also it may be too rare to be reflected in the short window.
- There seems to be a [react hook bug](https://github.com/mattermost/mattermost-load-test-ng/assets/1832946/a9a2fc1f-1d60-4e6a-91e9-966a36a4a765) occasionally causing fetching an additional empty page from the endpoint. 
  - Not sure what to do with this as it's not consistent and clearly bogus.
- Remounting the center channel view causes this call (and a few others) to be made. 
  - This could happen when switching between products (e.g. opening the playbooks page) or even by admins switching to the system console.
- Several system admin functionalities call `getUsers`.
  - We'd need to consider whether these happen often enough to justify adding some basic coverage for this. 
- Opening list of channel members. 
  - Again not sure if we have any telemetry on this but it would cause additional calls as well.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53823
