### PR TITLE
[MM-54702] Automatically clear licenses data from DB dumps

### DIFF
--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -208,7 +208,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		Clients: []*ssh.Client{appClients[0]},
 	}
 
-	dbCmds, err := deployment.BuildLoadDBDumpCmds(dumpFilename, deployment.DBSettings{
+	dbCmd, err := deployment.BuildLoadDBDumpCmd(dumpFilename, deployment.DBSettings{
 		UserName: dpConfig.TerraformDBSettings.UserName,
 		Password: dpConfig.TerraformDBSettings.Password,
 		DBName:   dbName,
@@ -216,10 +216,9 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		Engine:   dpConfig.TerraformDBSettings.InstanceEngine,
 	})
 	if err != nil {
-		return fmt.Errorf("error building commands for loading DB dump: %w", err)
+		return fmt.Errorf("error building command for loading DB dump: %w", err)
 	}
-
-	loadDBDumpCmd.Value = strings.Join(dbCmds, " | ")
+	loadDBDumpCmd.Value = dbCmd
 
 	resetBucketCmds := []localCmd{}
 	if s3BucketURI != "" && tfOutput.HasS3Bucket() {

--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -69,7 +69,7 @@ func (t *Terraform) IngestDump() error {
 		Clients: []*ssh.Client{appClients[0]},
 	}
 
-	dbCmds, err := deployment.BuildLoadDBDumpCmds(fileName, deployment.DBSettings{
+	dbCmd, err := deployment.BuildLoadDBDumpCmd(fileName, deployment.DBSettings{
 		UserName: t.config.TerraformDBSettings.UserName,
 		Password: t.config.TerraformDBSettings.Password,
 		DBName:   t.config.DBName(),
@@ -77,9 +77,9 @@ func (t *Terraform) IngestDump() error {
 		Engine:   t.config.TerraformDBSettings.InstanceEngine,
 	})
 	if err != nil {
-		return fmt.Errorf("error building commands for loading DB dump: %w", err)
+		return fmt.Errorf("error building command for loading DB dump: %w", err)
 	}
-	loadDBDumpCmd.Value = strings.Join(dbCmds, " | ")
+	loadDBDumpCmd.Value = dbCmd
 
 	startCmd := deployment.Cmd{
 		Msg:     "Restarting app server",

--- a/deployment/utils_test.go
+++ b/deployment/utils_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildLoadDBDumpCmd(t *testing.T) {
+	tcs := []struct {
+		name     string
+		dumpName string
+		dbInfo   DBSettings
+		cmd      string
+		err      string
+	}{
+		{
+			name:     "invalid engine",
+			dumpName: "invalid.dump.sql",
+			dbInfo: DBSettings{
+				Engine:   "invalid",
+				UserName: "mmuser",
+				Password: "mostest",
+				DBName:   "mattermost",
+				Host:     "localhost",
+			},
+			err: "invalid db engine invalid",
+		},
+		{
+			name:     "mysql",
+			dumpName: "mysql.dump.sql.xz",
+			dbInfo: DBSettings{
+				Engine:   "aurora-mysql",
+				UserName: "mmuser",
+				Password: "mostest",
+				DBName:   "mattermost",
+				Host:     "localhost",
+			},
+			cmd: `zcat mysql.dump.sql.xz | mysql -h localhost -u mmuser -pmostest mattermost && mysql -h localhost -u mmuser -pmostest mattermost -e "DELETE FROM Systems WHERE Name = 'ActiveLicenseId'; DELETE FROM Licenses;"`,
+		},
+		{
+			name:     "psql",
+			dumpName: "psql.dump.sql.xz",
+			dbInfo: DBSettings{
+				Engine:   "aurora-postgresql",
+				UserName: "mmuser",
+				Password: "mostest",
+				DBName:   "mattermost",
+				Host:     "localhost",
+			},
+			cmd: `zcat psql.dump.sql.xz | psql 'postgres://mmuser:mostest@localhost/mattermost?sslmode=disable' && psql 'postgres://mmuser:mostest@localhost/mattermost?sslmode=disable' -c "DELETE FROM Systems WHERE Name = 'ActiveLicenseId'; DELETE FROM Licenses;"`,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, err := BuildLoadDBDumpCmd(tc.dumpName, tc.dbInfo)
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.cmd, cmd)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

PR adds an extra step to the db dump loading command that clears existing license related information. This should be the last piece needed to fix the loading issues.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54702
