### PR TITLE
Revert "MM-55312: Bump MaxNotificationsPerChannel"

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -583,7 +583,6 @@ func (t *Terraform) updateAppConfig(siteURL string, sshc *ssh.Client, jobServerE
 
 	cfg.TeamSettings.MaxUsersPerTeam = model.NewInt(50000)
 	cfg.TeamSettings.EnableOpenServer = model.NewBool(true)
-	cfg.TeamSettings.MaxNotificationsPerChannel = model.NewInt64(100000)
 
 	cfg.ClusterSettings.GossipPort = model.NewInt(8074)
 	cfg.ClusterSettings.StreamingPort = model.NewInt(8075)


### PR DESCRIPTION
Reverts mattermost/mattermost-load-test-ng#662

After a discussion with @jwilander, he suggested that it's okay for this setting to be 1000 for large installs. 