### PR TITLE
MM-54314: Return the error correctly from config parse failure

### DIFF
--- a/defaults/json.go
+++ b/defaults/json.go
@@ -10,6 +10,10 @@ import (
 // This function will try to read from given path, if it is empty will try
 // fallback path. If it fails on fallback, it will set value to it's defaults
 func ReadFromJSON(path, fallbackPath string, value interface{}) error {
+	if err := Set(value); err != nil {
+		return err
+	}
+
 	if path != "" {
 		if err := readJSON(path, &value); err != nil {
 			return fmt.Errorf("failed to read from path %s: %w", path, err)
@@ -17,9 +21,6 @@ func ReadFromJSON(path, fallbackPath string, value interface{}) error {
 		return nil
 	}
 
-	if err := Set(value); err != nil {
-		return err
-	}
 
 	// If the fallback path doesn't exist, return.
 	if _, err := os.Stat(fallbackPath); err != nil && os.IsNotExist(err) {

--- a/defaults/json.go
+++ b/defaults/json.go
@@ -12,13 +12,13 @@ import (
 func ReadFromJSON(path, fallbackPath string, value interface{}) error {
 	if path != "" {
 		if err := readJSON(path, &value); err != nil {
-			return err
+			return fmt.Errorf("failed to read from path %s: %w", path, err)
 		}
 		return nil
 	}
 
-	if err := readJSON(fallbackPath, value); err == nil {
-		return nil
+	if err := readJSON(fallbackPath, value); err != nil {
+		return fmt.Errorf("failed to read from path %s: %w", fallbackPath, err)
 	}
 
 	if err := Set(value); err != nil {

--- a/defaults/json.go
+++ b/defaults/json.go
@@ -21,6 +21,11 @@ func ReadFromJSON(path, fallbackPath string, value interface{}) error {
 		return err
 	}
 
+	// If the fallback path doesn't exist, return.
+	if _, err := os.Stat(fallbackPath); err != nil && os.IsNotExist(err) {
+		return nil
+	}
+
 	if err := readJSON(fallbackPath, value); err != nil {
 		return fmt.Errorf("failed to read from path %s: %w", fallbackPath, err)
 	}

--- a/defaults/json.go
+++ b/defaults/json.go
@@ -27,7 +27,7 @@ func ReadFromJSON(path, fallbackPath string, value interface{}) error {
 	}
 
 	if err := readJSON(fallbackPath, value); err != nil {
-		return fmt.Errorf("failed to read from path %s: %w", fallbackPath, err)
+		return fmt.Errorf("failed to read from fallback path %s: %w", fallbackPath, err)
 	}
 
 	return nil

--- a/defaults/json.go
+++ b/defaults/json.go
@@ -17,12 +17,12 @@ func ReadFromJSON(path, fallbackPath string, value interface{}) error {
 		return nil
 	}
 
-	if err := readJSON(fallbackPath, value); err != nil {
-		return fmt.Errorf("failed to read from path %s: %w", fallbackPath, err)
-	}
-
 	if err := Set(value); err != nil {
 		return err
+	}
+
+	if err := readJSON(fallbackPath, value); err != nil {
+		return fmt.Errorf("failed to read from path %s: %w", fallbackPath, err)
 	}
 
 	return nil

--- a/defaults/json.go
+++ b/defaults/json.go
@@ -21,7 +21,6 @@ func ReadFromJSON(path, fallbackPath string, value interface{}) error {
 		return nil
 	}
 
-
 	// If the fallback path doesn't exist, return.
 	if _, err := os.Stat(fallbackPath); err != nil && os.IsNotExist(err) {
 		return nil

--- a/defaults/json_test.go
+++ b/defaults/json_test.go
@@ -1,0 +1,27 @@
+package defaults
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testCFG struct {
+	Setting string
+	Another int
+}
+
+func TestReadFromJSON(t *testing.T) {
+	var cfg testCFG
+	f, err := os.CreateTemp("", "loadtest")
+	require.NoError(t, err)
+	defer os.Remove(f.Name()) // clean up
+
+	// Ensuring that a bad config throws an error
+	_, err = f.Write([]byte(`{"setting": "hello" "another": 1}`))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.Error(t, ReadFromJSON("", f.Name(), &cfg))
+}

--- a/defaults/json_test.go
+++ b/defaults/json_test.go
@@ -10,7 +10,7 @@ import (
 
 type testCFG struct {
 	Setting string `default:"hi"`
-	Another int `default:"1"`
+	Another int    `default:"1"`
 }
 
 func TestReadFromJSON(t *testing.T) {

--- a/defaults/json_test.go
+++ b/defaults/json_test.go
@@ -4,16 +4,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type testCFG struct {
-	Setting string
-	Another int
+	Setting string `default:"hi"`
+	Another int `default:"1"`
 }
 
 func TestReadFromJSON(t *testing.T) {
-	var cfg testCFG
+	cfg := testCFG{}
 	f, err := os.CreateTemp("", "loadtest")
 	require.NoError(t, err)
 	defer os.Remove(f.Name()) // clean up
@@ -24,4 +25,18 @@ func TestReadFromJSON(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	require.Error(t, ReadFromJSON("", f.Name(), &cfg))
+
+	cfg = testCFG{}
+	f1, err := os.CreateTemp("", "loadtest")
+	require.NoError(t, err)
+	defer os.Remove(f1.Name()) // clean up
+
+	// Ensuring default values get correctly overridden
+	_, err = f1.Write([]byte(`{"setting": "hello"}`))
+	require.NoError(t, err)
+	require.NoError(t, f1.Close())
+
+	require.NoError(t, ReadFromJSON("", f1.Name(), &cfg))
+	assert.Equal(t, 1, cfg.Another)
+	assert.Equal(t, "hello", cfg.Setting)
 }

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -8,9 +8,16 @@ import (
 
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore"
+	"github.com/mattermost/mattermost-load-test-ng/logger"
 
 	"github.com/stretchr/testify/require"
 )
+
+type ratesDistribution struct {
+	Rate       float64 `default:"1.0" validate:"range:[0,)"`
+	Percentage float64 `default:"1.0" validate:"range:[0,1]"`
+}
+type userControllerType string
 
 type config struct {
 	ConnectionConfiguration struct {
@@ -19,6 +26,32 @@ type config struct {
 		AdminEmail    string `default:"sysadmin@sample.mattermost.com" validate:"email"`
 		AdminPassword string `default:"Sys@dmin-sample1" validate:"notempty"`
 	}
+	UserControllerConfiguration struct {
+		Type              userControllerType  `default:"simulative" validate:"oneof:{simple,simulative,noop,cluster,generative}"`
+		RatesDistribution []ratesDistribution `default_len:"1"`
+		ServerVersion     string
+	}
+	InstanceConfiguration struct {
+		NumTeams                    int64   `default:"2" validate:"range:[0,]"`
+		NumChannels                 int64   `default:"10" validate:"range:[0,]"`
+		NumPosts                    int64   `default:"0" validate:"range:[0,]"`
+		NumReactions                int64   `default:"0" validate:"range:[0,]"`
+		NumAdmins                   int64   `default:"0" validate:"range:[0,]"`
+		PercentReplies              float64 `default:"0.5" validate:"range:[0,1]"`
+		PercentRepliesInLongThreads float64 `default:"0.05" validate:"range:[0,1]"`
+		PercentUrgentPosts          float64 `default:"0.001" validate:"range:[0,1]"`
+		PercentPublicChannels       float64 `default:"0.2" validate:"range:[0,1]"`
+		PercentPrivateChannels      float64 `default:"0.1" validate:"range:[0,1]"`
+		PercentDirectChannels       float64 `default:"0.6" validate:"range:[0,1]"`
+		PercentGroupChannels        float64 `default:"0.1" validate:"range:[0,1]"`
+	}
+	UsersConfiguration struct {
+		UsersFilePath      string
+		InitialActiveUsers int `default:"0" validate:"range:[0,$MaxActiveUsers]"`
+		MaxActiveUsers     int `default:"2000" validate:"range:(0,]"`
+		AvgSessionsPerUser int `default:"1" validate:"range:[1,]"`
+	}
+	LogSettings logger.Settings
 }
 
 type TestHelper struct {


### PR DESCRIPTION
We were trying to set the defaults after parsing. But we were ignoring the errors from the parse. To solve this, we set the defaults first and then override it while unmarshaling the JSON. This achieves the same result but also returns errors correctly.

https://mattermost.atlassian.net/browse/MM-54314
