### PR TITLE
MM-54251: Let the user hardcode the name of the database

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -115,6 +115,10 @@ type TerraformDBSettings struct {
 	DBParameters DBParameters
 	// ClusterIdentifier indicates to point to an existing cluster
 	ClusterIdentifier string `default:""`
+	// DBName specifies the name of the database.
+	// If ClusterIdentifier is not empty, DBName should be set to the name of the database in such cluster.
+	// If ClusterIdentifier is empty, the database created will use DBName as its name.
+	DBName string `default:""`
 }
 
 // ExternalDBSettings contains the necessary data
@@ -214,6 +218,9 @@ func (c *Config) IsValid() error {
 
 // DBName returns the database name for the deployment.
 func (c *Config) DBName() string {
+	if c.TerraformDBSettings.DBName != "" {
+		return c.TerraformDBSettings.DBName
+	}
 	return c.ClusterName + "db"
 }
 

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -213,6 +213,11 @@ func (c *Config) IsValid() error {
 	if err := c.validateElasticSearchConfig(); err != nil {
 		return err
 	}
+
+	if err := c.validateDBName(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -247,6 +252,18 @@ func (c *Config) validateElasticSearchConfig() error {
 				"(hyphen). Current value is \"" + domainName + "\"")
 		}
 
+	}
+
+	return nil
+}
+
+func (c *Config) validateDBName() error {
+	if c.TerraformDBSettings.ClusterIdentifier == "" {
+		return nil
+	}
+
+	if c.TerraformDBSettings.DBName == "" {
+		return fmt.Errorf("TerraformDBSettings.ClusterIdentifier is specified but TerraformDBSettings.DBName is empty: TerraformDBSettings.DBName should be set to the name of the database contained in the cluster specified by TerraformDBSettings.ClusterIdentifier")
 	}
 
 	return nil

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -1,0 +1,50 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigIsValid(t *testing.T) {
+	baseConfig := func() Config {
+		return Config{
+			MattermostDownloadURL: "https://latest.mattermost.com/mattermost-enterprise-linux",
+			LoadTestDownloadURL:   "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.9.1/mattermost-load-test-ng-v1.9.1-linux-amd64.tar.gz",
+		}
+	}
+
+	t.Run("DBName is valid", func(t *testing.T) {
+		t.Run("empty ClusterIdentifier and empty DBName is valid", func(t *testing.T) {
+			c := baseConfig()
+			c.TerraformDBSettings.ClusterIdentifier = ""
+			c.TerraformDBSettings.DBName = ""
+
+			require.NoError(t, c.IsValid())
+		})
+
+		t.Run("empty ClusterIdentifier and non-empty DBName is valid", func(t *testing.T) {
+			c := baseConfig()
+			c.TerraformDBSettings.ClusterIdentifier = ""
+			c.TerraformDBSettings.DBName = "db"
+
+			require.NoError(t, c.IsValid())
+		})
+
+		t.Run("non-empty ClusterIdentifier and empty DBName is not valid", func(t *testing.T) {
+			c := baseConfig()
+			c.TerraformDBSettings.ClusterIdentifier = "cluster"
+			c.TerraformDBSettings.DBName = ""
+
+			require.Error(t, c.IsValid())
+		})
+
+		t.Run("non-empty ClusterIdentifier and non-empty DBName is valid", func(t *testing.T) {
+			c := baseConfig()
+			c.TerraformDBSettings.ClusterIdentifier = "cluster"
+			c.TerraformDBSettings.DBName = "db"
+
+			require.NoError(t, c.IsValid())
+		})
+	})
+}

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -184,6 +184,14 @@ If set to true enables performance insights for the created DB instances.
 
 The name of the existing cluster to attach to. If this is set, then the `DBDumpURI` does not have any effect. This string should be a restored AWS Aurora backup cluster.
 
+### DBName
+
+*string*
+
+The name of the database. This is meant to be used in conjunction with `ClusterIdentifier`, and its value should be the name of the database in such cluster.
+
+However, it can be used by itself to hardcode the name of the database that will otherwise be created. If `DBName` is not specified, and a brand new database is created for the deployment, its name will equal `${ClusterName}db`.
+
 ### DBParameters
 
 *[]DBParameter*


### PR DESCRIPTION
#### Summary
When using an existing DB cluster via `ClusterIdentifier`, a database is already present, and its name will be different from the one assumed in the code. The first error encountered because of this happened when trying to alter the database to set the default text search config to `english` instead of `simple` (see the ticket), but we can expect more problems of this broken assumption.

To solve this problem, I've added a new `DBName` parameter that the user can set to hardcode the name of the DB:
- If `ClusterIdentifier` is set, it should be the name of the database in such cluster
- If `ClusterIdentifier` is not set, its value can be whatever, and when the new database is created, instead of calling it `${ClusterName}db`, it'll be simply called `${DBName}`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54251
