### PR TITLE
MM-52240: Stop/Start DB Cluster after load test

### DIFF
--- a/cmd/ltctl/loadtest.go
+++ b/cmd/ltctl/loadtest.go
@@ -101,13 +101,13 @@ func RunLoadTestStartCmdF(cmd *cobra.Command, args []string) error {
 			time.Sleep(30 * time.Second)
 		}
 	} else if status != dbAvailable {
-		fmt.Println("The database isn't available at the moment. It might be either stopping or starting. Please wait until it has fully stopped or started, and then try again.")
+		fmt.Printf("The database isn't available at the moment. It's status is %q. Please wait until it has finished, and then try again. \n", status)
 		return nil
 	}
 
 	isSync, err := cmd.Flags().GetBool("sync")
 	if err != nil {
-		return fmt.Errorf("unable to check flag: %w", err)
+		return fmt.Errorf("unable to check -sync flag: %w", err)
 	}
 
 	// We simply return in async mode, which is the default.

--- a/cmd/ltctl/loadtest.go
+++ b/cmd/ltctl/loadtest.go
@@ -101,7 +101,7 @@ func RunLoadTestStartCmdF(cmd *cobra.Command, args []string) error {
 			time.Sleep(30 * time.Second)
 		}
 	} else if status != dbAvailable {
-		fmt.Printf("The database isn't available at the moment. It's status is %q. Please wait until it has finished, and then try again. \n", status)
+		fmt.Printf("The database isn't available at the moment. Its status is %q. Please wait until it has finished, and then try again. \n", status)
 		return nil
 	}
 
@@ -129,7 +129,7 @@ func RunLoadTestStartCmdF(cmd *cobra.Command, args []string) error {
 		}
 
 		if coordStatus.State == coordinator.Done {
-			fmt.Println("unbounded load-test has completed")
+			fmt.Println("load-test has completed")
 			break
 		}
 

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -85,6 +85,55 @@ func RunSyncCmdF(cmd *cobra.Command, args []string) error {
 	return t.Sync()
 }
 
