### PR TITLE
Default proxy count to 1

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -31,6 +31,7 @@
     "InstanceType": "c7i.xlarge"
   },
   "EnableAgentFullLogs": true,
+  "ProxyInstanceCount": 1,
   "ProxyInstanceType": "c7i.xlarge",
   "SSHPublicKey": "~/.ssh/id_rsa.pub",
   "TerraformStateDir" : "/var/lib/mattermost-load-test-ng",

--- a/config/deployer.sample.toml
+++ b/config/deployer.sample.toml
@@ -37,6 +37,7 @@ TerraformStateDir = '/var/lib/mattermost-load-test-ng'
 
 # Proxy server configuration
 ProxyInstanceType = 'c5.xlarge'
+ProxyInstanceCount = 1
 
 [ElasticSearchSettings]
 CreateRole = false

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	// Logs the command output (stdout & stderr) to home directory.
 	EnableAgentFullLogs bool `default:"true"`
 	// Number of proxy instances.
-	ProxyInstanceCount int `default:"0" validate:"range:[0,1]"`
+	ProxyInstanceCount int `default:"1" validate:"range:[0,1]"`
 	// Type of the EC2 instance for proxy.
 	ProxyInstanceType string `default:"m4.xlarge" validate:"notempty"`
 	// Path to the SSH public key.

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -154,6 +154,12 @@ The type of EC2 instance for the Job Server. See type [here](https://aws.amazon.
 
 Allows to log the agent service command output (`stdout` & `stderr`) to home directory.
 
+## ProxyInstanceCount
+
+*int*
+
+Number of proxy instances to run. Right now, only values `0` and `1` are allowed. Check [this FAQ](../faq.md#can-i-use-a-custom-load-balancer-like-an-albnlb-in-front-of-the-mattermost-server) for more information.
+
 ## ProxyInstanceType
 
 *string*


### PR DESCRIPTION
#### Summary
Running a 2-node deployment, I got confused because only one node was getting requests, although both of them were healthy. It took me a while to understand that I was running proxy-less! This happened because I was running an older config with a newer load-test version, so I think it's safer to default the new `ProxyInstanceCount` to 1. This would avoid breaking other people's configurations.

I've also added it to both sample files and the docs.

#### Ticket Link
--