### PR TITLE
Improvements from Redis investigation

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -346,7 +346,6 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 		MaxConnsPerHost:       maxHTTPconns,
 		MaxIdleConns:          maxHTTPconns,
 		MaxIdleConnsPerHost:   maxHTTPconns,
-		ResponseHeaderTimeout: 5 * time.Second,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   1 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
@@ -427,7 +426,7 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 		ueSetup := userentity.Setup{
 			Store:         store,
 			Transport:     transport,
-			ClientTimeout: transport.ResponseHeaderTimeout,
+			ClientTimeout: 5 * time.Second,
 		}
 		if metrics != nil {
 			ueSetup.Metrics = metrics.UserEntityMetrics()

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -194,7 +194,6 @@ proxy_cache mattermost_cache;
 proxy_cache_revalidate on;
 proxy_cache_min_uses 2;
 proxy_cache_use_stale timeout;
-proxy_cache_lock on;
 `
 
 const nginxSiteConfigTmpl = `

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -181,7 +181,7 @@ proxy_buffers 256 16k;
 proxy_buffer_size 16k;
 client_body_timeout 60s;
 send_timeout        300s;
-lingering_timeout   5s;
+lingering_timeout   30s;
 proxy_connect_timeout   30s;
 proxy_send_timeout      90s;
 proxy_read_timeout      90s;


### PR DESCRIPTION
- Turn off the cache_lock. This is unnecessary and
we shouldn't even have done this to start with.
- Set timeout for entire response and not just response header.
It is unclear why exactly this causes the problem. So open to
thoughts and suggestions.
