### PR TITLE
feat(ltkeycloak): added flag to force migrate all users

### DIFF
--- a/cmd/ltkeycloak/README.md
+++ b/cmd/ltkeycloak/README.md
@@ -28,7 +28,7 @@ Global Flags:
       --dry-run                  perform a dry run without making any changes
       --keycloak-host string     keycloak host (default "http://localhost:8484")
       --mattermost-host string   The Mattermost host to migrate users from
-      --migrate-all-users        Migrate all users ignoring their current auth method
+      --force-migrate            Migrate all users ignoring their current auth method
 ```
 
 #### Example

--- a/cmd/ltkeycloak/README.md
+++ b/cmd/ltkeycloak/README.md
@@ -15,7 +15,11 @@ ltkeycloak [command] [flags]
 This command will sync users from a Mattermost server to a Keycloak server, setting the same password for all users and creating a txt file to be used with the loadtest.
 
 ```
+Usage:
+  ltkeycloak sync from_mattermost [flags]
+
 Flags:
+  -h, --help                          help for from_mattermost
       --keycloak-realm string         The Keycloak realm to migrate users to (default "master")
       --set-user-password-to string   Set's the user password to the provided value (default "testpassword")
 
@@ -24,6 +28,7 @@ Global Flags:
       --dry-run                  perform a dry run without making any changes
       --keycloak-host string     keycloak host (default "http://localhost:8484")
       --mattermost-host string   The Mattermost host to migrate users from
