### PR TITLE
MM-56786: Adjust PercentOfUsersAreAdmin

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -50,7 +50,7 @@
     "UsersFilePath": "",
     "MaxActiveUsers": 2000,
     "AvgSessionsPerUser": 1,
-    "PercentOfUsersAreAdmin": 0.02
+    "PercentOfUsersAreAdmin": 0.0005
   },
   "LogSettings": {
     "EnableConsole": true,

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -136,7 +136,7 @@ type UsersConfiguration struct {
 	// The average number of sessions per user.
 	AvgSessionsPerUser int `default:"1" validate:"range:[1,]"`
 	// The percentage of users generated that will be system admins
-	PercentOfUsersAreAdmin float64 `default:"0.02" validate:"range:[0,1]"`
+	PercentOfUsersAreAdmin float64 `default:"0.0005" validate:"range:[0,1]"`
 }
 
 // Config holds information needed to create and initialize a new load-test

--- a/loadtest/user/userentity/helper_test.go
+++ b/loadtest/user/userentity/helper_test.go
@@ -50,7 +50,7 @@ type config struct {
 		InitialActiveUsers     int     `default:"0" validate:"range:[0,$MaxActiveUsers]"`
 		MaxActiveUsers         int     `default:"2000" validate:"range:(0,]"`
 		AvgSessionsPerUser     int     `default:"1" validate:"range:[1,]"`
-		PercentOfUsersAreAdmin float64 `default:"0.02" validate:"range:[0,1]"`
+		PercentOfUsersAreAdmin float64 `default:"0.0005" validate:"range:[0,1]"`
 	}
 	LogSettings logger.Settings
 }


### PR DESCRIPTION
#### Summary
[The investigation](https://community.mattermost.com/core/pl/kjs9bdxgw7fk7jpuyai1hcpjuh) showed no significant differences in the behaviour of the system between 0%, 0.05% and 2% of users admin, but it did show that our default value here was two orders of magnitude larger than what we see out there.

Will cherry-pick this into `release-1.14` as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56786