### PR TITLE
MM-54315: Expand UsersFilePath usage

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -91,6 +91,10 @@ type Config struct {
 	//   - Override the SiteUrl
 	//   - Point to the proxy IP via a new entry in the server's /etc/hosts file
 	SiteURL string `default:"ltserver"`
+	// UsersFilePath specifies the path to an optional file containing a list of credentials for the controllers
+	// to use. If present, it is used to automatically upload it to the agents and override the agent's config's
+	// own UsersFilePath.
+	UsersFilePath string `default:""`
 }
 
 // TerraformDBSettings contains the necessary data


### PR DESCRIPTION
#### Summary
This PR tries to fix the problem of the deployments not using the set of users present in the database dump. Instead of trying to change the user prefix so we can adapt it to the users from the dump, we leverage the already existing `UsersFilePath` setting in `config/config.json`, and expand its usage by:
- Adding a new `UsersFilePath` setting to `config/deployer.json` so that it overrides the data in the deployed agents.
- Splitting the contents of such file into $n$ chunks, where $n$ is the number of agents, and uploading a different chunk to each agent.
- Removing the limitation for mixing user credentials defined in `UsersFilePath` with automatic sign-ups of new users, so that the agent simply switches to automatic sign-ups when there are no more credentials to be consumed from the file, creating new users when needed.

This is an alternative to #646, so we should merge only one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54315
