### PR TITLE
MM-58347: Ensure all Elasticsearch data nodes have shard replicas

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -16,7 +16,9 @@
     "Version": "Elasticsearch_7.10",
     "CreateRole": false,
     "SnapshotRepository": "",
-    "SnapshotName": ""
+    "SnapshotName": "",
+    "RestoreTimeoutMinutes": "",
+    "ClusterTimeoutMinutes": ""
   },
   "JobServerSettings":{
     "InstanceCount": 0,

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -243,6 +243,10 @@ type ElasticSearchSettings struct {
 	SnapshotRepository string
 	// SnapshotName is the name of the snapshot to restore.
 	SnapshotName string
+	// RestoreTimeoutMinutes is the maximum time, in minutes, that the system will wait for the snapshot to be restored.
+	RestoreTimeoutMinutes int `default:"45" validate:"range:[0,)"`
+	// ClusterTimeoutMinutes is the maximum time, in minutes, that the system will wait for the cluster status to get green.
+	ClusterTimeoutMinutes int `default:"45" validate:"range:[0,)"`
 }
 
 // JobServerSettings contains the necessary data to deploy a job

--- a/deployment/elasticsearch/elasticsearch.go
+++ b/deployment/elasticsearch/elasticsearch.go
@@ -209,29 +209,49 @@ func (c *Client) CloseIndices(indices []string) error {
 	return err
 }
 
-// RestoreSnapshotOpts exposes two options for configuring the RestoreSnapshot
+// RestoreSnapshotOpts exposes three options for configuring the RestoreSnapshot
 // request:
 //   - WithIndices, a list of the indices from the snapshot that need to be
 //     restored.
 //   - WithoutIndices, a list of the indices from the snapshot that need to be
 //     skipped.
+//   - NumberOfReplicas, the number of replicas each primary shard has.
+//     Defaults to 1.
 type RestoreSnapshotOpts struct {
-	WithIndices    []string
-	WithoutIndices []string
+	WithIndices      []string
+	WithoutIndices   []string
+	NumberOfReplicas int
 }
 
 // MarshalJSON implements the Marshaler interface so that RestoreSnapshotOpts
 // can be easily marshalled.
 func (r RestoreSnapshotOpts) MarshalJSON() ([]byte, error) {
+	type restoreSnapshotBodyIndexSettings struct {
+		NumReplicas int `json:"index.number_of_replicas"`
+	}
+
+	type restoreSnapshotBody struct {
+		Indices       string                           `json:"indices"`
+		IndexSettings restoreSnapshotBodyIndexSettings `json:"index_settings"`
+	}
+
+	// Set the indices we want and the ones we want to exclude
 	indices := []string{}
 	indices = append(indices, r.WithIndices...)
 	for _, i := range r.WithoutIndices {
 		indices = append(indices, "-"+i)
 	}
 
-	payload := struct {
-		Indices string `json:"indices"`
-	}{strings.Join(indices, ",")}
+	// Set the number of replicas of each shard
+	numReplicas := 1
+	if r.NumberOfReplicas > 0 {
+		numReplicas = r.NumberOfReplicas
+	}
+
+	payload := restoreSnapshotBody{
+		Indices:       strings.Join(indices, ","),
+		IndexSettings: restoreSnapshotBodyIndexSettings{numReplicas},
+	}
 
 	return json.Marshal(payload)
 }

--- a/deployment/elasticsearch/elasticsearch.go
+++ b/deployment/elasticsearch/elasticsearch.go
@@ -379,6 +379,29 @@ func (c *Client) SnapshotIndicesRecovery(indices []string) ([]SnapshotIndexShard
 	return recovery, nil
 }
 
+const (
+	ClusterStatusGreen  = "green"
+	ClusterStatusYellow = "yellow"
+	ClusterStatusRed    = "red"
+)
+
+type ClusterHealthResponse struct {
+	Status             string `json:"status"`
+	InitializingShards int    `json:"initializing_shards"`
+	UnassignedShards   int    `json:"unassigned_shards"`
+}
+
+func (c *Client) ClusterHealth() (ClusterHealthResponse, error) {
+	req := esapi.ClusterHealthRequest{}
+
+	var response ClusterHealthResponse
+	if err := c.get(req, &response); err != nil {
+		return ClusterHealthResponse{}, fmt.Errorf("unable to perform ClusterHealth request: %w", err)
+	}
+
+	return response, nil
+}
+
 // requestDoer models all esapi.XYZRequest, which contains a Do function to
 // perform the request with the provided client
 type requestDoer interface {

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -454,6 +454,8 @@ func (t *Terraform) setupLoadtestAgents(extAgent *ssh.ExtAgent, initData bool) e
 }
 
 func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) error {
+	esSettings := t.config.ElasticSearchSettings
+
 	output, err := t.Output()
 	if err != nil {
 		return fmt.Errorf("unable to get Terraform output to setup ElasticSearch: %w", err)
@@ -482,7 +484,7 @@ func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) 
 	}
 	mlog.Debug("Repositories registered", mlog.Array("repositories", repositories))
 
