### PR TITLE
Automated generation of sample config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,11 @@ build-osx: ## Build the binary (only for OSX on AMD64).
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(AGENT) $(AGENT_ARGS)
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
 
-assets: ## Generate the assets. Install go-bindata if needed.
+assets: ## Generate assets and sample config files. It installs go-bindata if needed.
 	go install github.com/kevinburke/go-bindata/go-bindata@v3.23.0
 	go generate ./...
 	go fmt ./...
+	go run ./cmd/ltassist config sample
 
 build: assets build-linux build-osx ## Generate the assets and build the binary for all platforms.
 

--- a/defaults/set.go
+++ b/defaults/set.go
@@ -55,7 +55,7 @@ func structDefaults(value interface{}, sampleMode bool) error {
 		case reflect.Slice:
 			tag, ok := t.Field(i).Tag.Lookup("default_size")
 			if !ok {
-				continue
+				tag = "0"
 			}
 			size, err := strconv.Atoi(tag)
 			if err != nil {

--- a/defaults/set.go
+++ b/defaults/set.go
@@ -149,7 +149,7 @@ func setValue(t reflect.Type, data string) (reflect.Value, error) {
 func createSlice(defaultValue interface{}, size int, sampleMode bool) (reflect.Value, error) {
 	t := reflect.ValueOf(defaultValue).Type().Elem()
 	if t.Kind() == reflect.Struct {
-		values := reflect.MakeSlice(reflect.SliceOf(t), size, size)
+		values := reflect.MakeSlice(reflect.SliceOf(t), 0, size)
 		for i := 0; i < size; i++ {
 			dv := reflect.New(t).Interface()
 			err := structDefaults(dv, sampleMode)
@@ -160,7 +160,7 @@ func createSlice(defaultValue interface{}, size int, sampleMode bool) (reflect.V
 		}
 		return values, nil
 	}
-	return reflect.MakeSlice(t, size, size), nil
+	return reflect.MakeSlice(reflect.SliceOf(t), 0, size), nil
 }
 
 // createMap creates a map for the given map type

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -57,7 +57,7 @@ type UserControllerConfiguration struct {
 	// A Rate of < 1.0 will run actions at a faster pace.
 	// A Rate of 1.0 will run actions at the default pace.
 	// A Rate > 1.0 will run actions at a slower pace.
-	RatesDistribution []RatesDistribution `default_len:"1"`
+	RatesDistribution []RatesDistribution `default_size:"1"`
 	// An optional MM server version to use when running actions (e.g. `5.30.0`).
 	// This value overrides the actual server version. If left empty,
 	// the one returned by the server is used instead.

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -28,7 +28,7 @@ type config struct {
 	}
 	UserControllerConfiguration struct {
 		Type              userControllerType  `default:"simulative" validate:"oneof:{simple,simulative,noop,cluster,generative}"`
-		RatesDistribution []ratesDistribution `default_len:"1"`
+		RatesDistribution []ratesDistribution `default_size:"1"`
 		ServerVersion     string
 	}
 	InstanceConfiguration struct {


### PR DESCRIPTION
#### Summary
Just some Friday night fun to generate the sample config files automatically, since I found some discrepancies earlier this week and thought this was going to get out of sync rather sooner than later even if I fixed it.

So I created a command to generate the sample files automatically using the default values in the structs (making sure that slices had at least one element, so we could showcase all possible values), and added it to `make assets` so that CI will fail if it detects some change there.

Next step (next Friday, maybe?): use `ltassist check` to check the docs in CI as well.

#### Ticket Link
--
