### PR TITLE
Properly use EC2 API to get the proxy details

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -22,6 +22,9 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/assets"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/v8/config"
@@ -734,6 +737,26 @@ func genNginxConfig() (string, error) {
 	return fillConfigTemplate(nginxConfigTmpl, data)
 }
 
+func (t *Terraform) getProxyInstanceInfo() (*types.InstanceTypeInfo, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithSharedConfigProfile(t.config.AWSProfile),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error loading AWS config: %v", err)
+	}
+	descOutput, err := ec2.NewFromConfig(cfg).DescribeInstanceTypes(context.Background(), &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []types.InstanceType{types.InstanceType(t.config.ProxyInstanceType)},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error trying to describe instance type: %v", err)
+	}
+
+	if len(descOutput.InstanceTypes) == 0 {
+		return nil, fmt.Errorf("no instance types returned")
+	}
+	return &descOutput.InstanceTypes[0], nil
+}
+
 func (t *Terraform) setupProxyServer(extAgent *ssh.ExtAgent) {
 	ip := t.output.Proxy.PublicDNS
 
@@ -762,22 +785,22 @@ func (t *Terraform) setupProxyServer(extAgent *ssh.ExtAgent) {
 		cacheObjects := "10m"
 		cacheSize := "3g"
 		rxQueueSize := 1024 // This is the default on most EC2 instances
-		// Extracting the instance class from the type.
-		// Usually they are of the form (m7/c7).(large/2xlarge/4xlarge/..)
-		parts := strings.Split(t.config.ProxyInstanceType, ".")
-		if len(parts) > 1 {
-			// Hack alert. There can be other higher variants like 12xlarge or even metal. But we are keeping it simple for now.
-			switch parts[1] {
-			case "4", "8":
-				cacheObjects = "50m"
-				cacheSize = "16g" // Ideally we'd like half of the total server mem. But the mem consumption rarely exceeds 10G
-				// from my tests. So there's no point stretching it further.
 
-				// MM-58179
-				// We are increasing the receive ring buffer size on the network card. This proved to significantly lower packet loss
-				// (and retransmissions) on particularly bursty connections (e.g. websockets).
-				rxQueueSize = 8192
-			}
+		info, err := t.getProxyInstanceInfo()
+		if err != nil {
+			mlog.Error("Error while getting proxy info", mlog.Err(err))
+			return
+		}
+
+		if *info.MemoryInfo.SizeInMiB >= 32768 { // 32GiB
+			cacheObjects = "50m"
+			cacheSize = "16g" // Ideally we'd like half of the total server mem. But the mem consumption rarely exceeds 10G
+			// from my tests. So there's no point stretching it further.
+
+			// MM-58179
+			// We are increasing the receive ring buffer size on the network card. This proved to significantly lower packet loss
+			// (and retransmissions) on particularly bursty connections (e.g. websockets).
+			rxQueueSize = 8192
 		}
 
 		nginxConfig, err := genNginxConfig()

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -792,7 +792,7 @@ func (t *Terraform) setupProxyServer(extAgent *ssh.ExtAgent) {
 			return
 		}
 
-		if *info.MemoryInfo.SizeInMiB >= 32768 { // 32GiB
+		if *info.MemoryInfo.SizeInMiB >= 32768 { // 32GiB (Usually of instance classes >=4xlarge)
 			cacheObjects = "50m"
 			cacheSize = "16g" // Ideally we'd like half of the total server mem. But the mem consumption rarely exceeds 10G
 			// from my tests. So there's no point stretching it further.

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.30.3
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.37.3
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
 	github.com/gliderlabs/ssh v0.1.1
 	github.com/graph-gophers/graphql-go v1.5.1-0.20230110080634-edea822f558a

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.37.3 h1:pnvujeesw3tP0iDLKdREjPAzxmPqC8F0bov77VN2wSk=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.37.3/go.mod h1:eJZGfJNuTmvBgiy2O5XIPlHMBi4GUYoJoKZ6U6wCVVk=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0 h1:ta62lid9JkIpKZtZZXSj6rP2AqY5x1qYGq53ffxqD9Q=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0/go.mod h1:o6QDjdVKpP5EF0dp/VlvqckzuSDATr1rLdHt3A5m0YY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3 h1:dT3MqvGhSoaIhRseqw2I0yH81l7wiR2vjs57O51EAm8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3/go.mod h1:GlAeCkHwugxdHaueRr4nhPuY+WW+gR8UjlcqzPr1SPI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17 h1:HGErhhrxZlQ044RiM+WdoZxp0p+EGM62y3L6pwA4olE=


### PR DESCRIPTION
Previously, there was a bug in the logic. Do it properly now.
