### PR TITLE
[MM-53348] Use proxy instance IP to substitute permalinks IPs

### DIFF
--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -208,7 +208,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		Clients: []*ssh.Client{appClients[0]},
 	}
 
-	dbCmds, err := deployment.BuildLoadDBDumpCmds(dumpFilename, tfOutput.Instances[0].PublicIP, permalinkIPsToReplace, deployment.DBSettings{
+	dbCmds, err := deployment.BuildLoadDBDumpCmds(dumpFilename, tfOutput.PermalinksIPsSubstCommand(permalinkIPsToReplace), deployment.DBSettings{
 		UserName: dpConfig.TerraformDBSettings.UserName,
 		Password: dpConfig.TerraformDBSettings.Password,
 		DBName:   dbName,

--- a/comparison/loadtest_test.go
+++ b/comparison/loadtest_test.go
@@ -14,7 +14,7 @@ func TestBuildLoadDBDumpCmd(t *testing.T) {
 		newIP := "192.168.1.1"
 		oldIPs := []string{}
 
-		cmds, err := deployment.BuildLoadDBDumpCmds("dbfilename", newIP, oldIPs, deployment.DBSettings{
+		cmds, err := deployment.BuildLoadDBDumpCmds("dbfilename", deployment.GenCmdForPermalinksIPsSubstitution(newIP, oldIPs, false), deployment.DBSettings{
 			UserName: "mmuser",
 			Password: "mostest",
 			DBName:   "mattermost",
@@ -33,7 +33,7 @@ func TestBuildLoadDBDumpCmd(t *testing.T) {
 		newIP := "192.168.1.1"
 		oldIPs := []string{"54.78.456.5", "56.78.98.1"}
 
-		cmds, err := deployment.BuildLoadDBDumpCmds("dbfilename", newIP, oldIPs, deployment.DBSettings{
+		cmds, err := deployment.BuildLoadDBDumpCmds("dbfilename", deployment.GenCmdForPermalinksIPsSubstitution(newIP, oldIPs, false), deployment.DBSettings{
 			UserName: "mmuser",
 			Password: "mostest",
 			DBName:   "mattermost",

--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -69,7 +69,7 @@ func (t *Terraform) IngestDump() error {
 		Clients: []*ssh.Client{appClients[0]},
 	}
 
-	dbCmds, err := deployment.BuildLoadDBDumpCmds(fileName, output.Instances[0].PublicIP, t.config.PermalinkIPsToReplace, deployment.DBSettings{
+	dbCmds, err := deployment.BuildLoadDBDumpCmds(fileName, output.PermalinksIPsSubstCommand(t.config.PermalinkIPsToReplace), deployment.DBSettings{
 		UserName: t.config.TerraformDBSettings.UserName,
 		Password: t.config.TerraformDBSettings.Password,
 		DBName:   t.config.DBName(),

--- a/deployment/terraform/output.go
+++ b/deployment/terraform/output.go
@@ -7,6 +7,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
 type output struct {
@@ -225,4 +229,22 @@ func (o *Output) DBWriter() string {
 		}
 	}
 	return wr
+}
+
+// PermalinksIPsSubstCommand returns the substitution command to replace
+// permalinks in the DB dump for the current deployment.
+func (o *Output) PermalinksIPsSubstCommand(permalinkIPsToReplace []string) string {
+	if len(permalinkIPsToReplace) == 0 {
+		return ""
+	}
+
+	if o.HasProxy() {
+		return deployment.GenCmdForPermalinksIPsSubstitution(o.Proxy.PublicIP, permalinkIPsToReplace, true)
+	}
+
+	if len(o.Instances) > 0 {
+		mlog.Warn("detected multiple app instances with no proxy, using only first instance's IP for permalink substitution")
+	}
+
+	return deployment.GenCmdForPermalinksIPsSubstitution(o.Instances[0].PublicIP, permalinkIPsToReplace, false)
 }

--- a/deployment/utils_test.go
+++ b/deployment/utils_test.go
@@ -1,0 +1,124 @@
+package deployment
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenCmdForPermalinksIPsSubstitution(t *testing.T) {
+	tcs := []struct {
+		name                  string
+		newIP                 string
+		permalinkIPsToReplace []string
+		replacePort           bool
+		input                 string
+		output                string
+	}{
+		{
+			name:   "empty permalinkIPsToReplace",
+			newIP:  "127.0.0.1",
+			input:  ``,
+			output: ``,
+		},
+		{
+			name:                  "empty newIP",
+			permalinkIPsToReplace: []string{"10.1.1.1"},
+			input:                 ``,
+			output:                ``,
+		},
+		{
+			name:                  "single IP",
+			newIP:                 "127.0.0.1",
+			permalinkIPsToReplace: []string{"10.1.1.1"},
+			input: `
+https://10.1.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/xx/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+			`,
+			output: `
+https://127.0.0.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/xx/5njz9f9y6jfhxe1o7ec76mjjow
+https://127.0.0.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://127.0.0.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+			`,
+		},
+		{
+			name:                  "multiple IPs",
+			newIP:                 "127.0.0.1",
+			permalinkIPsToReplace: []string{"10.1.1.1", "10.1.1.2"},
+			input: `
+https://10.1.1.2:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/xx/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.2/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+			`,
+			output: `
+https://127.0.0.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/xx/5njz9f9y6jfhxe1o7ec76mjjow
+https://127.0.0.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://127.0.0.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.2/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+			`,
+		},
+		{
+			name:                  "with port replacement",
+			newIP:                 "127.0.0.1",
+			permalinkIPsToReplace: []string{"10.1.1.1", "10.1.1.2"},
+			input: `
+https://10.1.1.2:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/xx/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.2:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+			`,
+			output: `
+https://127.0.0.1/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.1:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.1.1.1:8065/private-core/xx/5njz9f9y6jfhxe1o7ec76mjjow
+https://127.0.0.1/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://127.0.0.1/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://10.0.1.2:8065/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+https://127.0.0.1/private-core/pl/5njz9f9y6jfhxe1o7ec76mjjow
+			`,
+			replacePort: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			outputBuf := bytes.NewBuffer(nil)
+			errorBuf := bytes.NewBuffer(nil)
+
+			cmdStr := GenCmdForPermalinksIPsSubstitution(tc.newIP, tc.permalinkIPsToReplace, tc.replacePort)
+			if cmdStr != "" {
+				cmd := exec.Command("bash", "-c", cmdStr)
+				cmd.Stdin = bytes.NewBufferString(tc.input)
+				cmd.Stdout = outputBuf
+				cmd.Stderr = errorBuf
+
+				err := cmd.Run()
+				require.Empty(t, errorBuf.String())
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.output, outputBuf.String())
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

PR partially addresses the issue of permalinks IPs substitution not being properly load balanced. If the target deployment has a proxy we use its IP to do the substitution.

We are left with the case of multiple app servers without a proxy which I am not sure if it's worth investing more time on it. The implementation would be much more complex, likely requiring a bash script or small Go program to make it work since we'd have to pick IPs dynamically when doing the substitution.

I added a warning if we hit this case but happy to hear your thoughts on the above.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53348
