### PR TITLE
Allow binaries with specific Mattermost builds; don't fail on license check

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	// on a custom build. The path should be prefixed with "file://". In that case,
 	// only the binary gets replaced, and the rest of the build comes
 	// from the release at MattermostDownloadURL
-	MattermostBinaryPath string `default:"" validate:"url`
+	MattermostBinaryPath string `default:"" validate:"url"`
 	// Path to the Mattermost EE license file.
 	MattermostLicenseFile string `default:"" validate:"file"`
 	// Optional path to a partial Mattermost config file to be applied as patch during

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	ExternalBucketSettings ExternalBucketSettings
 	// ExternalAuthProviderSettings contains the settings for configuring an external auth provider.
 	ExternalAuthProviderSettings ExternalAuthProviderSettings
-	// URL from where to download the Mattermost release.
+	// URL from which to download the Mattermost release.
 	MattermostDownloadURL string `default:"https://latest.mattermost.com/mattermost-enterprise-linux" validate:"url"`
 	// Point to a local binary path if the user wants to run the loadtest
 	// on a custom build. The path should be prefixed with "file://". In that case,

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -53,12 +53,13 @@ type Config struct {
 	ExternalBucketSettings ExternalBucketSettings
 	// ExternalAuthProviderSettings contains the settings for configuring an external auth provider.
 	ExternalAuthProviderSettings ExternalAuthProviderSettings
-	// URL from where to download Mattermost release.
-	// This can also point to a local binary path if the user wants to run loadtest
-	// on a custom build. The path should be prefixed with "file://". In that case,
-	// only the binary gets replaced, and the rest of the build comes from the latest
-	// stable release.
+	// URL from where to download the Mattermost release.
 	MattermostDownloadURL string `default:"https://latest.mattermost.com/mattermost-enterprise-linux" validate:"url"`
+	// Point to a local binary path if the user wants to run the loadtest
+	// on a custom build. The path should be prefixed with "file://". In that case,
+	// only the binary gets replaced, and the rest of the build comes
+	// from the release at MattermostDownloadURL
+	MattermostBinaryPath string `default:"" validate:"url`
 	// Path to the Mattermost EE license file.
 	MattermostLicenseFile string `default:"" validate:"file"`
 	// Optional path to a partial Mattermost config file to be applied as patch during
@@ -286,8 +287,12 @@ func (p DBParameters) String() string {
 
 // IsValid reports whether a given deployment config is valid or not.
 func (c *Config) IsValid() error {
-	if !checkPrefix(c.MattermostDownloadURL) {
-		return fmt.Errorf("mattermost download url is not in correct format: %q", c.MattermostDownloadURL)
+	if !checkUrlPrefix(c.MattermostDownloadURL) {
+		return fmt.Errorf("mattermost download url is not in correct format. MattermostDownloadURL should be an http or https link to a base image; use MattermostBinaryPath to specify a custom binary: %q", c.MattermostDownloadURL)
+	}
+
+	if c.MattermostBinaryPath != "" && !checkFilePrefix(c.MattermostBinaryPath) {
+		return fmt.Errorf("mattermost binary path is not in correct format: %q", c.MattermostBinaryPath)
 	}
 
 	if !checkPrefix(c.LoadTestDownloadURL) {
@@ -317,6 +322,14 @@ func checkPrefix(str string) bool {
 	return strings.HasPrefix(str, "https://") ||
 		strings.HasPrefix(str, "http://") ||
 		strings.HasPrefix(str, "file://")
+}
+
+func checkFilePrefix(str string) bool {
+	return strings.HasPrefix(str, "file://")
+}
+
+func checkUrlPrefix(str string) bool {
+	return strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "http://")
 }
 
 func (c *Config) validateElasticSearchConfig() error {

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -15,36 +15,22 @@ func TestConfigIsValid(t *testing.T) {
 	}
 
 	t.Run("paths", func(t *testing.T) {
-		t.Run("MattermostDownloadUrl should be an url", func(t *testing.T) {
+		t.Run("MattermostDownloadUrl can be an url", func(t *testing.T) {
 			c := baseConfig()
 
 			require.NoError(t, c.IsValid())
 		})
 
-		t.Run("MattermostDownloadUrl should not be a path", func(t *testing.T) {
+		t.Run("MattermostDownloadUrl can be a path", func(t *testing.T) {
 			c := baseConfig()
 			c.MattermostDownloadURL = "file:///some/path"
 
-			require.Error(t, c.IsValid())
-		})
-
-		t.Run("empty MattermostBinaryPath is valid", func(t *testing.T) {
-			c := baseConfig()
-			c.MattermostBinaryPath = ""
-
 			require.NoError(t, c.IsValid())
 		})
 
-		t.Run("non-empty MattermostBinaryPath is valid", func(t *testing.T) {
+		t.Run("MattermostDownloadUrl must be an url or a file", func(t *testing.T) {
 			c := baseConfig()
-			c.MattermostBinaryPath = "file:///some/path"
-
-			require.NoError(t, c.IsValid())
-		})
-
-		t.Run("non-empty MattermostBinaryPath should be a path", func(t *testing.T) {
-			c := baseConfig()
-			c.MattermostBinaryPath = "https://example.com"
+			c.MattermostDownloadURL = "/some/path"
 
 			require.Error(t, c.IsValid())
 		})

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -14,6 +14,42 @@ func TestConfigIsValid(t *testing.T) {
 		}
 	}
 
+	t.Run("paths", func(t *testing.T) {
+		t.Run("MattermostDownloadUrl should be an url", func(t *testing.T) {
+			c := baseConfig()
+
+			require.NoError(t, c.IsValid())
+		})
+
+		t.Run("MattermostDownloadUrl should not be a path", func(t *testing.T) {
+			c := baseConfig()
+			c.MattermostDownloadURL = "file:///some/path"
+
+			require.Error(t, c.IsValid())
+		})
+
+		t.Run("empty MattermostBinaryPath is valid", func(t *testing.T) {
+			c := baseConfig()
+			c.MattermostBinaryPath = ""
+
+			require.NoError(t, c.IsValid())
+		})
+
+		t.Run("non-empty MattermostBinaryPath is valid", func(t *testing.T) {
+			c := baseConfig()
+			c.MattermostBinaryPath = "file:///some/path"
+
+			require.NoError(t, c.IsValid())
+		})
+
+		t.Run("non-empty MattermostBinaryPath should be a path", func(t *testing.T) {
+			c := baseConfig()
+			c.MattermostBinaryPath = "https://example.com"
+
+			require.Error(t, c.IsValid())
+		})
+	})
+
 	t.Run("DBName is valid", func(t *testing.T) {
 		t.Run("empty ClusterIdentifier and empty DBName is valid", func(t *testing.T) {
 			c := baseConfig()

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -99,7 +99,7 @@ func (t *Terraform) Create(initData bool) error {
 	}
 
 	if err := validateLicense(t.config.MattermostLicenseFile); err != nil {
-		mlog.Error(fmt.Errorf("license validation failed: %w", err).Error())
+		return fmt.Errorf("license validation failed: %w", err)
 	}
 
 	extAgent, err := ssh.NewAgent()

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -99,7 +99,7 @@ func (t *Terraform) Create(initData bool) error {
 	}
 
 	if err := validateLicense(t.config.MattermostLicenseFile); err != nil {
-		return fmt.Errorf("license validation failed: %w", err)
+		mlog.Error(fmt.Errorf("license validation failed: %w", err).Error())
 	}
 
 	extAgent, err := ssh.NewAgent()
@@ -124,8 +124,9 @@ func (t *Terraform) Create(initData bool) error {
 
 	var uploadBinary bool
 	var binaryPath string
-	if strings.HasPrefix(t.config.MattermostDownloadURL, filePrefix) {
-		binaryPath = strings.TrimPrefix(t.config.MattermostDownloadURL, filePrefix)
+
+	if t.config.MattermostBinaryPath != "" {
+		binaryPath = strings.TrimPrefix(t.config.MattermostBinaryPath, filePrefix)
 		info, err := os.Stat(binaryPath)
 		if err != nil {
 			return err
@@ -140,7 +141,6 @@ func (t *Terraform) Create(initData bool) error {
 			return fmt.Errorf("binary path %s has to be a regular file", binaryPath)
 		}
 
-		t.config.MattermostDownloadURL = latestReleaseURL
 		uploadBinary = true
 	}
 

--- a/loadtest/control/simulcontroller/config.go
+++ b/loadtest/control/simulcontroller/config.go
@@ -27,7 +27,7 @@ type Config struct {
 func ReadConfig(configFilePath string) (*Config, error) {
 	var cfg Config
 
-	if err := defaults.ReadFrom(configFilePath, "./config/simulcontoller.json", &cfg); err != nil {
+	if err := defaults.ReadFrom(configFilePath, "./config/simulcontroller.json", &cfg); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
#### Summary
- I had some troubles testing old Mattermost builds (7.10), things kept failing after I put in my custom Mattemost build. Then I saw that if you put in a custom binary it would use the `latest` MM build. So I'm adding flexibility to specify your base build, if you need to.
- Note, this will break previous `deployment.json`s if you were using a `file://` for `MattermostDownloadURL`, but it will give you an error telling you what to do to fix it. Not sure if you really want to avoid that or not.
- Also changed the license check to log the error instead of exit out, since the license file I had to use was not passing the check for whatever reason. I could keep that as a local change, so tell me if you want it removed.

#### Ticket Link
- none
