### PR TITLE
MM-54986: Disable app and/or agent profiling

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -111,5 +111,9 @@
         "Query": "histogram_quantile(0.99, sum(rate(mattermost_api_time_bucket[1m])) by (le))"
       }
     ]
+  },
+  "PyroscopeSettings": {
+    "EnableAppProfiling": true,
+    "EnableAgentProfiling": true
   }
 }

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -108,20 +108,6 @@ type PyroscopeSettings struct {
 	EnableAgentProfiling bool `default:"true"`
 }
 
-func (ps PyroscopeSettings) GenString(template string, mmTargets, ltTargets []string) string {
-	pyroscopeAppConfig := ""
-	if ps.EnableAppProfiling {
-		pyroscopeAppConfig = strings.Join(mmTargets, ",")
-	}
-	pyroscopeAgentsConfig := ""
-	if ps.EnableAgentProfiling {
-		pyroscopeAgentsConfig = strings.Join(ltTargets, ",")
-	}
-	pyroscopeConfigFile := fmt.Sprintf(template, pyroscopeAppConfig, pyroscopeAgentsConfig)
-
-	return pyroscopeConfigFile
-}
-
 // TerraformDBSettings contains the necessary data
 // to configure an instance to be deployed
 // and provisioned.

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -108,6 +108,20 @@ type PyroscopeSettings struct {
 	EnableAgentProfiling bool `default:"true"`
 }
 
+func (ps PyroscopeSettings) GenString(template string, mmTargets, ltTargets []string) string {
+	pyroscopeAppConfig := ""
+	if ps.EnableAppProfiling {
+		pyroscopeAppConfig = strings.Join(mmTargets, ",")
+	}
+	pyroscopeAgentsConfig := ""
+	if ps.EnableAgentProfiling {
+		pyroscopeAgentsConfig = strings.Join(ltTargets, ",")
+	}
+	pyroscopeConfigFile := fmt.Sprintf(template, pyroscopeAppConfig, pyroscopeAgentsConfig)
+
+	return pyroscopeConfigFile
+}
+
 // TerraformDBSettings contains the necessary data
 // to configure an instance to be deployed
 // and provisioned.

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -95,6 +95,17 @@ type Config struct {
 	// to use. If present, it is used to automatically upload it to the agents and override the agent's config's
 	// own UsersFilePath.
 	UsersFilePath string `default:""`
+	// PyroscopeSettings contains the settings for configuring the continuous profiling through Pyroscope
+	PyroscopeSettings PyroscopeSettings
+}
+
+// PyroscopeSettings contains flags to enable/disable the profiling
+// of the different parts of the deployment.
+type PyroscopeSettings struct {
+	// Enable profiling of all the app instances
+	EnableAppProfiling bool `default:"true"`
+	// Enable profiling of all the agent instances
+	EnableAgentProfiling bool `default:"true"`
 }
 
 // TerraformDBSettings contains the necessary data

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -140,16 +140,8 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 		return fmt.Errorf("error upload prometheus config: output: %s, error: %w", out, err)
 	}
 
-	pyroscopeAppConfig := ""
-	if t.config.PyroscopeSettings.EnableAppProfiling {
-		pyroscopeAppConfig = strings.Join(mmTargets, ",")
-	}
-	pyroscopeAgentsConfig := ""
-	if t.config.PyroscopeSettings.EnableAppProfiling {
-		pyroscopeAgentsConfig = strings.Join(ltTargets, ",")
-	}
 	mlog.Info("Updating Pyroscope config", mlog.String("host", t.output.MetricsServer.PublicIP))