+      --migrate-all-users        Migrate all users ignoring their current auth method
 ```
 
 #### Example

--- a/cmd/ltkeycloak/from_mattermost.go
+++ b/cmd/ltkeycloak/from_mattermost.go
@@ -266,7 +266,7 @@ func RunSyncFromMattermostCommandF(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to refresh keycloak token: %w", err)
 	}
 
-	migrateAllUsers, err := cmd.Flags().GetBool("force-migrate")
+	forceMigrate, err := cmd.Flags().GetBool("force-migrate")
 	if err != nil {
 		return fmt.Errorf("failed to read flag: %w", err)
 	}
@@ -305,7 +305,7 @@ func RunSyncFromMattermostCommandF(cmd *cobra.Command, _ []string) error {
 			userPassword:     userPassword,
 			deploymentConfig: deploymentConfig,
 			doneChan:         doneChan,
-			forceMigrate:     migrateAllUsers,
+			forceMigrate:     forceMigrate,
 		})
 	}
 
@@ -333,7 +333,7 @@ func RunSyncFromMattermostCommandF(cmd *cobra.Command, _ []string) error {
 			}
 
 			// Already migrated
-			if user.AuthService == model.UserAuthServiceSaml && !migrateAllUsers {
+			if user.AuthService == model.UserAuthServiceSaml && !forceMigrate {
 				continue
 			}
 

--- a/cmd/ltkeycloak/from_mattermost.go
+++ b/cmd/ltkeycloak/from_mattermost.go
@@ -41,7 +41,7 @@ func migrateUser(worker *workerConfig, user *model.User) error {
 		if apiErr, ok := err.(*gocloak.APIError); ok && apiErr.Code == 409 {
 			mlog.Debug("user already exists in keycloak", mlog.String("username", user.Username))
 
-			// Return early if we are not forcing the migration of all the users users
+			// Return early if we are not forcing the migration of all the users
 			if !worker.forceMigrate {
 				worker.errorsChan <- err
 				return err

--- a/cmd/ltkeycloak/from_mattermost.go
+++ b/cmd/ltkeycloak/from_mattermost.go
@@ -70,6 +70,13 @@ func migrateUser(worker *workerConfig, user *model.User) error {
 				return err
 			}
 
+			// This should not happen, but just in case...
+			if users[0] == nil || users[0].ID == nil {
+				err = fmt.Errorf("somehow keycloak returned incorrect data for user %s (nil values)", user.Username)
+				worker.errorsChan <- err
+				return err
+			}
+
 			kcUserID = *users[0].ID
 		} else {
 			mlog.Error("failed to create user in keycloak", mlog.String("err", err.Error()))

--- a/cmd/ltkeycloak/from_mattermost.go
+++ b/cmd/ltkeycloak/from_mattermost.go
@@ -61,8 +61,7 @@ func migrateUser(worker *workerConfig, user *model.User) error {
 				}
 
 				if len(users) != 1 {
-					err = fmt.Errorf("expected 1 user, got %d", len(users))
-					mlog.Error("got more users than expected in keycloak", mlog.String("username", user.Username), mlog.Int("users_count", len(users)))
+					err = fmt.Errorf("got %d users in keycloak for user %s", len(users), user.Username)
 					worker.errorsChan <- err
 					return err
 				}

--- a/cmd/ltkeycloak/from_mattermost.go
+++ b/cmd/ltkeycloak/from_mattermost.go
@@ -37,7 +37,7 @@ func migrateUser(worker *workerConfig, user *model.User) error {
 		},
 	})
 	if err != nil {
-		// Ignore already existing users
+		// Check if the error is due to the user already existing in keycloak
 		if apiErr, ok := err.(*gocloak.APIError); ok && apiErr.Code == 409 {
 			mlog.Debug("user already exists in keycloak", mlog.String("username", user.Username))
 

--- a/cmd/ltkeycloak/main.go
+++ b/cmd/ltkeycloak/main.go
@@ -26,7 +26,7 @@ func MakeSyncCommand() *cobra.Command {
 	cmd.PersistentFlags().StringP("keycloak-host", "", "http://localhost:8484", "keycloak host")
 	cmd.PersistentFlags().String("mattermost-host", "", "The Mattermost host to migrate users from")
 	cmd.PersistentFlags().BoolP("dry-run", "", false, "perform a dry run without making any changes")
-	cmd.PersistentFlags().BoolP("migrate-all-users", "", false, "Migrate all users ignoring their current auth method")
+	cmd.PersistentFlags().BoolP("force-migrate", "", false, "Migrate all users ignoring their current auth method")
 
 	cmd.AddCommand(MakeSyncFromMattermostCommand())
 	return cmd

--- a/cmd/ltkeycloak/main.go
+++ b/cmd/ltkeycloak/main.go
@@ -26,6 +26,7 @@ func MakeSyncCommand() *cobra.Command {
 	cmd.PersistentFlags().StringP("keycloak-host", "", "http://localhost:8484", "keycloak host")
 	cmd.PersistentFlags().String("mattermost-host", "", "The Mattermost host to migrate users from")
 	cmd.PersistentFlags().BoolP("dry-run", "", false, "perform a dry run without making any changes")
+	cmd.PersistentFlags().BoolP("migrate-all-users", "", false, "Migrate all users ignoring their current auth method")
 
 	cmd.AddCommand(MakeSyncFromMattermostCommand())
 	return cmd

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -1118,7 +1118,6 @@ func (t *Terraform) init() error {
 	assets.RestoreAssets(t.config.TerraformStateDir, "keycloak.service")
 	assets.RestoreAssets(t.config.TerraformStateDir, "saml-idp.crt")
 	assets.RestoreAssets(t.config.TerraformStateDir, "provisioners")
-	assets.RestoreAssets(t.config.TerraformStateDir, "saml-idp.crt")
 
 	// We lock to make this call safe for concurrent use
 	// since "terraform init" command can write to common files under

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -1118,6 +1118,7 @@ func (t *Terraform) init() error {
 	assets.RestoreAssets(t.config.TerraformStateDir, "keycloak.service")
 	assets.RestoreAssets(t.config.TerraformStateDir, "saml-idp.crt")
 	assets.RestoreAssets(t.config.TerraformStateDir, "provisioners")
+	assets.RestoreAssets(t.config.TerraformStateDir, "saml-idp.crt")
 
 	// We lock to make this call safe for concurrent use
 	// since "terraform init" command can write to common files under


### PR DESCRIPTION
#### Summary
Added a `--migrate-all-users` flag that forces migration of all users, which changes two things:
- Skips checking if the `authmethod` for the Mattermost user is `password`
- When creating a Keycloak user, instead of directly failing if the user exists, when the flag is set we will try to retrieve that user and update the Mattermost user accordingly.
- Changed the `UpdateUser` to `UpdateUserAuth` to work with newer Mattermost versions.

This flag is required for environment where the data loaded into Mattermost already points users to an external auth provider. Even if the data was wrong and wasn't working, the tool couldn't migrate those users as it was.
