### PR TITLE
[WIP] Add "wizard createconfig" command to easily populate configuration files

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -420,6 +420,31 @@ func main() {
 	comparisonCmd.AddCommand(runComparisonCmd, destroyComparisonCmd, collectComparisonCmd)
 	rootCmd.AddCommand(comparisonCmd)
 
+	wizardCmd := &cobra.Command{
+		Use:               "wizard",
+		Short:             "Wizard utilities to setup the",
+		PersistentPreRun:  func(cmd *cobra.Command, _ []string) { setServiceEnv(cmd) },
+		PersistentPostRun: func(_ *cobra.Command, _ []string) { os.Unsetenv("MM_SERVICEENVIRONMENT") },
+	}
+
+	wizardCreateConfigCmd := &cobra.Command{
+		Use:   "createconfig",
+		Short: "Create configuration files",
+		RunE:  RunWizardCreateConfigF,
+	}
+	wizardCreateConfigCmd.Flags().Bool("create-config", true, "Create a config.json file")
+	wizardCreateConfigCmd.Flags().Bool("create-deployer", true, "Create a deployer.json file")
+	wizardCreateConfigCmd.Flags().Int("active-users", 1000, "Number of expected concurrent active users")
+	wizardCreateConfigCmd.Flags().Bool("with-elasticsearch", false, "Enable Elasticsearch")
+	wizardCreateConfigCmd.Flags().Bool("with-keycloak", false, "Enable Keycloak")
+	// cmd.Flags().String("license-file-path", "", "Path to the license file")
+	// cmd.MarkFlagRequired("license-file-path")
+
+	wizardCmdCommands := []*cobra.Command{wizardCreateConfigCmd}
+
+	wizardCmd.AddCommand(wizardCmdCommands...)
+	rootCmd.AddCommand(wizardCmd)
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/ltctl/wizard.go
+++ b/cmd/ltctl/wizard.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mattermost/mattermost-load-test-ng/defaults"
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest"
+	"github.com/spf13/cobra"
+)
+
+func RunWizardCreateConfigF(cmd *cobra.Command, args []string) error {
+	activeUsers, err := cmd.Flags().GetInt("active-users")
+	if err != nil {
+		return fmt.Errorf("failed to get active users flag: %w", err)
+	}
+
+	arch, ok := deployment.Architectures[activeUsers]
+	if !ok {
+		var keys []string
+		for k := range deployment.Architectures {
+			keys = append(keys, fmt.Sprintf("%d", k))
+		}
+		return fmt.Errorf("reference architecture for %d users not found. Use one of: %s", activeUsers, keys)
+	}
+
+	createDeployerConfig, err := cmd.Flags().GetBool("create-deployer")
+	if err != nil {
+		return fmt.Errorf("failed to get create deployer flag: %w", err)
+	}
+
+	if createDeployerConfig {
+		deployerConfig := deployment.Config{}
+		defaults.Set(&deployerConfig)
+
+		deployerConfig.AppInstanceCount = arch.AppServers.Count
+		deployerConfig.AppInstanceType = arch.AppServers.InstanceType
+
+		deployerConfig.TerraformDBSettings.InstanceCount = arch.DatabaseServer.Count
+		deployerConfig.TerraformDBSettings.InstanceType = arch.DatabaseServer.InstanceType
+
+		if err := writeToFile("./config/deployer.json", deployerConfig); err != nil {
+			return fmt.Errorf("failed to write deployer config: %w", err)
+		}
+	}
+
+	createConfig, err := cmd.Flags().GetBool("create-config")
+	if err != nil {
+		return fmt.Errorf("failed to get create deployer flag: %w", err)
+	}
+
+	if createConfig {
+		config := loadtest.Config{}
+		defaults.Set(&config)
+
+		if err := writeToFile("./config/config.json", config); err != nil {
+			return fmt.Errorf("failed to write config: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func writeToFile(filename string, cfg any) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", filename, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("failed to write %s: %w", filename, err)
+	}
+
+	return nil
+}

--- a/deployment/infrastructure.go
+++ b/deployment/infrastructure.go
@@ -1,0 +1,26 @@
+package deployment
+
+type Server struct {
+	Count        int
+	InstanceType string
+}
+
+type ReferenceArchitecture struct {
+	ActiveUsers    int
+	AppServers     Server
+	DatabaseServer Server
+}
+
+var Architectures = map[int]ReferenceArchitecture{
+	100: {
+		ActiveUsers: 100,
+		AppServers: Server{
+			Count:        1,
+			InstanceType: "c6i.large",
+		},
+		DatabaseServer: Server{
+			Count:        1,
+			InstanceType: "db.r6g.large",
+		},
+	},
+}


### PR DESCRIPTION
#### Summary
In order to make iteration, first usage and potentially development faster I see myself editing, copying and pasting files manually around so it occurred to me that having a command to easily populate the basics for configuration files would be particularily useful.

I envisioned this as a question-answer prompt, but having a command with flags seems more appropriate here and we can always evolve into something like that.

This Pull Request contains the first steps for that, allowing to run a `ltctl wizard createconfig` command with several flags to populate the `config.json` and `deployment.json` files with predefined values for an environment with an specific amount of active concurrent users (determines by the `--active-users` flag).

I added some draft structures around to define this architecture list borrowing the information from the references architectures work, but we would also need to define number of agents and all other load-test specific configuration.

This is just a first step/draft idea, let me know what you think @agnivade @agarciamontoro 