### PR TITLE
Uniformly load-balance connections across cores

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -203,7 +203,7 @@ upstream backend {
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_size=3g inactive=120m use_temp_path=off;
 
 server {
-  listen 80;
+  listen 80 reuseport;
   server_name _;
 
   location ~ /api/v[0-9]+/(users/)?websocket$ {


### PR DESCRIPTION
Our current model uses a single TCP accept queue and shares
it across all workers. Unfortunately, Linux uses a FIFO model
which will push new connections to the busiest connection
leading to a scenario where some workers will not get
any connection at all.

```
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3332/nginx" | wc -l
3769
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3333/nginx" | wc -l
9846
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3334/nginx" | wc -l
898
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3331/nginx" | wc -l
59114
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3335/nginx" | wc -l
98
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3336/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3337/nginx" | wc -l
27425
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3338/nginx" | wc -l
11
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3339/nginx" | wc -l
2
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3340/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3341/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3342/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3343/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3344/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3345/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3346/nginx" | wc -l
0
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "3347/nginx" | wc -l
0
```

This means that the busiest worker will have most connections leading
to the chances of it exceeding the max_connections setting.

Using REUSEPORT indicates the kernel to set up separate accept queues
per worker leading to a uniform usage across workers.

Thw downside is that this can lead to non-uniform latency if one worker
gets busy, so connections in that queue won't be able to respond quickly
enough. This is not applicable in our case since we use nginx only as a
proxy.

After changes. (Although it's at a lower total websocket count, but we
                can see the even distribution)

```
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7071/nginx"  | wc -l
607
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7072/nginx"  | wc -l
591
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7073/nginx"  | wc -l
619
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7074/nginx"  | wc -l
584
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7075/nginx"  | wc -l
611
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7076/nginx"  | wc -l
654
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7077/nginx"  | wc -l
593
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7078/nginx"  | wc -l
606
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7079/nginx"  | wc -l
631
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7080/nginx"  | wc -l
622
ubuntu@ip-172-27-47-66:~$ sudo netstat -p | grep "7081/nginx"  | wc -l
602
```

https://blog.cloudflare.com/the-sad-state-of-linux-socket-balancing/
