### PR TITLE
Prevent nginx from flagging temporarily unavailable backends as dead

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -423,7 +423,7 @@ func (t *Terraform) setupProxyServer(extAgent *ssh.ExtAgent) {
 
 		backends := ""
 		for _, addr := range t.output.Instances {
-			backends += "server " + addr.PrivateIP + ":8065 max_fails=3;\n"
+			backends += "server " + addr.PrivateIP + ":8065 max_fails=0;\n"
 		}
 
 		nginxConfig, err := genNginxConfig()


### PR DESCRIPTION
#### Summary

There was an interesting race condition that could happen during automated comparisons due to `nginx` temporarily flagging the app servers as unavailable. This could result in requests to running app servers to preemptively fail for up to [`fail_timeout`](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#server) seconds (defaults to 10s). 

In the case of the reported issue these requests were made during agent creation which caused the whole comparison to fail even though the app server was already up and running (meaning [this check](https://github.com/mattermost/mattermost-load-test-ng/blob/6dcb79e4c2cc4bbfa9facfe0227d83206ca14583/comparison/loadtest.go#L186) passed successfully).

Setting `max_fails=0` should disable any mechanism to flag dead backends which I think is reasonable under our testing conditions as requests should be attempted regardless of previous failures.

The full investigation/issue is at https://community.mattermost.com/core/pl/5xewf765x7d4drueknseu7k9sy
