### PR TITLE
Fix malformed Prometheus configuration YAML file

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -55,6 +55,7 @@ scrape_configs:
     static_configs:
         - targets: [%s]
   - job_name: cloudwatch
+    static_configs:
         - targets: [%s]
   - job_name: netpeek
     static_configs:


### PR DESCRIPTION
#### Summary
It seems that https://github.com/mattermost/mattermost-load-test-ng/pull/807 stole the `static_configs:` line from the cloudwatch section and gave it to the `netpeek` one :smiling_imp:

#### Ticket Link
--
