### PR TITLE
MM-55312: Bump MaxNotificationsPerChannel

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -579,6 +579,7 @@ func (t *Terraform) updateAppConfig(siteURL string, sshc *ssh.Client, jobServerE
 
 	cfg.TeamSettings.MaxUsersPerTeam = model.NewInt(50000)
 	cfg.TeamSettings.EnableOpenServer = model.NewBool(true)
+	cfg.TeamSettings.MaxNotificationsPerChannel = model.NewInt64(100000)
 
 	cfg.ClusterSettings.GossipPort = model.NewInt(8074)
 	cfg.ClusterSettings.StreamingPort = model.NewInt(8075)


### PR DESCRIPTION
By default, this number was 1000 which didn't allow
typing events to be sent for channels with larger
member counts.

https://mattermost.atlassian.net/browse/MM-55312
