### PR TITLE
MM-55150: Enable performance insights by default

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -33,7 +33,7 @@
     "InstanceType": "db.r6g.large",
     "UserName": "mmuser",
     "Password": "mostest80098bigpass_",
-    "EnablePerformanceInsights": false,
+    "EnablePerformanceInsights": true,
     "DBParameters": [],
     "ClusterIdentifier": ""
   },

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -112,7 +112,7 @@ type TerraformDBSettings struct {
 	// Password to connect to the DB.
 	Password string `default:"mostest80098bigpass_" validate:"notempty"`
 	// If set to true enables performance insights for the created DB instances.
-	EnablePerformanceInsights bool `default:"false"`
+	EnablePerformanceInsights bool `default:"true"`
 	// A list of DB specific parameters to use for the created instance.
 	DBParameters DBParameters
 	// ClusterIdentifier indicates to point to an existing cluster


### PR DESCRIPTION
#### Summary
Literally what the title says :) I've also updated the base config files we used for the ceiling tests in the launcher instance.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55150