### PR TITLE
feat: allow saml with the external auth provider

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -508,7 +508,7 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 				return nil, fmt.Errorf("invalid custom authentication found in %q", email)
 			}
 			authService = split[0]
-			if authService != userentity.AuthenticationTypeOpenID && authService != userentity.AuthenticationTypeMattermost {
+			if authService != userentity.AuthenticationTypeOpenID && authService != userentity.AuthenticationTypeSAML && authService != userentity.AuthenticationTypeMattermost {
 				return nil, fmt.Errorf("invalid custom authentication type %q", authService)
 			}
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -508,7 +508,11 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 				return nil, fmt.Errorf("invalid custom authentication found in %q", email)
 			}
 			authService = split[0]
-			if authService != userentity.AuthenticationTypeOpenID && authService != userentity.AuthenticationTypeSAML && authService != userentity.AuthenticationTypeMattermost {
+			switch(authService) {
+			case userentity.AuthenticationTypeOpenID:
+			case userentity.AuthenticationTypeSAML:
+			case userentity.AuthenticationTypeMattermost:
+			default :
 				return nil, fmt.Errorf("invalid custom authentication type %q", authService)
 			}
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -508,11 +508,11 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 				return nil, fmt.Errorf("invalid custom authentication found in %q", email)
 			}
 			authService = split[0]