+func RunStopDBCmdF(cmd *cobra.Command, args []string) error {
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	t, err := terraform.New("", config)
+	if err != nil {
+		return fmt.Errorf("failed to create terraform engine: %w", err)
+	}
+
+	return t.StopDB()
+}
+
+func RunStartDBCmdF(cmd *cobra.Command, args []string) error {
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	t, err := terraform.New("", config)
+	if err != nil {
+		return fmt.Errorf("failed to create terraform engine: %w", err)
+	}
+
+	return t.StartDB()
+}
+
+func RunDBStatusCmdF(cmd *cobra.Command, args []string) error {
+	config, err := getConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	t, err := terraform.New("", config)
+	if err != nil {
+		return fmt.Errorf("failed to create terraform engine: %w", err)
+	}
+
+	status, err := t.DBStatus()
+	if err != nil {
+		return fmt.Errorf("failed to get DB status: %w", err)
+	}
+
+	fmt.Println("Status: ", status)
+
+	return nil
+}
+
 func RunSSHListCmdF(cmd *cobra.Command, args []string) error {
 	config, err := getConfig(cmd)
 	if err != nil {
@@ -166,6 +215,21 @@ func main() {
 			Short: "Syncs the local .tfstate file with any changes made remotely",
 			RunE:  RunSyncCmdF,
 		},
+		{
+			Use:   "stop-db",
+			Short: "Stops the DB cluster and syncs the changes.",
+			RunE:  RunStopDBCmdF,
+		},
+		{
+			Use:   "start-db",
+			Short: "Starts the DB cluster and syncs the changes.",
+			RunE:  RunStartDBCmdF,
+		},
+		{
+			Use:   "db-info",
+			Short: "Display info about the DB cluster.",
+			RunE:  RunDBStatusCmdF,
+		},
 	}
 
 	deploymentCmd.AddCommand(deploymentCommands...)
@@ -185,12 +249,15 @@ func main() {
 	}
 	resetCmd.Flags().Bool("confirm", false, "Confirm you really want to reset the database and re-initialize it.")
 
+	ltStartCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the coordinator in the current load-test deployment",
+		RunE:  RunLoadTestStartCmdF,
+	}
+	ltStartCmd.Flags().Bool("sync", false, "Changes the command to not return until the test has finished, and then stops the DB after that")
+
 	loadtestComands := []*cobra.Command{
-		{
-			Use:   "start",
-			Short: "Start the coordinator in the current load-test deployment",
-			RunE:  RunLoadTestStartCmdF,
-		},
+		ltStartCmd,
 		{
 			Use:   "stop",
 			Short: "Stop the coordinator in the current load-test deployment",

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -174,7 +174,7 @@ func (t *Terraform) Create(initData bool) error {
 			"--vpc-security-group-ids=" + sgID,
 			"--region=" + t.config.AWSRegion,
 		}
-		if err := t.runAWSCommand(nil, args); err != nil {
+		if err := t.runAWSCommand(nil, args, nil); err != nil {
 			return err
 		}
 	}

--- a/deployment/terraform/db_operations.go
+++ b/deployment/terraform/db_operations.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package terraform
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// StopDB stops the DB cluster and syncs the changes.
+func (t *Terraform) StopDB() error {
+	if err := t.preFlightCheck(); err != nil {
+		return err
+	}
+
+	output, err := t.Output()
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"--profile=" + t.config.AWSProfile,
+		"rds",
+		"stop-db-cluster",
+		"--db-cluster-identifier=" + output.DBCluster.ClusterIdentifier,
+		"--region=" + t.config.AWSRegion,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := t.runAWSCommand(ctx, args, nil); err != nil {
+		return err
+	}
+
+	return t.Sync()
+}
+
+// StartDB starts the DB cluster and syncs the changes.
+func (t *Terraform) StartDB() error {
+	if err := t.preFlightCheck(); err != nil {
+		return err
+	}
+
+	output, err := t.Output()
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"--profile=" + t.config.AWSProfile,
+		"rds",
+		"start-db-cluster",
+		"--db-cluster-identifier=" + output.DBCluster.ClusterIdentifier,
+		"--region=" + t.config.AWSRegion,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := t.runAWSCommand(ctx, args, nil); err != nil {
+		return err
+	}
+
+	return t.Sync()
+}
+
+type rdsOutput struct {
+	DBCluster []struct {
+		DatabaseName        string `json:"DatabaseName"`
+		DBClusterIdentifier string `json:"DBClusterIdentifier"`
+		Status              string `json:"Status"`
+		Engine              string `json:"Engine"`
+		EngineVersion       string `json:"EngineVersion"`
+	} `json:"DBClusters"`
+}
+
+// DBStatus returns the status of the DB cluster.
+func (t *Terraform) DBStatus() (string, error) {
+	if err := t.preFlightCheck(); err != nil {
+		return "", err
+	}
+
+	output, err := t.Output()
+	if err != nil {
+		return "", err
+	}
+
+	if output.DBCluster.ClusterIdentifier == "" {
+		return "", errors.New("DB cluster identifier not found")
+	}
+
+	var buf bytes.Buffer
+	args := []string{
+		"--profile=" + t.config.AWSProfile,
+		"rds",
+		"describe-db-clusters",
+		"--db-cluster-identifier=" + output.DBCluster.ClusterIdentifier,
+		"--region=" + t.config.AWSRegion,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := t.runAWSCommand(ctx, args, &buf); err != nil {
+		return "", err
+	}
+
+	var out rdsOutput
+	err = json.Unmarshal(buf.Bytes(), &out)
+	if err != nil {
+		return "", err
+	}
+
+	if len(out.DBCluster) == 0 {
+		return "", fmt.Errorf("No DB Clusters found for cluster identifier: %s", output.DBCluster.ClusterIdentifier)
+	}
+
+	return out.DBCluster[0].Status, nil
+}

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -38,7 +38,7 @@ func (t *Terraform) Destroy() error {
 				"s3://" + t.output.S3Bucket.Id,
 				"--recursive",
 			}
-			if err := t.runAWSCommand(emptyBucketCtx, emptyS3BucketArgs); err != nil {
+			if err := t.runAWSCommand(emptyBucketCtx, emptyS3BucketArgs, nil); err != nil {
 				emptyBucketErrCh <- fmt.Errorf("failed to run local cmd \"aws %s\": %w", strings.Join(emptyS3BucketArgs, " "), err)
 				return
 			}
@@ -69,7 +69,7 @@ func (t *Terraform) Destroy() error {
 			"--skip-final-snapshot",
 		}
 		// We have to ignore if the cluster was already deleted to make the command idempotent.
-		if err := t.runAWSCommand(nil, args); err != nil && !strings.Contains(err.Error(), "DBClusterNotFoundFault") {
+		if err := t.runAWSCommand(nil, args, nil); err != nil && !strings.Contains(err.Error(), "DBClusterNotFoundFault") {
 			return err
 		}
 	}

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -43,7 +43,7 @@ func (t *Terraform) runCommand(dst io.Writer, args ...string) error {
 	return _runCommand(cmd, dst)
 }
 
-func (t *Terraform) runAWSCommand(ctx context.Context, args []string) error {
+func (t *Terraform) runAWSCommand(ctx context.Context, args []string, dst io.Writer) error {
 	awsBin := "aws"
 	if _, err := exec.LookPath(awsBin); err != nil {
 		return fmt.Errorf("aws not installed. Please install aws. (https://aws.amazon.com/cli): %w", err)
@@ -58,7 +58,7 @@ func (t *Terraform) runAWSCommand(ctx context.Context, args []string) error {
 	mlog.Debug("Running aws command", mlog.String("args", fmt.Sprintf("%v", args)))
 	cmd := exec.CommandContext(ctx, awsBin, args...)
 
-	return _runCommand(cmd, nil)
+	return _runCommand(cmd, dst)
 }
 
 func _runCommand(cmd *exec.Cmd, dst io.Writer) error {

--- a/deployment/terraform/info.go
+++ b/deployment/terraform/info.go
@@ -57,6 +57,7 @@ func displayInfo(output *Output) {
 		fmt.Println("Pyroscope URL: http://" + output.MetricsServer.PublicIP + ":4040")
 	}
 	if output.HasDB() {
+		fmt.Println("DB Cluster Identifier: ", output.DBCluster.ClusterIdentifier)
 		fmt.Println("DB writer endpoint: " + output.DBWriter())
 		for _, rd := range output.DBReaders() {
 			fmt.Println("DB reader endpoint: " + rd)

--- a/deployment/terraform/output.go
+++ b/deployment/terraform/output.go
@@ -18,7 +18,8 @@ type output struct {
 	} `json:"instances"`
 	DBCluster struct {
 		Value []struct {
-			Endpoint string `json:"endpoint"`
+			Endpoint          string `json:"endpoint"`
+			ClusterIdentifier string `json:"cluster_identifier"`
 		} `json:"value"`
 	} `json:"dbCluster"`
 	Agents struct {
@@ -82,7 +83,8 @@ type Tags struct {
 
 // DBCluster defines a RDS cluster instance resource.
 type DBCluster struct {
-	Endpoints []string `json:"endpoint"`
+	Endpoints         []string `json:"endpoint"`
+	ClusterIdentifier string   `json:"cluster_identifier"`
 }
 
 // IAMAccess is a set of credentials that allow API requests to be made as an IAM user.
@@ -132,6 +134,7 @@ func (t *Terraform) loadOutput() error {
 		for _, ep := range o.DBCluster.Value {
 			outputv2.DBCluster.Endpoints = append(outputv2.DBCluster.Endpoints, ep.Endpoint)
 		}
+		outputv2.DBCluster.ClusterIdentifier = o.DBCluster.Value[0].ClusterIdentifier
 	}
 	if len(o.MetricsServer.Value) > 0 {
 		outputv2.MetricsServer = o.MetricsServer.Value[0]


### PR DESCRIPTION
We add the ability to stop/start the DB cluster after a load-test is complete.

There is a dedicated command that the users can run any time. Additionally, there is also an automated way to stop the DB after a load test finishes, which is exposed via a flag.

Using the flag makes the load test runs synchronously, so it is advised to be used only by advanced users running the command preferably inside an EC2 instance in a screen session.

https://mattermost.atlassian.net/browse/MM-52240
