### PR TITLE
MM-60439: Set websocket scope early

### DIFF
--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -1393,14 +1393,6 @@ func (c *SimulController) initialJoinTeam(u user.User) control.UserActionRespons
 		return resp
 	}
 
-	team, err := c.user.Store().CurrentTeam()
-	if err != nil {
-		return control.UserActionResponse{Err: control.NewUserError(err)}
-	} else if team == nil {
-		// only join a team if we are not in one already.
-		return c.joinTeam(c.user)
-	}
-
 	if c.user.Store().FeatureFlags()["WebSocketEventScope"] {
 		// Setting the active thread to empty to allow the optimization to kick in early.
 		// We don't do this in the webapp to keep the code simple, but it's okay to do this in load-test
@@ -1408,6 +1400,14 @@ func (c *SimulController) initialJoinTeam(u user.User) control.UserActionRespons
 		if err := u.UpdateActiveThread(""); err != nil {
 			mlog.Warn("Failed to update active thread", mlog.String("channel_id", ""))
 		}
+	}
+
+	team, err := c.user.Store().CurrentTeam()
+	if err != nil {
+		return control.UserActionResponse{Err: control.NewUserError(err)}
+	} else if team == nil {
+		// only join a team if we are not in one already.
+		return c.joinTeam(c.user)
 	}
 
 	return resp


### PR DESCRIPTION
Because there is a return statement which gets executed
if the user isn't part of any teams, this optimization
won't kick in if that's the case.

To let the optimization happen in all cases, we move the
line earlier.

https://mattermost.atlassian.net/browse/MM-60439