-	pyroscopeConfigFile := fmt.Sprintf(pyroscopeConfig, pyroscopeAppConfig, pyroscopeAgentsConfig)
+	pyroscopeConfigFile := t.config.PyroscopeSettings.GenString(pyroscopeConfig, mmTargets, ltTargets)
 
 	rdr = strings.NewReader(pyroscopeConfigFile)
 	if out, err := sshc.Upload(rdr, "/etc/pyroscope/server.yml", true); err != nil {

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -139,11 +139,18 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	if out, err := sshc.Upload(rdr, "/etc/prometheus/prometheus.yml", true); err != nil {
 		return fmt.Errorf("error upload prometheus config: output: %s, error: %w", out, err)
 	}
+
+	pyroscopeAppConfig := ""
+	if t.config.PyroscopeSettings.EnableAppProfiling {
+		pyroscopeAppConfig = strings.Join(mmTargets, ",")
+	}
+	pyroscopeAgentsConfig := ""
+	if t.config.PyroscopeSettings.EnableAppProfiling {
+		pyroscopeAgentsConfig = strings.Join(ltTargets, ",")
+	}
 	mlog.Info("Updating Pyroscope config", mlog.String("host", t.output.MetricsServer.PublicIP))
-	pyroscopeConfigFile := fmt.Sprintf(pyroscopeConfig,
-		strings.Join(mmTargets, ","),
-		strings.Join(ltTargets, ","),
-	)
+	pyroscopeConfigFile := fmt.Sprintf(pyroscopeConfig, pyroscopeAppConfig, pyroscopeAgentsConfig)
+
 	rdr = strings.NewReader(pyroscopeConfigFile)
 	if out, err := sshc.Upload(rdr, "/etc/pyroscope/server.yml", true); err != nil {
 		return fmt.Errorf("error upload pyroscope config: output: %s, error: %w", out, err)

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -91,25 +91,25 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	var mmTargets, nodeTargets, esTargets, ltTargets []string
 	for i, val := range t.output.Instances {
 		host := fmt.Sprintf("app-%d", i)
-		mmTargets = append(mmTargets, fmt.Sprintf("'%s:8067'", host))
-		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
+		mmTargets = append(mmTargets, fmt.Sprintf("%s:8067", host))
+		nodeTargets = append(nodeTargets, fmt.Sprintf("%s:9100", host))
 		hosts += fmt.Sprintf("%s %s\n", val.PrivateIP, host)
 	}
 	for i, val := range t.output.Agents {
 		host := fmt.Sprintf("agent-%d", i)
-		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
-		ltTargets = append(ltTargets, fmt.Sprintf("'%s:4000'", host))
+		nodeTargets = append(nodeTargets, fmt.Sprintf("%s:9100", host))
+		ltTargets = append(ltTargets, fmt.Sprintf("%s:4000", host))
 		hosts += fmt.Sprintf("%s %s\n", val.PrivateIP, host)
 	}
 	if t.output.HasProxy() {
 		host := "proxy"
-		nodeTargets = append(nodeTargets, fmt.Sprintf("'%s:9100'", host))
+		nodeTargets = append(nodeTargets, fmt.Sprintf("%s:9100", host))
 		hosts += fmt.Sprintf("%s %s\n", t.output.Proxy.PrivateIP, host)
 	}
 
 	if t.output.HasElasticSearch() {
 		esEndpoint := fmt.Sprintf("https://%s", t.output.ElasticSearchServer.Endpoint)
-		esTargets = append(esTargets, "'metrics:9114'")
+		esTargets = append(esTargets, "metrics:9114")
 
 		mlog.Info("Enabling Elasticsearch exporter", mlog.String("host", t.output.MetricsServer.PublicIP))
 		esExporterService := fmt.Sprintf(esExporterServiceFile, esEndpoint)
@@ -129,12 +129,20 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 		}
 	}
 
+	quoteAll := func(elems []string) []string {
+		quoted := make([]string, 0, len(elems))
+		for _, elem := range elems {
+			quoted = append(quoted, "'"+elem+"'")
+		}
+		return quoted
+	}
+
 	mlog.Info("Updating Prometheus config", mlog.String("host", t.output.MetricsServer.PublicIP))
 	prometheusConfigFile := fmt.Sprintf(prometheusConfig,
-		strings.Join(nodeTargets, ","),
-		strings.Join(mmTargets, ","),
-		strings.Join(esTargets, ","),
-		strings.Join(ltTargets, ","),
+		strings.Join(quoteAll(nodeTargets), ","),
+		strings.Join(quoteAll(mmTargets), ","),
+		strings.Join(quoteAll(esTargets), ","),
+		strings.Join(quoteAll(ltTargets), ","),
 	)
 	rdr := strings.NewReader(prometheusConfigFile)
 	if out, err := sshc.Upload(rdr, "/etc/prometheus/prometheus.yml", true); err != nil {

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -49,23 +49,59 @@ scrape_configs:
         - targets: [%s]
 `
 
-const pyroscopeConfig = `
-log-level: debug
-no-self-profiling: true
+type PyroscopeConfig struct {
+	LogLevel        string         `yaml:"log-level"`
+	NoSelfProfiling bool           `yaml:"no-self-profiling"`
+	ScrapeConfigs   []ScrapeConfig `yaml:"scrape-configs"`
+}
 
-scrape-configs:
-  - job-name: pyroscope
-    scheme: http
-    scrape-interval: 60s
-    enabled-profiles: [cpu, mem, goroutines]
-    static-configs:
-    - application: mattermost
-      spy-name: gospy
-      targets: [%s]
-    - application: agents
-      spy-name: gospy
-      targets: [%s]
-`
+type ScrapeConfig struct {
+	JobName         string         `yaml:"job-name"`
+	Scheme          string         `yaml:"scheme"`
+	ScrapeInterval  string         `yaml:"scrape-interval"`
+	EnabledProfiles []string       `yaml:"enabled-profiles,flow"`
+	StaticConfigs   []StaticConfig `yaml:"static-configs,omitempty"`
+}
+
+type StaticConfig struct {
+	Application string   `yaml:"application"`
+	SpyName     string   `yaml:"spy-name"`
+	Targets     []string `yaml:"targets,flow"`
+}
+
+func NewPyroscopeConfig(mmTargets, ltTargets []string) *PyroscopeConfig {
+	var staticConfigs []StaticConfig
+
+	if len(mmTargets) > 0 {
+		staticConfigs = append(staticConfigs, StaticConfig{
+			Application: "mattermost",
+			SpyName:     "gospy",
+			Targets:     mmTargets,
+		})
+	}
+
+	if len(ltTargets) > 0 {
+		staticConfigs = append(staticConfigs, StaticConfig{
+			Application: "agents",
+			SpyName:     "gospy",
+			Targets:     ltTargets,
+		})
+	}
+
+	return &PyroscopeConfig{
+		LogLevel:        "debug",
+		NoSelfProfiling: true,
+		ScrapeConfigs: []ScrapeConfig{
+			{
+				JobName:         "pryoscope",
+				Scheme:          "http",
+				ScrapeInterval:  "60s",
+				EnabledProfiles: []string{"cpu", "mem", "goroutines"},
+				StaticConfigs:   staticConfigs,
+			},
+		},
+	}
+}
 
 const metricsHosts = `
 127.0.0.1 localhost

--- a/deployment/terraform/strings_test.go
+++ b/deployment/terraform/strings_test.go
@@ -1,101 +1,32 @@
 package terraform
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
 	"testing"
 
-	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/stretchr/testify/require"
 )
 
-var reListElems = regexp.MustCompile(`\[(.*)\]`)
-
-func TestPyroscopeSettingsGenString(t *testing.T) {
+func TestNewPyroscopeConfig(t *testing.T) {
 	mmTarget := "app-0:8067"
 	ltTarget := "agent-0:4000"
 
-	// The Name represents the state of each setting, with
-	// 1 meaning true for bool and non-empty for []string,
-	// and 0 meaning false for bool and empty for []string
 	testCases := []struct {
-		Name                 string
-		EnableAppProfiling   bool
-		EnableAgentProfiling bool
-		MMTargets            []string
-		LTTargets            []string
+		Name                  string
+		MMTargets             []string
+		LTTargets             []string
+		ExpectedStaticConfigs []StaticConfig
 	}{
-		{"0000", false, false, []string{}, []string{}},
-		{"0001", false, false, []string{}, []string{ltTarget}},
-		{"0010", false, false, []string{mmTarget}, []string{}},
-		{"0011", false, false, []string{mmTarget}, []string{ltTarget}},
-		{"0100", false, true, []string{}, []string{}},
-		{"0101", false, true, []string{}, []string{ltTarget}},
-		{"0110", false, true, []string{mmTarget}, []string{}},
-		{"0111", false, true, []string{mmTarget}, []string{ltTarget}},
-		{"1000", true, false, []string{}, []string{}},
-		{"1001", true, false, []string{}, []string{ltTarget}},
-		{"1010", true, false, []string{mmTarget}, []string{}},
-		{"1011", true, false, []string{mmTarget}, []string{ltTarget}},
-		{"1100", true, true, []string{}, []string{}},
-		{"1101", true, true, []string{}, []string{ltTarget}},
-		{"1110", true, true, []string{mmTarget}, []string{}},
-		{"1111", true, true, []string{mmTarget}, []string{ltTarget}},
+		{"Both empty", []string{}, []string{}, []StaticConfig{}},
+		{"MMTargets empty", []string{}, []string{ltTarget}, []StaticConfig{{"agents", "gospy", []string{ltTarget}}}},
+		{"LTTargets empty", []string{mmTarget}, []string{}, []StaticConfig{{"mattermost", "gospy", []string{mmTarget}}}},
+		{"Both populated", []string{mmTarget}, []string{ltTarget}, []StaticConfig{{"mattermost", "gospy", []string{mmTarget}}, {"agents", "gospy", []string{ltTarget}}}},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			settings := deployment.PyroscopeSettings{
-				EnableAppProfiling:   tc.EnableAppProfiling,
-				EnableAgentProfiling: tc.EnableAgentProfiling,
-			}
-
-			generatedYaml := settings.GenString(pyroscopeConfig, tc.MMTargets, tc.LTTargets)
-
-			// We need to do some parsing here to get the part we're interested in, which is the targets
-			// for the app nodes (the first 'targets: [...]' line), and the targets for the agent nodes,
-			// (the second 'targets: [...]' line), and then we extract everything that is inside the
-			// square brackets
-			targets := []string{}
-			for _, line := range strings.Split(generatedYaml, "\n") {
-				if strings.Contains(line, "targets") {
-					matches := reListElems.FindStringSubmatch(line)
-					fmt.Println(matches)
-					require.Len(t, matches, 2)
-					targets = append(targets, matches[1])
-				}
-			}
-			require.Len(t, targets, 2)
-
-			// Now we need to reconstruct the slice of targets for the app nodes
-			actualMMTargets := []string{}
-			mmTargets := targets[0]
-			if mmTargets != "" {
-				actualMMTargets = strings.Split(mmTargets, ",")
-			}
-
-			// And the same for the agent nodes
-			actualLTTargets := []string{}
-			ltTargets := targets[1]
-			if ltTargets != "" {
-				actualLTTargets = strings.Split(ltTargets, ",")
-			}
-
-			// Now it's time to check the targets for the app nodes
-			if tc.EnableAppProfiling {
-				require.ElementsMatch(t, tc.MMTargets, actualMMTargets)
-			} else {
-				require.Empty(t, actualMMTargets)
-			}
-
-			// And again for the agent nodes
-			if tc.EnableAgentProfiling {
-				require.ElementsMatch(t, tc.LTTargets, actualLTTargets)
-			} else {
-				require.Empty(t, actualLTTargets)
-			}
+			config := NewPyroscopeConfig(tc.MMTargets, tc.LTTargets)
+			require.Len(t, config.ScrapeConfigs, 1)
+			require.ElementsMatch(t, config.ScrapeConfigs[0].StaticConfigs, tc.ExpectedStaticConfigs)
 		})
 	}
-
 }