-	repo := t.config.ElasticSearchSettings.SnapshotRepository
+	repo := esSettings.SnapshotRepository
 
 	// Check if the registered repositories already include the one configured
 	repoFound := false
@@ -511,7 +513,7 @@ func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) 
 
 	// Look for the configured snapshot
 	var snapshot elasticsearch.Snapshot
-	snapshotName := t.config.ElasticSearchSettings.SnapshotName
+	snapshotName := esSettings.SnapshotName
 	for _, s := range snapshots {
 		if s.Name == snapshotName {
 			snapshot = s
@@ -558,30 +560,32 @@ func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) 
 		mlog.Array("indices", snapshotIndices))
 	opts := elasticsearch.RestoreSnapshotOpts{
 		WithIndices:      snapshotIndices,
-		NumberOfReplicas: t.config.ElasticSearchSettings.InstanceCount - 1,
+		NumberOfReplicas: esSettings.InstanceCount - 1,
 	}
 	if err := es.RestoreSnapshot(repo, snapshotName, opts); err != nil {
 		return fmt.Errorf("unable to restore snapshot: %w", err)
 	}
 
-	// Wait until the snapshot is completely restored, or 45 minutes have
-	// passed, whatever happens first
-	if err := waitForSnapshot(45*time.Minute, es, snapshotIndices); err != nil {
+	// Wait until the snapshot is completely restored, or the user-specified
+	// timeout is triggered, whatever happens first
+	restoreTimeout := time.Duration(esSettings.RestoreTimeoutMinutes) * time.Minute
+	if err := waitForSnapshot(restoreTimeout, es, snapshotIndices); err != nil {
 		return fmt.Errorf("failed to wait for snapshot completion: %w", err)
 	}
 
 	// Double-check that the cluster's status is green: even if the index is
 	// fully restored, the creation of shard replicas may not have finished,
-	// so we give it an additional 45 minutes. The time it takes for all shards
+	// so we give it an additional timeout. The time it takes for all shards
 	// to get assigned and initialized is proportional to the number of nodes
 	// in the Elasticsearch cluster.
-	// The large combined timeout (45 minutes for restoring the snapshot, 45
-	// minutes for a green cluster) will rarely happen, but we need a large
-	// timeout here as well in case the snapshot is already restored and we
-	// re-deploy the cluster with additional data nodes: in that case,
-	// waitForSnapshot will return immediately, so we'll only wait for the
-	// cluster's status to get green.
-	if err := waitForGreenCluster(45*time.Minute, es); err != nil {
+	// The potentially large combined timeout (by default, 45 minutes for
+	// restoring the snapshot, 45 minutes for a green cluster) will rarely
+	// happen, but we need a large timeout here as well in case the snapshot is
+	// already restored and we re-deploy the cluster with additional data
+	// nodes: in that case, waitForSnapshot will return immediately, so we'll
+	// only wait for the cluster's status to get green.
+	clusterTimeout := time.Duration(esSettings.ClusterTimeoutMinutes) * time.Minute
+	if err := waitForGreenCluster(clusterTimeout, es); err != nil {
 		return fmt.Errorf("failed to wait for snapshot completion: %w", err)
 	}
 

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -941,7 +941,7 @@ func (t *Terraform) updateAppConfig(siteURL string, sshc *ssh.Client, jobServerE
 		numReplicas := t.config.ElasticSearchSettings.InstanceCount - 1
 		cfg.ElasticsearchSettings.ChannelIndexReplicas = model.NewInt(numReplicas)
 		cfg.ElasticsearchSettings.PostIndexReplicas = model.NewInt(numReplicas)
-		cfg.ElasticsearchSettings.PostIndexReplicas = model.NewInt(numReplicas)
+		cfg.ElasticsearchSettings.UserIndexReplicas = model.NewInt(numReplicas)
 	}
 
 	if t.config.MattermostConfigPatchFile != "" {

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -557,7 +557,8 @@ func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) 
 		mlog.String("snapshot", snapshotName),
 		mlog.Array("indices", snapshotIndices))
 	opts := elasticsearch.RestoreSnapshotOpts{
-		WithIndices: snapshotIndices,
+		WithIndices:      snapshotIndices,
+		NumberOfReplicas: t.config.ElasticSearchSettings.InstanceCount - 1,
 	}
 	if err := es.RestoreSnapshot(repo, snapshotName, opts); err != nil {
 		return fmt.Errorf("unable to restore snapshot: %w", err)

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -936,6 +936,12 @@ func (t *Terraform) updateAppConfig(siteURL string, sshc *ssh.Client, jobServerE
 		cfg.ElasticsearchSettings.EnableIndexing = model.NewBool(true)
 		cfg.ElasticsearchSettings.EnableAutocomplete = model.NewBool(true)
 		cfg.ElasticsearchSettings.EnableSearching = model.NewBool(true)
+
+		// Make all indices have a shard replica in every data node
+		numReplicas := t.config.ElasticSearchSettings.InstanceCount - 1
+		cfg.ElasticsearchSettings.ChannelIndexReplicas = model.NewInt(numReplicas)
+		cfg.ElasticsearchSettings.PostIndexReplicas = model.NewInt(numReplicas)
+		cfg.ElasticsearchSettings.PostIndexReplicas = model.NewInt(numReplicas)
 	}
 
 	if t.config.MattermostConfigPatchFile != "" {

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -122,6 +122,18 @@ A *snapshot repository*, as [defined by Elasticsearch](https://www.elastic.co/gu
 
 If you want to deploy an already indexed database, you need to provide both the name of the repository where the snapshot lives and the snapshot's name. `SnapshotName` is the name of the snapshot itself.
 
+### RestoreTimeoutMinutes
+
+*int*
+
+The maximum time, in minutes, that the system will wait for the Elasticsearch snapshot to be restored. Defaults to 45 minutes.
+
+### ClusterTimeoutMinutes
+
+*int*
+
+The maximum time, in minutes, that the system will wait for the Elasticsearch cluster status to get green after having restored the snapshot. Defaults to 45 minutes.
+
 ## JobServerSettings
 
 ### InstanceCount


### PR DESCRIPTION
#### Summary
We [recently found out](https://mattermost.atlassian.net/wiki/spaces/XYZ/pages/2827059205/ElasticSearch+load-balancing+investigation+report) that the cause of the unbalanced Elasticsearch queries was the lack of shard replicas in most of the nodes, since we were using the default value of 1 replica per shard, which was allocated to a random data node. The solution to get all data nodes to handle queries at the same rate, then, is to have one replica of the indices' shards in each of them. We only have one shard per index, so this means that every node will contain exactly one copy of each index.

That's what this PR does in [the first commit](https://github.com/mattermost/mattermost-load-test-ng/commit/98b4194c7af8165fa209d5b5a12f0507343c700f): fortunately, the Elasticsearch API allows overwriting index settings when restoring a snapshot, so I just had to modify that request to also specify the number of replicas we wanted per shard.

Then I noticed another problem: even once the snapshot is fully restored, the replicas of shards may not be assigned or initialized, making the [cluster status](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/cluster-health.html) yellow instead of green. We do need to wait for the cluster status to get green again to get the load-balancing of queries perfectly right, so [the second commit](https://github.com/mattermost/mattermost-load-test-ng/commit/a4c11a1b6439a7f9582973b9007003339ee3442b) adds a new `ClusterHealth` method to the Elasticsearch client to check the cluster status. We use it to wait for the green status, while informing the user of the remaining unassigned or initializing shards.

Even after all this, with all shards assigned and initialized, and the cluster green, I was getting an index with only two replicas, regardless of the number of data nodes I deployed :angry: I later realized that it happened only with the new indices, not the ones we restored from the snapshot (the server creates a new posts index as soon as it starts to track the new posts), so I had to configure the number of replicas in the server config as well, something we should have done before, honestly. That's what [the third commit](https://github.com/mattermost/mattermost-load-test-ng/commit/1205f7a220392875b574d9f972362978a7538b67) does. (I [first thought](https://community.mattermost.com/core/pl/en4xcbawjb8tbptpps6rpj9z7y) I needed to create a new index template, but that's not actually needed, since the server already takes care of that configuration for us).


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58347