-			switch(authService) {
+			switch authService {
 			case userentity.AuthenticationTypeOpenID:
 			case userentity.AuthenticationTypeSAML:
 			case userentity.AuthenticationTypeMattermost:
-			default :
+			default:
 				return nil, fmt.Errorf("invalid custom authentication type %q", authService)
 			}
 

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -133,6 +133,7 @@ func (ue *UserEntity) authIDP(action authIDPAction, provider string) error {
 		if err != nil {
 			return fmt.Errorf("error while reading saml response body: %w", err)
 		}
+		loginResponse.Body.Close()
 
 		redirectURLMatcher := keycloakIDPLoginFormActionRegex.FindSubmatch(samlResponseBody)
 		if len(redirectURLMatcher) == 0 {
@@ -156,6 +157,7 @@ func (ue *UserEntity) authIDP(action authIDPAction, provider string) error {
 		if err != nil {
 			return fmt.Errorf("error while posting SAML form: %w", err)
 		}
+		samlForm.Body.Close()
 		if samlForm.StatusCode != http.StatusOK {
 			return fmt.Errorf("SAML form failed with status code %d", samlForm.StatusCode)
 		}

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -137,7 +137,7 @@ func (ue *UserEntity) authIDP(action authIDPAction, provider string) error {
 
 		redirectURLMatcher := keycloakIDPLoginFormActionRegex.FindSubmatch(samlResponseBody)
 		if len(redirectURLMatcher) == 0 {
-			return errors.New("redirect URL not found in SAML login page, there was probably an error or the configuration is wrong")
+			return errors.New("redirect URL not found in SAML login page, there was probably an error in configuration or the login page changed and the regular expression requires updating")
 		}
 		formURL := string(redirectURLMatcher[1])
 

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -21,16 +21,16 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
-// Possible actions for the openID authentication
-type authOpenIDAction string
+// Possible actions for the IDP authentication
+type authIDPAction string
 
 const (
-	authOpenIDLogin  authOpenIDAction = "login"
-	authOpenIDSignup authOpenIDAction = "signup"
+	authIDPLogin  authIDPAction = "login"
+	authIDPSignup authIDPAction = "signup"
 )
 
 var (
-	openIDLoginFormActionRegex = regexp.MustCompile(`action=["'](.*?)["']`)
+	keycloakIDPLoginFormActionRegex = regexp.MustCompile(`action=["'](.*?)["']`)
 )
 
 // SignUp signs up the user with the given credentials.
@@ -39,15 +39,18 @@ func (ue *UserEntity) SignUp(email, username, password string) error {
 	var err error
 
 	switch ue.config.AuthenticationType {
+	case AuthenticationTypeSAML:
+		fallthrough
 	case AuthenticationTypeOpenID:
-		if err := ue.authOpenID(authOpenIDSignup); err != nil {
-			return fmt.Errorf("error while signing up using OpenID: %w", err)
+		if err := ue.authIDP(authIDPSignup, ue.config.AuthenticationType); err != nil {
+			return fmt.Errorf("error while signing up using %s: %w", ue.config.AuthenticationType, err)
 		}
 
 		newUser, _, err = ue.client.GetUserByUsername(context.Background(), username, "")
 		if err != nil {
 			return fmt.Errorf("error while getting user by username: %w", err)
 		}
+
 	default:
 		user := model.User{
 			Email:    email,
@@ -65,10 +68,10 @@ func (ue *UserEntity) SignUp(email, username, password string) error {
 	return ue.store.SetUser(newUser)
 }
 
-// authOpenID logs the user in using OpenID.
-func (ue *UserEntity) authOpenID(action authOpenIDAction) error {
-	if action != authOpenIDLogin && action != authOpenIDSignup {
-		return errors.New("invalid openid auth action")
+// authIDP logs the user in using the specified idp
+func (ue *UserEntity) authIDP(action authIDPAction, provider string) error {
+	if action != authIDPLogin && action != authIDPSignup {
+		return errors.New("invalid idp auth action")
 	}
 
 	jar, err := cookiejar.New(nil)
@@ -80,10 +83,20 @@ func (ue *UserEntity) authOpenID(action authOpenIDAction) error {
 		Jar: jar,
 	}
 
-	// make a request to the openid login page of mattermost
-	resp, err := client.Get(ue.client.URL + "/oauth/openid/" + string(action))
+	// make a request to the provider login page of mattermost
+	var authURL string
+	switch provider {
+	case AuthenticationTypeSAML:
+		authURL = ue.client.URL + "/login/sso/saml"
+	case AuthenticationTypeOpenID:
+		authURL = ue.client.URL + "/oauth/openid/" + string(action)
+	default:
+		return fmt.Errorf("invalid idp provider: %s", provider)
+	}
+
+	resp, err := client.Get(authURL)
 	if err != nil {
-		return fmt.Errorf("error while making request to openid %s page: %w", action, err)
+		return fmt.Errorf("error while making request to %s %s page: %w", provider, action, err)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -92,11 +105,11 @@ func (ue *UserEntity) authOpenID(action authOpenIDAction) error {
 	}
 	resp.Body.Close()
 
-	loginURLMatches := openIDLoginFormActionRegex.FindSubmatch(body)
+	loginURLMatches := keycloakIDPLoginFormActionRegex.FindSubmatch(body)
 	if len(loginURLMatches) == 0 {
 		return errors.New("login URL not found in keyloak login page, there was probably an error or the configuration is wrong")
 	}
-	loginURL := string(openIDLoginFormActionRegex.FindSubmatch(body)[1])
+	loginURL := string(loginURLMatches[1])
 
 	loginResponse, err := client.PostForm(loginURL, url.Values{
 		"username": {ue.config.Username},
@@ -112,6 +125,7 @@ func (ue *UserEntity) authOpenID(action authOpenIDAction) error {
 
 	cookies := jar.Cookies(loginResponse.Request.URL)
 	for _, cookie := range cookies {
+		fmt.Printf("Cookie: %s=%s", cookie.Name, cookie.Value)
 		if cookie.Name == "MMAUTHTOKEN" {
 			ue.client.SetToken(cookie.Value)
 			return nil
@@ -130,14 +144,16 @@ func (ue *UserEntity) Login() error {
 	var loggedUser *model.User
 
 	switch ue.config.AuthenticationType {
+	case AuthenticationTypeSAML:
+		fallthrough
 	case AuthenticationTypeOpenID:
-		if err := ue.authOpenID(authOpenIDLogin); err != nil {
-			return fmt.Errorf("error while logging in using OpenID: %w", err)
+		if err := ue.authIDP(authIDPLogin, ue.config.AuthenticationType); err != nil {
+			return fmt.Errorf("error while logging in using %s: %w", ue.config.AuthenticationType, err)
 		}
 
 		loggedUser, _, err = ue.client.GetUserByUsername(context.Background(), user.Username, "")
 		if err != nil {
-			return fmt.Errorf("error while getting user by username through openid: %w", err)
+			return fmt.Errorf("error while getting user by username through %s: %w", ue.config.AuthenticationType, err)
 		}
 	default:
 		loggedUser, _, err = ue.client.Login(context.Background(), user.Email, user.Password)

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -124,7 +124,7 @@ func (ue *UserEntity) authIDP(action authIDPAction, provider string) error {
 		return fmt.Errorf("%s failed with status code %d", action, loginResponse.StatusCode)
 	}
 
-	// Perform an extra step when doing SAML authentication, since the Keycloak server wont redirect
+	// Perform an extra step when doing SAML authentication, since the Keycloak server won't redirect
 	// to the Mattermost server automatically, instead it will display a form with the SAML response
 	// that needs to be submitted to the Mattermost server. This is done via Javascript in the browser,
 	// but we can simulate it by parsing the form and doing the same request manually.

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -36,6 +36,7 @@ type UserEntity struct {
 const (
 	AuthenticationTypeMattermost = "mattermost"
 	AuthenticationTypeOpenID     = "openid"
+	AuthenticationTypeSAML       = "saml"
 )
 
 // Config holds necessary information required by a UserEntity.


### PR DESCRIPTION
#### Summary
- Allow using `saml` with the external auth provider
- Logic is mostly the same OpenID uses, just added logic to control the redirect from the IDP (keycloak) back to Mattermost to retrieve the cookie, since that uses a form and javascript on the keycloak side.
