### PR TITLE
Fix incorrect deployer.sample.json

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -17,8 +17,8 @@
     "CreateRole": false,
     "SnapshotRepository": "",
     "SnapshotName": "",
-    "RestoreTimeoutMinutes": "",
-    "ClusterTimeoutMinutes": ""
+    "RestoreTimeoutMinutes": 45,
+    "ClusterTimeoutMinutes": 45
   },
   "JobServerSettings":{
     "InstanceCount": 0,


### PR DESCRIPTION
The newly added Elasticsearch config settings don't accept string values.
