### PR TITLE
MM-56605: Create results file and print to file

### DIFF
--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -175,7 +175,6 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		// Call writeResults and handle any errors it returns
 		err := writeResults(output.Results, multiWriter)
 		if err != nil {
-			fmt.Println("Error:", err)
 			return fmt.Errorf("failed to write results: %w", err)
 		}
 

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -63,7 +63,7 @@ func getReportFilename(id int, res comparison.Result) string {
 	return fmt.Sprintf("report_%s.md", name)
 }
 
-func printResults(results []comparison.Result) {
+func writeToFile() {
 	var resultsFile *os.File
 
 	// Create or open the file for writing
@@ -73,6 +73,16 @@ func printResults(results []comparison.Result) {
 		return
 	}
 	defer resultsFile.Close()
+
+}
+
+func printResults(results []comparison.Result, resultsFile *os.File) {
+	_, err := fmt.Println("Error with file:")
+
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
 
 	for i, res := range results {
 		_, err = fmt.Fprintf(resultsFile, "==================================================")

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -101,7 +101,7 @@ func printResults(results []comparison.Result, writer io.Writer) {
 			} else if ltRes.Config.Type == comparison.LoadTestTypeUnbounded {
 				fmt.Fprintf(writer, "  Supported Users: %d\n", ltRes.Status.SupportedUsers)
 			}
-			fmt.Printf("  Errors: %d\n", ltRes.Status.NumErrors)
+			fmt.Fprintf(writer, "  Errors: %d\n", ltRes.Status.NumErrors)
 		}
 		fmt.Fprintf(writer, "==================================================\n\n")
 	}

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -67,8 +67,8 @@ func writeResults(results []comparison.Result, writer io.Writer) error {
 	var content string
 
 	for i, res := range results {
-		content += ("==================================================")
-		content += ("Comparison result:")
+		content += "=================================================="
+		content += "Comparison result:"
 		content += fmt.Sprintf("Report: %s\n", getReportFilename(i, res))
 		content += fmt.Sprintf("Grafana Dashboard: %s\n", res.DashboardURL)
 		for _, ltRes := range res.LoadTests {
@@ -83,7 +83,7 @@ func writeResults(results []comparison.Result, writer io.Writer) error {
 			}
 			content += fmt.Sprintf("  Errors: %d\n", ltRes.Status.NumErrors)
 		}
-		content += ("==================================================\n\n")
+		content += "==================================================\n\n"
 	}
 	_, err := fmt.Fprintf(writer, content)
 	return err
@@ -162,7 +162,7 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to write reports: %w", err)
 		}
 
-		//write to file here
+		//create the file
 		resultsFile, errResult := os.Create(filepath.Join(outputPath, "results.txt"))
 		if errResult != nil {
 			fmt.Println("Error:", errResult)
@@ -172,7 +172,12 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 
 		multiWriter := io.MultiWriter(resultsFile, os.Stdout)
 
-		writeResults(output.Results, multiWriter)
+		// Call writeResults and handle any errors it returns
+		err := writeResults(output.Results, multiWriter)
+		if err != nil {
+			fmt.Println("Error:", err)
+			return fmt.Errorf("failed to write results: %w", err)
+		}
 
 		if archive {
 			if err := createArchive(outputPath, archivePath); err != nil {

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -64,28 +64,48 @@ func getReportFilename(id int, res comparison.Result) string {
 }
 
 func printResults(results []comparison.Result) {
+	var resultsFile *os.File
+
+	// Create or open the file for writing
+	resultsFile, err := os.Create("results.txt")
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	defer resultsFile.Close()
+
 	for i, res := range results {
-		fmt.Println("==================================================")
-		fmt.Println("Comparison result:")
+		_, err = fmt.Fprintf(resultsFile, "==================================================")
+		if err != nil {
+			fmt.Println("Error:", err)
+			return
+		}
+
+		_, err = fmt.Fprintf(resultsFile, "Comparison result:")
+		if err != nil {
+			fmt.Println("Error:", err)
+			return
+		}
+
 		if res.Report != "" {
-			fmt.Printf("Report: %s\n", getReportFilename(i, res))
+			fmt.Fprintf(resultsFile, "Report: %s\n", getReportFilename(i, res))
 		}
 		if res.DashboardURL != "" {
-			fmt.Printf("Grafana Dashboard: %s\n", res.DashboardURL)
+			fmt.Fprintf(resultsFile, "Grafana Dashboard: %s\n", res.DashboardURL)
 		}
 		for _, ltRes := range res.LoadTests {
-			fmt.Printf("%s:\n", ltRes.Label)
-			fmt.Printf("  Type: %s\n", ltRes.Config.Type)
-			fmt.Printf("  DB Engine: %s\n", ltRes.Config.DBEngine)
+			fmt.Fprintf(resultsFile, "%s:\n", ltRes.Label)
+			fmt.Fprintf(resultsFile, "  Type: %s\n", ltRes.Config.Type)
+			fmt.Fprintf(resultsFile, "  DB Engine: %s\n", ltRes.Config.DBEngine)
 			if ltRes.Config.Type == comparison.LoadTestTypeBounded {
-				fmt.Printf("  Duration: %s\n", ltRes.Config.Duration)
-				fmt.Printf("  Users: %d\n", ltRes.Config.NumUsers)
+				fmt.Fprintf(resultsFile, "  Duration: %s\n", ltRes.Config.Duration)
+				fmt.Fprintf(resultsFile, "  Users: %d\n", ltRes.Config.NumUsers)
 			} else if ltRes.Config.Type == comparison.LoadTestTypeUnbounded {
-				fmt.Printf("  Supported Users: %d\n", ltRes.Status.SupportedUsers)
+				fmt.Fprintf(resultsFile, "  Supported Users: %d\n", ltRes.Status.SupportedUsers)
 			}
 			fmt.Printf("  Errors: %d\n", ltRes.Status.NumErrors)
 		}
-		fmt.Printf("==================================================\n\n")
+		fmt.Fprintf(resultsFile, "==================================================\n\n")
 	}
 }
 

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -63,17 +63,14 @@ func getReportFilename(id int, res comparison.Result) string {
 	return fmt.Sprintf("report_%s.md", name)
 }
 
-func writeToFile() {
-	var resultsFile *os.File
-
+func writeToFile() *os.File {
 	// Create or open the file for writing
 	resultsFile, err := os.Create("results.txt")
 	if err != nil {
 		fmt.Println("Error:", err)
-		return
+		return nil
 	}
-	defer resultsFile.Close()
-
+	return resultsFile
 }
 
 func printResults(results []comparison.Result, resultsFile *os.File) {

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -165,7 +165,7 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		//create the file
 		resultsFile, errResult := os.Create(filepath.Join(outputPath, "results.txt"))
 		if errResult != nil {
-			return fmt.Errorf("failed to create file: %w", err)
+			return fmt.Errorf("failed to create file: %w", errResult)
 		}
 		defer resultsFile.Close()
 

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -63,7 +63,7 @@ func getReportFilename(id int, res comparison.Result) string {
 	return fmt.Sprintf("report_%s.md", name)
 }
 
-func writeToFile() *os.File {
+func writeToFile() io.Writer {
 	// Create or open the file for writing
 	resultsFile, err := os.Create("results.txt")
 	if err != nil {
@@ -74,9 +74,9 @@ func writeToFile() *os.File {
 
 }
 
-func printResults(results []comparison.Result, resultsFile *os.File) {
+func printResults(results []comparison.Result, writer io.Writer) {
 	// Create a multi writer to write to both resultsFile and os.Stdout
-	multiWriter := io.MultiWriter(resultsFile, os.Stdout)
+	multiWriter := io.MultiWriter(writer, os.Stdout)
 
 	_, err := fmt.Println("Error with file:")
 
@@ -116,7 +116,7 @@ func printResults(results []comparison.Result, resultsFile *os.File) {
 			}
 			fmt.Printf("  Errors: %d\n", ltRes.Status.NumErrors)
 		}
-		fmt.Fprintf(resultsFile, "==================================================\n\n")
+		fmt.Fprintf(multiWriter, "==================================================\n\n")
 	}
 }
 

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -71,9 +71,13 @@ func writeToFile() *os.File {
 		return nil
 	}
 	return resultsFile
+
 }
 
 func printResults(results []comparison.Result, resultsFile *os.File) {
+	// Create a multi writer to write to both resultsFile and os.Stdout
+	multiWriter := io.MultiWriter(resultsFile, os.Stdout)
+
 	_, err := fmt.Println("Error with file:")
 
 	if err != nil {
@@ -82,33 +86,33 @@ func printResults(results []comparison.Result, resultsFile *os.File) {
 	}
 
 	for i, res := range results {
-		_, err = fmt.Fprintf(resultsFile, "==================================================")
+		_, err = fmt.Fprintf(multiWriter, "==================================================")
 		if err != nil {
 			fmt.Println("Error:", err)
 			return
 		}
 
-		_, err = fmt.Fprintf(resultsFile, "Comparison result:")
+		_, err = fmt.Fprintf(multiWriter, "Comparison result:")
 		if err != nil {
 			fmt.Println("Error:", err)
 			return
 		}
 
 		if res.Report != "" {
-			fmt.Fprintf(resultsFile, "Report: %s\n", getReportFilename(i, res))
+			fmt.Fprintf(multiWriter, "Report: %s\n", getReportFilename(i, res))
 		}
 		if res.DashboardURL != "" {
-			fmt.Fprintf(resultsFile, "Grafana Dashboard: %s\n", res.DashboardURL)
+			fmt.Fprintf(multiWriter, "Grafana Dashboard: %s\n", res.DashboardURL)
 		}
 		for _, ltRes := range res.LoadTests {
-			fmt.Fprintf(resultsFile, "%s:\n", ltRes.Label)
-			fmt.Fprintf(resultsFile, "  Type: %s\n", ltRes.Config.Type)
-			fmt.Fprintf(resultsFile, "  DB Engine: %s\n", ltRes.Config.DBEngine)
+			fmt.Fprintf(multiWriter, "%s:\n", ltRes.Label)
+			fmt.Fprintf(multiWriter, "  Type: %s\n", ltRes.Config.Type)
+			fmt.Fprintf(multiWriter, "  DB Engine: %s\n", ltRes.Config.DBEngine)
 			if ltRes.Config.Type == comparison.LoadTestTypeBounded {
-				fmt.Fprintf(resultsFile, "  Duration: %s\n", ltRes.Config.Duration)
-				fmt.Fprintf(resultsFile, "  Users: %d\n", ltRes.Config.NumUsers)
+				fmt.Fprintf(multiWriter, "  Duration: %s\n", ltRes.Config.Duration)
+				fmt.Fprintf(multiWriter, "  Users: %d\n", ltRes.Config.NumUsers)
 			} else if ltRes.Config.Type == comparison.LoadTestTypeUnbounded {
-				fmt.Fprintf(resultsFile, "  Supported Users: %d\n", ltRes.Status.SupportedUsers)
+				fmt.Fprintf(multiWriter, "  Supported Users: %d\n", ltRes.Status.SupportedUsers)
 			}
 			fmt.Printf("  Errors: %d\n", ltRes.Status.NumErrors)
 		}

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -67,8 +67,8 @@ func writeResults(results []comparison.Result, writer io.Writer) error {
 	var content string
 
 	for i, res := range results {
-		content += fmt.Sprintf("==================================================")
-		content += fmt.Sprintf("Comparison result:")
+		content += ("==================================================")
+		content += ("Comparison result:")
 		content += fmt.Sprintf("Report: %s\n", getReportFilename(i, res))
 		content += fmt.Sprintf("Grafana Dashboard: %s\n", res.DashboardURL)
 		for _, ltRes := range res.LoadTests {
@@ -83,7 +83,7 @@ func writeResults(results []comparison.Result, writer io.Writer) error {
 			}
 			content += fmt.Sprintf("  Errors: %d\n", ltRes.Status.NumErrors)
 		}
-		content += fmt.Sprintf("==================================================\n\n")
+		content += ("==================================================\n\n")
 	}
 	_, err := fmt.Fprintf(writer, content)
 	return err

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -165,7 +165,6 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		//create the file
 		resultsFile, errResult := os.Create(filepath.Join(outputPath, "results.txt"))
 		if errResult != nil {
-			fmt.Println("Error:", errResult)
 			return fmt.Errorf("failed to create file: %w", err)
 		}
 		defer resultsFile.Close()

--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -163,7 +163,7 @@ func RunComparisonCmdF(cmd *cobra.Command, args []string) error {
 		}
 
 		//write to file here
-		resultsFile, errResult := os.Create("results.txt")
+		resultsFile, errResult := os.Create(filepath.Join(outputPath, "results.txt"))
 		if errResult != nil {
 			fmt.Println("Error:", errResult)
 			return fmt.Errorf("failed to create file: %w", err)

--- a/cmd/ltctl/comparison_test.go
+++ b/cmd/ltctl/comparison_test.go
@@ -3,6 +3,10 @@ package main
 import (
 	"bytes"
 	"testing"
+
+	"github.com/mattermost/mattermost-load-test-ng/comparison"
+	"github.com/mattermost/mattermost-load-test-ng/coordinator"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrintResults(t *testing.T) {
@@ -10,20 +14,20 @@ func TestPrintResults(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	// Prepare test data
-	results := []Result{
+	results := []comparison.Result{
 		{
 			Report:       "Sample Report",
 			DashboardURL: "http://example.com/dashboard",
-			LoadTests: []LoadTestResult{
+			LoadTests: [2]comparison.LoadTestResult{
 				{
 					Label: "Test1",
-					Config: LoadTestConfig{
+					Config: comparison.LoadTestConfig{
 						Type:     "bounded",
 						DBEngine: "postgres",
 						NumUsers: 100,
 						Duration: "10m",
 					},
-					Status: LoadTestStatus{
+					Status: coordinator.Status{
 						SupportedUsers: 80,
 						NumErrors:      2,
 					},
@@ -31,17 +35,12 @@ func TestPrintResults(t *testing.T) {
 			},
 		},
 	}
-}
 	// Call the function with the test data and the buffer
-  printResults(results, buf)
+	printResults(results, buf)
 
 	// Verify the output
-	expectedOutput := `==================================================
-Comparison result:
-Report: Sample Report
-Grafana Dashboard: http://example.com/dashboard
-Test1:
-  Type: bounded
+	expectedOutput := `==================================================Comparison result:Report: report_0_postgres_bounded_100.md
+Grafana Dashboard: http://example.com/dashboard\nTest:1\nType: bounded
   DB Engine: postgres
   Duration: 10m
   Users: 100

--- a/cmd/ltctl/comparison_test.go
+++ b/cmd/ltctl/comparison_test.go
@@ -49,7 +49,7 @@ func TestPrintResults(t *testing.T) {
 		},
 	}
 	// Call the function with the test data and the buffer
-	printResults(results, buf)
+	writeResults(results, buf)
 
 	// Verify the output
 	expectedOutput := `==================================================Comparison result:Report: report_0_postgres_bounded_100.md

--- a/cmd/ltctl/comparison_test.go
+++ b/cmd/ltctl/comparison_test.go
@@ -40,13 +40,13 @@ func TestPrintResults(t *testing.T) {
 
 	// Verify the output
 	expectedOutput := `==================================================Comparison result:Report: report_0_postgres_bounded_100.md
-Grafana Dashboard: http://example.com/dashboard\nTest:1\nType: bounded
+Grafana Dashboard: http://example.com/dashboard
+Test:1
+  Type: bounded
   DB Engine: postgres
   Duration: 10m
   Users: 100
   Errors: 2
-==================================================
-
-`
+==================================================`
 	require.Equal(t, expectedOutput, buf.String())
 }

--- a/cmd/ltctl/comparison_test.go
+++ b/cmd/ltctl/comparison_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPrintResults(t *testing.T) {
+	// Create a buffer to capture the output
+	buf := &bytes.Buffer{}
+
+	// Prepare test data
+	results := []Result{
+		{
+			Report:       "Sample Report",
+			DashboardURL: "http://example.com/dashboard",
+			LoadTests: []LoadTestResult{
+				{
+					Label: "Test1",
+					Config: LoadTestConfig{
+						Type:     "bounded",
+						DBEngine: "postgres",
+						NumUsers: 100,
+						Duration: "10m",
+					},
+					Status: LoadTestStatus{
+						SupportedUsers: 80,
+						NumErrors:      2,
+					},
+				},
+			},
+		},
+	}
+}
+	// Call the function with the test data and the buffer
+  printResults(results, buf)
+
+	// Verify the output
+	expectedOutput := `==================================================
+Comparison result:
+Report: Sample Report
+Grafana Dashboard: http://example.com/dashboard
+Test1:
+  Type: bounded
+  DB Engine: postgres
+  Duration: 10m
+  Users: 100
+  Errors: 2
+==================================================
+
+`
+	require.Equal(t, expectedOutput, buf.String())
+}

--- a/cmd/ltctl/comparison_test.go
+++ b/cmd/ltctl/comparison_test.go
@@ -32,6 +32,19 @@ func TestPrintResults(t *testing.T) {
 						NumErrors:      2,
 					},
 				},
+				{
+					Label: "Test2",
+					Config: comparison.LoadTestConfig{
+						Type:     "bounded",
+						DBEngine: "postgres",
+						NumUsers: 100,
+						Duration: "10m",
+					},
+					Status: coordinator.Status{
+						SupportedUsers: 80,
+						NumErrors:      2,
+					},
+				},
 			},
 		},
 	}
@@ -41,12 +54,20 @@ func TestPrintResults(t *testing.T) {
 	// Verify the output
 	expectedOutput := `==================================================Comparison result:Report: report_0_postgres_bounded_100.md
 Grafana Dashboard: http://example.com/dashboard
-Test:1
+Test1:
   Type: bounded
   DB Engine: postgres
   Duration: 10m
   Users: 100
   Errors: 2
-==================================================`
+Test2:
+  Type: bounded
+  DB Engine: postgres
+  Duration: 10m
+  Users: 100
+  Errors: 2
+==================================================
+
+`
 	require.Equal(t, expectedOutput, buf.String())
 }


### PR DESCRIPTION
#### Summary
This will create a the `results.txt` file and write the results blocks to it eliminating the need to manually copy from the console. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56605
