### PR TITLE
Bump version to v1.11.0-rc1

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -60,7 +60,7 @@
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",
-  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.9.1/mattermost-load-test-ng-v1.9.1-linux-amd64.tar.gz",
+  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.11.0-rc1/mattermost-load-test-ng-v1.11.0-rc1-linux-amd64.tar.gz",
   "LogSettings": {
     "EnableConsole": true,
     "ConsoleLevel": "INFO",

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	// URL from where to download load-test-ng binaries and configuration files.
 	// The configuration files provided in the package will be overridden in
 	// the deployment process.
-	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.9.1/mattermost-load-test-ng-v1.9.1-linux-amd64.tar.gz" validate:"url"`
+	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.11.0-rc1/mattermost-load-test-ng-v1.11.0-rc1-linux-amd64.tar.gz" validate:"url"`
 	ElasticSearchSettings ElasticSearchSettings
 	JobServerSettings     JobServerSettings
 	LogSettings           logger.Settings

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -10,7 +10,7 @@ func TestConfigIsValid(t *testing.T) {
 	baseConfig := func() Config {
 		return Config{
 			MattermostDownloadURL: "https://latest.mattermost.com/mattermost-enterprise-linux",
-			LoadTestDownloadURL:   "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.9.1/mattermost-load-test-ng-v1.9.1-linux-amd64.tar.gz",
+			LoadTestDownloadURL:   "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.11.0-rc1/mattermost-load-test-ng-v1.11.0-rc1-linux-amd64.tar.gz",
 		}
 	}
 


### PR DESCRIPTION
#### Summary
Bump version to v1.11.0.

Last time (https://github.com/mattermost/mattermost-load-test-ng/pull/657) we only merged the version bump change to the release branch, `release-1.10`, so we had not updated the sample config files in master to 1.10.0. This is not a showstopper issue, but we need to do it a bit differently. We could simply merge first to `master` and cherry-pick then to `release-x.y`, although there would be a period of time (5 working days?) where the sample config file would have a version that has not been released yet. Not a big problem I guess.

--