### PR TITLE
Add *.tar to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ config/metricswatcher.json
 mattermost-load-test.iml
 
 .terraform.tfstate.lock.info
+
+*.tar


### PR DESCRIPTION
#### Summary
Since the `collect` command drops a *.tar file into the main directory you're running the load tester from, it makes sense to ignore those for the Git repository, so they aren't accidentally committed/sitting in your unstaged changes.

