### PR TITLE
Skip Elasticsearch validation if InstanceCount = 0

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -270,12 +270,16 @@ func checkPrefix(str string) bool {
 }
 
 func (c *Config) validateElasticSearchConfig() error {
+	if c.ElasticSearchSettings.InstanceCount == 0 {
+		return nil
+	}
+
 	if (c.ElasticSearchSettings != ElasticSearchSettings{}) {
 		if c.ElasticSearchSettings.InstanceCount > 1 {
 			return errors.New("it is not possible to create more than 1 instance of Elasticsearch")
 		}
 
-		if c.ElasticSearchSettings.InstanceCount > 0 && c.ElasticSearchSettings.VpcID == "" {
+		if c.ElasticSearchSettings.VpcID == "" {
 			return errors.New("VpcID must be set in order to create an Elasticsearch instance")
 		}
 


### PR DESCRIPTION
#### Summary
In order to avoid spurious error messages, we simply skip the validation of the Elasticsearch settings whenever it's disabled; i.e., when `InstanceCount == 0`

#### Ticket Link
Fixes #735 