### PR TITLE
MM-56918: Ingest the DB dump from inside Terraform.Create

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -27,20 +27,12 @@ func RunCreateCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create terraform engine: %w", err)
 	}
 
-	// If DBDumpURI is not set, we seed data. Otherwise,
-	// we just load the dump.
 	initData := config.DBDumpURI == ""
 	err = t.Create(initData)
 	if err != nil {
 		return fmt.Errorf("failed to create terraform env: %w", err)
 	}
 
-	if !initData {
-		err = t.IngestDump()
-		if err != nil {
-			return fmt.Errorf("failed to create ingest dump: %w", err)
-		}
-	}
 	return nil
 }
 

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -226,6 +226,14 @@ func (t *Terraform) Create(initData bool) error {
 	// Otherwise, the vacuuming command will fail because no tables would
 	// have been created by then.
 	if t.output.HasDB() {
+		// Load the dump if specified
+		if !initData && t.config.DBDumpURI != "" {
+			err = t.IngestDump()
+			if err != nil {
+				return fmt.Errorf("failed to create ingest dump: %w", err)
+			}
+		}
+
 		if t.config.TerraformDBSettings.InstanceEngine == "aurora-postgresql" {
 			// updatePostgresSettings does some housekeeping stuff like setting
 			// default_search_config and vacuuming tables.


### PR DESCRIPTION
#### Summary
When using `config.DBDumpURI`, the generated DB did not get the settings applied from `updatePostgresSettings`, since the latter was executed before ingesting the dump. We cannot simply move the call to `IngestDump` before the call to `Create`, though, because we need the DB cluster up and running to ingest the dump. Thus, this PR moves the call to `IngestDump` inside `Create`, after the DB cluster creation and right before updating the settings.

I'm testing a deployment with these changes as we speak.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56918
