### PR TITLE
Check DB status before destroy

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -48,14 +48,18 @@ func RunDestroyCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create terraform engine: %w", err)
 	}
 
-	status, err := t.DBStatus()
-	if err != nil {
-		return fmt.Errorf("failed to get DB status: %w", err)
+	// If we are using a Terraform managed DB.
+	if config.ExternalDBSettings.DataSource == "" {
+		status, err := t.DBStatus()
+		if err != nil {
+			return fmt.Errorf("failed to get DB status: %w", err)
+		}
+
+		if status != dbAvailable {
+			return fmt.Errorf("The database isn't available at the moment. Its status is %q. Please check this, and then try again", status)
+		}
 	}
 
-	if status != dbAvailable {
-		return fmt.Errorf("The database isn't available at the moment. Its status is %q. Please check this, and then try again", status)
-	}
 
 	return t.Destroy()
 }

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -47,6 +47,16 @@ func RunDestroyCmdF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create terraform engine: %w", err)
 	}
+
+	status, err := t.DBStatus()
+	if err != nil {
+		return fmt.Errorf("failed to get DB status: %w", err)
+	}
+
+	if status != dbAvailable {
+		return fmt.Errorf("The database isn't available at the moment. Its status is %q. Please check this, and then try again", status)
+	}
+
 	return t.Destroy()
 }
 

--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -60,7 +60,6 @@ func RunDestroyCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-
 	return t.Destroy()
 }
 


### PR DESCRIPTION
We check if the DB is available or not before destroying.
Because going ahead with the destroy if the DB is stopped
messes up with the Terraform state.

https://mattermost.atlassian.net/browse/MM-58236
