### PR TITLE
MM-58444: Fix race condition in RoundTrip test

### DIFF
--- a/deployment/elasticsearch/roundtripper_test.go
+++ b/deployment/elasticsearch/roundtripper_test.go
@@ -36,7 +36,6 @@ var awsDummyCreds = aws.Credentials{
 }
 
 func TestRoundTrip(t *testing.T) {
-	t.Skip("MM-58444")
 	setupSSHServer(t)
 	sshc := setupSSHClient(t)
 
@@ -98,8 +97,13 @@ func setupSSHClient(t *testing.T) *ltssh.Client {
 
 	extAgent, err := ltssh.NewAgent()
 	require.NoError(t, err)
-	sshc, err := extAgent.NewClientWithPort(sshIP, sshPort)
-	require.NoError(t, err)
+
+	// Wait for the SSH server to start
+	var sshc *ltssh.Client
+	require.Eventually(t, func() bool {
+		sshc, err = extAgent.NewClientWithPort(sshIP, sshPort)
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond)
 
 	return sshc
 }


### PR DESCRIPTION
#### Summary
There was a race condition where the test ended up creating the SSH client *before* the SSH server was up.

Using `require.Eventually`, we check every 100ms, up to 5s, that the client is correctly created, giving time to the server to start.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58444