--- a/deployment/terraform/strings_test.go
+++ b/deployment/terraform/strings_test.go
@@ -1,0 +1,101 @@
+package terraform
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
+	"github.com/stretchr/testify/require"
+)
+
+var reListElems = regexp.MustCompile(`\[(.*)\]`)
+
+func TestPyroscopeSettingsGenString(t *testing.T) {
+	mmTarget := "app-0:8067"
+	ltTarget := "agent-0:4000"
+
+	// The Name represents the state of each setting, with
+	// 1 meaning true for bool and non-empty for []string,
+	// and 0 meaning false for bool and empty for []string
+	testCases := []struct {
+		Name                 string
+		EnableAppProfiling   bool
+		EnableAgentProfiling bool
+		MMTargets            []string
+		LTTargets            []string
+	}{
+		{"0000", false, false, []string{}, []string{}},
+		{"0001", false, false, []string{}, []string{ltTarget}},
+		{"0010", false, false, []string{mmTarget}, []string{}},
+		{"0011", false, false, []string{mmTarget}, []string{ltTarget}},
+		{"0100", false, true, []string{}, []string{}},
+		{"0101", false, true, []string{}, []string{ltTarget}},
+		{"0110", false, true, []string{mmTarget}, []string{}},
+		{"0111", false, true, []string{mmTarget}, []string{ltTarget}},
+		{"1000", true, false, []string{}, []string{}},
+		{"1001", true, false, []string{}, []string{ltTarget}},
+		{"1010", true, false, []string{mmTarget}, []string{}},
+		{"1011", true, false, []string{mmTarget}, []string{ltTarget}},
+		{"1100", true, true, []string{}, []string{}},
+		{"1101", true, true, []string{}, []string{ltTarget}},
+		{"1110", true, true, []string{mmTarget}, []string{}},
+		{"1111", true, true, []string{mmTarget}, []string{ltTarget}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			settings := deployment.PyroscopeSettings{
+				EnableAppProfiling:   tc.EnableAppProfiling,
+				EnableAgentProfiling: tc.EnableAgentProfiling,
+			}
+
+			generatedYaml := settings.GenString(pyroscopeConfig, tc.MMTargets, tc.LTTargets)
+
+			// We need to do some parsing here to get the part we're interested in, which is the targets
+			// for the app nodes (the first 'targets: [...]' line), and the targets for the agent nodes,
+			// (the second 'targets: [...]' line), and then we extract everything that is inside the
+			// square brackets
+			targets := []string{}
+			for _, line := range strings.Split(generatedYaml, "\n") {
+				if strings.Contains(line, "targets") {
+					matches := reListElems.FindStringSubmatch(line)
+					fmt.Println(matches)
+					require.Len(t, matches, 2)
+					targets = append(targets, matches[1])
+				}
+			}
+			require.Len(t, targets, 2)
+
+			// Now we need to reconstruct the slice of targets for the app nodes
+			actualMMTargets := []string{}
+			mmTargets := targets[0]
+			if mmTargets != "" {
+				actualMMTargets = strings.Split(mmTargets, ",")
+			}
+
+			// And the same for the agent nodes
+			actualLTTargets := []string{}
+			ltTargets := targets[1]
+			if ltTargets != "" {
+				actualLTTargets = strings.Split(ltTargets, ",")
+			}
+
+			// Now it's time to check the targets for the app nodes
+			if tc.EnableAppProfiling {
+				require.ElementsMatch(t, tc.MMTargets, actualMMTargets)
+			} else {
+				require.Empty(t, actualMMTargets)
+			}
+
+			// And again for the agent nodes
+			if tc.EnableAgentProfiling {
+				require.ElementsMatch(t, tc.LTTargets, actualLTTargets)
+			} else {
+				require.Empty(t, actualLTTargets)
+			}
+		})
+	}
+
+}

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -446,3 +446,9 @@ The name of a host that will be used for two purposes:
 - It will override the server's site URL.
 - It will populate a new entry in the /etc/hosts file of the app nodes, so that it points to the proxy private IP or, if there's no proxy, to the current app node.
 This config is used for tests that require an existing database dump that contains permalinks. These permalinks point to a specific hostname. Without this setting, that hostname is not known by the nodes of a new deployment and the permalinks cannot be resolved.
