### PR TITLE
MM-53920: Add new coordinator metrics

### DIFF
--- a/config/coordinator.sample.json
+++ b/config/coordinator.sample.json
@@ -46,6 +46,34 @@
         "Threshold": 0.025,
         "MinIntervalSec": 60,
         "Alert": true
+      },
+      {
+        "Description": "CPU utilization",
+        "Query": "100 - 100 * (avg(irate(node_cpu_seconds_total{instance=~\"app.*\",mode=\"idle\"}[5m])))",
+        "Threshold": 85,
+        "MinIntervalSec": 60,
+        "Alert": true
+      },
+      {
+        "Description": "Memory utilization",
+        "Query": "100 - 100 * avg(node_memory_MemAvailable_bytes{instance=~\"app.*\"} / node_memory_MemTotal_bytes{instance=~\"app.*\"})",
+        "Threshold": 85,
+        "MinIntervalSec": 60,
+        "Alert": true
+      },
+      {
+        "Description": "Percentage of TCP segments retransmitted",
+        "Query": "100 * avg(rate(node_netstat_Tcp_RetransSegs{instance=~\"app.*\"}[1m]) / rate(node_netstat_Tcp_OutSegs{instance=~\"app.*\"}[1m]))",
+        "Threshold": 0.1,
+        "MinIntervalSec": 60,
+        "Alert": true
+      },
+      {
+        "Description": "Total TCP listen drops",
+        "Query": "avg(rate(node_netstat_TcpExt_ListenDrops{instance=~\"app.*\"}[1m]))",
+        "Threshold": 20,
+        "MinIntervalSec": 60,
+        "Alert": true
       }
     ]
   },

--- a/config/coordinator.sample.json
+++ b/config/coordinator.sample.json
@@ -62,16 +62,17 @@
         "Alert": true
       },
       {
-        "Description": "Percentage of TCP segments retransmitted",
-        "Query": "100 * avg(rate(node_netstat_Tcp_RetransSegs{instance=~\"app.*\"}[1m]) / rate(node_netstat_Tcp_OutSegs{instance=~\"app.*\"}[1m]))",
-        "Threshold": 0.1,
+        "Description": "Percentage of TCP timeouts in the proxy node",
+        "Query": "100 * rate(node_netstat_TcpExt_TCPTimeouts{instance=~\"proxy:9100\"}[1m]) / (rate(node_netstat_TcpExt_TCPTimeouts{instance=~\"proxy:9100\"}[1m]) + node_netstat_Tcp_CurrEstab{instance=~\"proxy:9100\"})",
+        "Threshold": 0.2,
         "MinIntervalSec": 60,
         "Alert": true
       },
+
       {
-        "Description": "Total TCP listen drops",
-        "Query": "avg(rate(node_netstat_TcpExt_ListenDrops{instance=~\"app.*\"}[1m]))",
-        "Threshold": 20,
+        "Description": "Percentage of TCP timeouts in the app nodes",
+        "Query": "100 * avg(rate(node_netstat_TcpExt_TCPTimeouts{instance=~\"app.*\"}[1m])) / (avg(rate(node_netstat_TcpExt_TCPTimeouts{instance=~\"app.*\"}[1m])) + avg(node_netstat_Tcp_CurrEstab{instance=~\"app.*\"}))",
+        "Threshold": 3.0,
         "MinIntervalSec": 60,
         "Alert": true
       }


### PR DESCRIPTION
#### Summary

This PR adds four more queries to the default coordinator metrics. I thought this was going to be straightforward, but the nuances of each of the `node_*` metrics and the complexity of analyzing when a network is congested or not made this a bit more difficult. So a thorough explanation follows, sorry for the long wall of text.

##### CPU utilization
We compute the percentage of CPU used, by subtracting the percentage of time in idle mode (`node_cpu_seconds_total` is already a percentage) to the total:

```
100 - 100 * (avg(irate(node_cpu_seconds_total{instance=~"app.*",mode="idle"}[5m])))
```

This one is clear, already tested in the first version of the ceiling tests, and it does not need much more discussion.

##### Memory utilization

Similarly, we compute the percentage of memory used, by substracting the percentage of available memory (computed as MemAvailable / MemTotal) to the total:

```
100 - 100 * avg(
    node_memory_MemAvailable_bytes{instance=~"app.*"}
    /
    node_memory_MemTotal_bytes{instance=~\"app.*\"
)
```

The goal for this metric is clear as well, but it needs some clarification, since the `node_memory_*` metrics are a bit confusing. This could be computed as follows as well, computing the available memory as MemFree + Cached + Buffers:

```
100 - 100 * avg(
    (node_memory_MemFree_bytes{instance=~"app.*"} + node_memory_Cached_bytes{instance=~"app.*"} + node_memory_Buffers_bytes{instance=~"app.*"})
    /
    node_memory_MemTotal_bytes{instance=~"app.*"}
)
```

The latter is suggested in many places as the golden rule, but I've chosen the former for two reasons:
1. It seems `MemAvailable` is the correct metric to look at: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
2. Using `MemAvailable` is more conservative than using `MemFree + Cached + Buffers`, as in: the estimated percentage of used memory is slightly higher when using `MemAvailable`. See the comparison:
![image](https://github.com/mattermost/mattermost-load-test-ng/assets/3924815/28c19a25-4e52-4aaa-8c11-70a53fc2b370)

##### TCP metrics

The two other metrics are designed to keep an eye on the potential congestion of the network. These two may need a bit more discussion.

###### Segments retransmitted

One of the best metrics I've found that may point to unreliable networks is the rate of segments retransmitted versus segments sent out (stolen from Brendan Gregg's Systems Performance book). The query is straightforward:

```
100 * avg(rate(node_netstat_Tcp_RetransSegs{instance=~"app.*"}[1m]) / rate(node_netstat_Tcp_OutSegs{instance=~"app.*"}[1m]))
```

This percentage is very very low in the environments I've tested it, unless there is a weird spike, as shown in the two following examples of two different tests (~15K and ~18K users, respectively):

![image](https://github.com/mattermost/mattermost-load-test-ng/assets/3924815/8be03732-7f27-4440-8550-bb10c68031a2)
![image](https://github.com/mattermost/mattermost-load-test-ng/assets/3924815/450755a7-1b89-4811-a67b-4e9778d8c40e)

Looking at these two examples, I've set the threshold to 0.1%

###### Listen drops

As discussed in the thread in Community, we were also interested in the total number of listen drops (which includes listen overflows as well). Again, the query is straightforward:

```
avg(rate(node_netstat_TcpExt_ListenDrops{instance=~"app.*"}[1m]))
```

And looking at its values in the same environments as before, I've decide to set the threshold at 20. I'm not too convinced this is right, or if it may be too low, so I'm open to suggestions on how to decide its value:

![image](https://github.com/mattermost/mattermost-load-test-ng/assets/3924815/26689ce0-53e1-43fa-9553-d76d669bfaaa)
![image](https://github.com/mattermost/mattermost-load-test-ng/assets/3924815/405ce377-8fe7-44ca-9a2a-56aa640ade89)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53920