### PR TITLE
Enable proxy_cache_lock again

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -194,6 +194,7 @@ proxy_cache mattermost_cache;
 proxy_cache_revalidate on;
 proxy_cache_min_uses 2;
 proxy_cache_use_stale timeout;
+proxy_cache_lock on;
 `
 
 const nginxSiteConfigTmpl = `


### PR DESCRIPTION
#### Summary
Release testing for v1.19 of the load-test tool showed that disabling proxy_cache_lock was affecting the performance of the app nodes, which were eventually killed by the overhead of the requests that were no longer waiting for the cache to be updated.

This commit reverts that change, and a subsequent investigation into the proxy_cache_lock_timeout fine-tuning will follow.
See https://mattermost.atlassian.net/browse/MM-59871

#### Ticket Link
--