### PR TITLE
Allow 0 shard replicas

### DIFF
--- a/deployment/elasticsearch/elasticsearch.go
+++ b/deployment/elasticsearch/elasticsearch.go
@@ -243,7 +243,7 @@ func (r RestoreSnapshotOpts) MarshalJSON() ([]byte, error) {
 	}
 
 	// Set the number of replicas of each shard
-	numReplicas := 1
+	numReplicas := 0
 	if r.NumberOfReplicas > 0 {
 		numReplicas = r.NumberOfReplicas
 	}

--- a/deployment/elasticsearch/elasticsearch.go
+++ b/deployment/elasticsearch/elasticsearch.go
@@ -242,23 +242,29 @@ func (r RestoreSnapshotOpts) MarshalJSON() ([]byte, error) {
 		indices = append(indices, "-"+i)
 	}
 
-	// Set the number of replicas of each shard
-	numReplicas := 0
-	if r.NumberOfReplicas > 0 {
-		numReplicas = r.NumberOfReplicas
-	}
-
 	payload := restoreSnapshotBody{
 		Indices:       strings.Join(indices, ","),
-		IndexSettings: restoreSnapshotBodyIndexSettings{numReplicas},
+		IndexSettings: restoreSnapshotBodyIndexSettings{r.NumberOfReplicas},
 	}
 
 	return json.Marshal(payload)
 }
 
+func (r RestoreSnapshotOpts) IsValid() error {
+	if r.NumberOfReplicas < 0 {
+		return fmt.Errorf("number of replicas must be at least 0, but it is %d", r.NumberOfReplicas)
+	}
+
+	return nil
+}
+
 // RestoreSnapshot restores a snapshot from a repository using the options
 // provided.
 func (c *Client) RestoreSnapshot(repositoryName, snapshotName string, opts RestoreSnapshotOpts) error {
+	if err := opts.IsValid(); err != nil {
+		return fmt.Errorf("invalid options for restoring the snapshot: %w", err)
+	}
+
 	body, err := json.Marshal(opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Summary
I knew I had tested 1-node ES clusters before! I must have tested them prior to the implementation of the MarshalJSON for the RestoreSnapshotOpts struct, though, where I mistakenly assumed the default number of replicas must be 1 instead of 0. This is what made the cluster status to be yellow, and, [contrary to the docs](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/handling-errors.html#handling-errors-yellow-cluster-status) (:shrug:), if we set the number of replicas to 0 when there are no replicas, the cluster status is green, as it should be.

Check an example of a 1-node cluster with a green status :tada: 
![image](https://github.com/mattermost/mattermost-load-test-ng/assets/3924815/055e2502-b847-49a6-9771-1bce9945e5dd)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59312