### PR TITLE
MM-54455: Fix CORS issue in load test deployment

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -539,6 +539,8 @@ func (t *Terraform) updateAppConfig(siteURL string, sshc *ssh.Client, jobServerE
 	cfg.ServiceSettings.EnableLinkPreviews = model.NewBool(true)
 	cfg.ServiceSettings.EnablePermalinkPreviews = model.NewBool(true)
 	cfg.ServiceSettings.PostPriority = model.NewBool(true)
+	// Setting to * is more of a quick fix. A proper fix would be to get the DNS name of the first
+	// node or the proxy and set that.
 	cfg.ServiceSettings.AllowCorsFrom = model.NewString("*")
 	cfg.EmailSettings.SMTPServer = model.NewString(t.output.MetricsServer.PrivateIP)
 	cfg.EmailSettings.SMTPPort = model.NewString("2500")

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -539,6 +539,7 @@ func (t *Terraform) updateAppConfig(siteURL string, sshc *ssh.Client, jobServerE
 	cfg.ServiceSettings.EnableLinkPreviews = model.NewBool(true)
 	cfg.ServiceSettings.EnablePermalinkPreviews = model.NewBool(true)
 	cfg.ServiceSettings.PostPriority = model.NewBool(true)
+	cfg.ServiceSettings.AllowCorsFrom = model.NewString("*")
 	cfg.EmailSettings.SMTPServer = model.NewString(t.output.MetricsServer.PrivateIP)
 	cfg.EmailSettings.SMTPPort = model.NewString("2500")
 


### PR DESCRIPTION
Since we are using ltserver as the site URL, the ws connection
fails when connecting via browser.

https://mattermost.atlassian.net/browse/MM-54455
