### PR TITLE
MM-58178: Apply server side TCP buffer settings to client

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -247,6 +247,16 @@ net.ipv4.tcp_fin_timeout = 30
 
 # Reuse TIME-WAIT sockets for new outgoing connections.
 net.ipv4.tcp_tw_reuse = 1
+
+# TCP buffer sizes are tuned for 10Gbit/s bandwidth and 0.5ms RTT (as measured intra EC2 cluster).
+# This gives a BDP (bandwidth-delay-product) of 625000 bytes.
+net.ipv4.tcp_rmem = 4096 156250 625000
+net.ipv4.tcp_wmem = 4096 156250 625000
+net.core.rmem_max = 312500
+net.core.wmem_max = 312500
+net.core.rmem_default = 312500
+net.core.wmem_default = 312500
+net.ipv4.tcp_mem = 1638400 1638400 1638400
 `
 
 const serverSysctlConfig = `


### PR DESCRIPTION
In our investigation, we could see more packet drops on the client
side than server side. This would indicate that the TCP buffer
sizes on the client side need some bumping as well.

https://mattermost.atlassian.net/browse/MM-58178
