### PR TITLE
MM-59319: Allow opensearch installations to be created

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -234,7 +234,7 @@ type ElasticSearchSettings struct {
 	// Elasticsearch instance type to be created.
 	InstanceType string
 	// Elasticsearch version to be deployed.
-	Version string `default:"Elasticsearch_7.10" validate:"prefix:Elasticsearch_"`
+	Version string `default:"Elasticsearch_7.10"`
 	// Id of the VPC associated with the instance to be created.
 	VpcID string
 	// Set to true if the AWSServiceRoleForAmazonElasticsearchService role should be created.
@@ -336,6 +336,10 @@ func (c *Config) validateElasticSearchConfig() error {
 				"(hyphen). Current value is \"" + domainName + "\"")
 		}
 
+	}
+
+	if !strings.HasPrefix(c.ElasticSearchSettings.Version, "Elasticsearch") && !strings.HasPrefix(c.ElasticSearchSettings.Version, "OpenSearch") {
+		return fmt.Errorf("Incorrect engine version: %s. Must start with either %q or %q", c.ElasticSearchSettings.Version, "Elasticsearch", "OpenSearch")
 	}
 
 	return nil

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -57,6 +57,7 @@ func TestValidateElasticSearchConfig(t *testing.T) {
 			LoadTestDownloadURL:   "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.18.0/mattermost-load-test-ng-v1.18.0-linux-amd64.tar.gz",
 			ElasticSearchSettings: ElasticSearchSettings{
 				InstanceCount: 1,
+				Version:       "Elasticsearch_7.10",
 				VpcID:         "vpc-01234567890abcdef",
 			},
 		}


### PR DESCRIPTION
We unblock the prefix limitation, and allow
either prefixes.

https://mattermost.atlassian.net/browse/MM-59319
