### PR TITLE
MM-56288: Fix panic while getting config

### DIFF
--- a/loadtest/control/gencontroller/actions.go
+++ b/loadtest/control/gencontroller/actions.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -407,13 +408,18 @@ func (c *GenController) addReaction(u user.User) (res control.UserActionResponse
 		}
 	}
 
-	if reactionLimit := u.Store().Config().ServiceSettings.UniqueEmojiReactionLimitPerPost; reactionLimit != nil {
+	reactionLimit, err := strconv.ParseInt(u.Store().ClientConfig()["UniqueEmojiReactionLimitPerPost"], 10, 64)
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	if reactionLimit != 0 {
 		uniqueEmojiNames := map[string]bool{reaction.EmojiName: true}
 		for _, r := range reactions {
 			uniqueEmojiNames[r.EmojiName] = true
 		}
 
-		if len(uniqueEmojiNames) >= *reactionLimit {
+		if len(uniqueEmojiNames) >= int(reactionLimit) {
 			return control.UserActionResponse{Info: "reaction limit reached"}
 		}
 	}

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -825,13 +825,18 @@ func (c *SimulController) addReaction(u user.User) control.UserActionResponse {
 		}
 	}
 
-	if reactionLimit := u.Store().Config().ServiceSettings.UniqueEmojiReactionLimitPerPost; reactionLimit != nil {
+	reactionLimit, err := strconv.ParseInt(u.Store().ClientConfig()["UniqueEmojiReactionLimitPerPost"], 10, 64)
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	}
+
+	if reactionLimit != 0 {
 		uniqueEmojiNames := map[string]bool{reaction.EmojiName: true}
 		for _, r := range reactions {
 			uniqueEmojiNames[r.EmojiName] = true
 		}
 
-		if len(uniqueEmojiNames) >= *reactionLimit {
+		if len(uniqueEmojiNames) >= int(reactionLimit) {
 			return control.UserActionResponse{Info: "reaction limit reached"}
 		}
 	}


### PR DESCRIPTION
The entire Config struct isn't set until the API call is made.
Clients are expected to use the ClientConfig which is guaranteed to be
always set before actions are called. So we use that instead.

https://mattermost.atlassian.net/browse/MM-56288