+
+## UsersFilePath
+
+*string*
+
+The path to a file containing a list of credentials for the controllers to use. If present, it is used to automatically upload it to the agents and override the agent's config's own [`UsersFilePath`](config.md/#UsersFilePath).

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -452,3 +452,17 @@ This config is used for tests that require an existing database dump that contai
 *string*
 
 The path to a file containing a list of credentials for the controllers to use. If present, it is used to automatically upload it to the agents and override the agent's config's own [`UsersFilePath`](config.md/#UsersFilePath).
+
+## PyroscopeSettings
+
+### EnableAppProfiling
+
+*bool*
+
+Enable continuous profiling of all the app instances.
+
+### EnableAgentProfiling
+
+*bool*
+
+Enable continuous profiling of all the agent instances.

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	github.com/wiggin77/merror v1.0.5
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -123,7 +124,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/uint128 v1.3.0 // indirect
 	modernc.org/cc/v3 v3.41.0 // indirect
 	modernc.org/ccgo/v3 v3.16.14 // indirect


### PR DESCRIPTION
#### Summary
Motivated for the huge amount of memory consumed by profiling 50 agents in the ceiling tests, we decided to allow the user to selectively disable that type of profiling. This PR solves that by making it optional to profile both the app and the agent nodes.

~~Note that the approach to test the generated yaml is a bit esoteric, but parsing the generated yaml seemed even more convoluted than this. I'm open to changing it if your eyes bleed a lot when reading the test, though.~~ Ended up using go-yaml to generate the config, much easier and cleaner.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54986
