### PR TITLE
[MM-54315] Allow overriding user prefix on automated deployments

### DIFF
--- a/cmd/ltagent/loadtest.go
+++ b/cmd/ltagent/loadtest.go
@@ -47,6 +47,15 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	userPrefix, err := cmd.Flags().GetString("user-prefix")
+	if err != nil {
+		return err
+	}
+
+	if config.UsersConfiguration.UserPrefix == "" || userPrefix != loadtest.UserPrefixDefault {
+		config.UsersConfiguration.UserPrefix = userPrefix
+	}
+
 	if err := defaults.Validate(*config); err != nil {
 		return fmt.Errorf("could not validate configuration: %w", err)
 	}
@@ -77,11 +86,6 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read controller configuration: %w", err)
 	}
 
-	userPrefix, err := cmd.Flags().GetString("user-prefix")
-	if err != nil {
-		return err
-	}
-
 	userOffset, err := cmd.Flags().GetInt("user-offset")
 	if err != nil {
 		return err
@@ -108,7 +112,7 @@ func RunLoadTestCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	newC, err := api.NewControllerWrapper(config, ucConfig, userOffset, userPrefix, nil)
+	newC, err := api.NewControllerWrapper(config, ucConfig, userOffset, nil)
 	if err != nil {
 		return fmt.Errorf("error while creating new controller: %w", err)
 	}

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -49,7 +49,8 @@
     "InitialActiveUsers": 0,
     "UsersFilePath": "",
     "MaxActiveUsers": 2000,
-    "AvgSessionsPerUser": 1
+    "AvgSessionsPerUser": 1,
+    "UserPrefix": "testuser"
   },
   "LogSettings": {
     "EnableConsole": true,

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -27,6 +27,7 @@
   "S3BucketDumpURI" : "",
   "DBDumpURI": "",
   "SiteURL": "",
+  "UserPrefix": "",
   "TerraformDBSettings": {
     "InstanceCount": 1,
     "InstanceEngine": "aurora-postgresql",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -91,6 +91,9 @@ type Config struct {
 	//   - Override the SiteUrl
 	//   - Point to the proxy IP via a new entry in the server's /etc/hosts file
 	SiteURL string `default:"ltserver"`
+	// An optional prefix that overrides the generated username prefix used to
+	// register and authenticate users.
+	UserPrefix string `default:""`
 }
 
 // TerraformDBSettings contains the necessary data

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -29,6 +29,7 @@ func (t *Terraform) generateLoadtestAgentConfig() (*loadtest.Config, error) {
 	cfg.ConnectionConfiguration.WebSocketURL = "ws://" + url
 	cfg.ConnectionConfiguration.AdminEmail = t.config.AdminEmail
 	cfg.ConnectionConfiguration.AdminPassword = t.config.AdminPassword
+	cfg.UsersConfiguration.UserPrefix = t.config.UserPrefix
 
 	return cfg, nil
 }

--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -122,6 +122,12 @@ The path to the file which contains a list of user email and passwords that will
 
 The maximum amount of concurrently active users the load-test agent will run.
 
+### UserPrefix
+
+*string*
+
+The user prefix to use to register and authenticate users.
+
 ## LogSettings
 
 ### EnableConsole

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -446,3 +446,9 @@ The name of a host that will be used for two purposes:
 - It will override the server's site URL.
 - It will populate a new entry in the /etc/hosts file of the app nodes, so that it points to the proxy private IP or, if there's no proxy, to the current app node.
 This config is used for tests that require an existing database dump that contains permalinks. These permalinks point to a specific hostname. Without this setting, that hostname is not known by the nodes of a new deployment and the permalinks cannot be resolved.
+
+## UserPrefix
+
+*string*
+
+An optional prefix that overrides the generated username prefix used to register and authenticate users.

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -135,7 +135,11 @@ type UsersConfiguration struct {
 	MaxActiveUsers int `default:"2000" validate:"range:(0,]"`
 	// The average number of sessions per user.
 	AvgSessionsPerUser int `default:"1" validate:"range:[1,]"`
+	// The user prefix to use to register and authenticate users.
+	UserPrefix string `default:"testuser" validate:"notempty"`
 }
+
+const UserPrefixDefault = "testuser"
 
 // Config holds information needed to create and initialize a new load-test
 // agent.

--- a/loadtest/loadtest_test.go
+++ b/loadtest/loadtest_test.go
@@ -31,6 +31,7 @@ var ltConfig = Config{
 		MaxActiveUsers:     8,
 		InitialActiveUsers: 0,
 		AvgSessionsPerUser: 1,
+		UserPrefix:         UserPrefixDefault,
 	},
 	InstanceConfiguration: InstanceConfiguration{
 		NumTeams:                    1,


### PR DESCRIPTION
#### Summary

PR introduces a new `UserPrefix` setting to allow overriding the generated username prefix used on automated deployments. If none is provided (empty string), we keep generating it based on the agent's id.

This shouldn't change the existing semantic for the manual use case where we still default to `testuser` and can always override through the `--user-prefix` command line flag.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54315
