### PR TITLE
Missing comma in deployer.json

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -14,7 +14,7 @@
     "InstanceType": "r6g.large.search",
     "VpcID": "",
     "Version": "Elasticsearch_7.10",
-    "CreateRole": false
+    "CreateRole": false,
     "SnapshotRepository": "",
     "SnapshotName": ""
   },


### PR DESCRIPTION
Added a missing comma to the example deployer.json