### PR TITLE
[MM-56029] Set HTTP client timeout on UserEntity

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -405,8 +405,9 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 		}
 
 		ueSetup := userentity.Setup{
-			Store:     store,
-			Transport: transport,
+			Store:         store,
+			Transport:     transport,
+			ClientTimeout: transport.ResponseHeaderTimeout,
 		}
 		if metrics != nil {
 			ueSetup.Metrics = metrics.UserEntityMetrics()

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -55,6 +55,8 @@ type Setup struct {
 	Transport http.RoundTripper
 	// An optional object used to collect metrics.
 	Metrics *performance.UserEntityMetrics
+	// The HTTP client timeout to use.
+	ClientTimeout time.Duration
 }
 
 type userTypingMsg struct {
@@ -104,7 +106,10 @@ func New(setup Setup, config Config) *UserEntity {
 			ue:        &ue,
 		}
 	}
-	ue.client.HTTPClient = &http.Client{Transport: setup.Transport}
+	ue.client.HTTPClient = &http.Client{
+		Transport: setup.Transport,
+		Timeout:   setup.ClientTimeout,
+	}
 
 	err := ue.store.SetUser(&model.User{
 		Username: config.Username,


### PR DESCRIPTION
#### Summary

We had this issue where a load-test would seem to completely stop after a few minutes when running against a Cloud workspace. Looking at the backtrace I was able to identify that all users were essentially deadlocked waiting for http requests to go through. This seemed strange considering we are definitely [enforcing some timeouts](https://github.com/mattermost/mattermost-load-test-ng/blob/19bc7bc5944b83545b257d0b3693fbe3ded4e9f6/api/agent.go#L340-L351) at both the dialer and transport level. Also I don't believe we ever saw this happening before or we would have addressed it by now. The theory so far is that in this specific case clients don't even get to read response, probably blocking on sending the request.

There's also a good chance this is a regression introduced when updating the server dependency that added a context to all `Client4` requests. Setting the timeout on the shared client object during setup seems to be working. I am currently using the same value (5 seconds). Let me know if you have different suggestions.

Thanks @angeloskyratzakos for helping me to debug this.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56029