### PR TITLE
MM-56989: Sanitize collected MM config

### DIFF
--- a/cmd/ltctl/collect.go
+++ b/cmd/ltctl/collect.go
@@ -192,7 +192,9 @@ func collect(config deployment.Config, deploymentId string, outputName string) e
 			addInfo(name, "/opt/mattermost/logs/mattermost.log", true, nil)
 			addInfo(name, "/opt/mattermost/config/config.json", false, func(input []byte) ([]byte, error) {
 				var cfg model.Config
-				json.Unmarshal(input, &cfg)
+				if err := json.Unmarshal(input, &cfg); err != nil {
+					return nil, fmt.Errorf("failed to unmarshal MM configuration: %w", err)
+				}
 				cfg.Sanitize()
 				sanitizedCfg, err := json.MarshalIndent(cfg, "", "  ")
 				if err != nil {


### PR DESCRIPTION
#### Summary
This PR adds an optional step for all files collected during the `collect` command: a `func(input []bytes) ([]bytes, error)` that is called when the corresponding file is downloaded from the instance and before adding it to the collection.

This is used for all app nodes to sanitize the config retrieved from them. As an example, this is an excerpt of the `FileSettings` section in the generated file:

```json
  "FileSettings": {
    "PublicLinkSalt": "********************************",
    "InitialFont": "nunito-bold.ttf",
    "AmazonS3AccessKeyId": "AKIA2TV23Z44BXMGHWOE",
    "AmazonS3SecretAccessKey": "********************************",
    "AmazonS3Bucket": "mm569896989agm.s3bucket",
    "AmazonS3PathPrefix": "",
  },
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56989

