### PR TITLE
Remove checking DB status while destroying

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -48,18 +48,6 @@ func RunDestroyCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create terraform engine: %w", err)
 	}
 
-	// If we are using a Terraform managed DB.
-	if config.ExternalDBSettings.DataSource == "" {
-		status, err := t.DBStatus()
-		if err != nil {
-			return fmt.Errorf("failed to get DB status: %w", err)
-		}
-
-		if status != dbAvailable {
-			return fmt.Errorf("The database isn't available at the moment. Its status is %q. Please check this, and then try again", status)
-		}
-	}
-
 	return t.Destroy()
 }
 


### PR DESCRIPTION
This has caused more headache than benefit. The problem is that
if you mess up your deployment slightly and lose your cluster,
then you cannot clean up any other resources because it fails
on "DB cluster not found".

Currently, this causes problems while destroying deployments
with db parameter groups. While that's a separate bug, Stu
also ran into this problem when he messed up his setup.

Whereas, if this check didn't exist, it would naturally fail
during terraform destroy. This check just made it fail sooner.
