### PR TITLE
Use `us-east-1c` as default AZ

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -1,7 +1,7 @@
 {
   "AWSProfile": "mm-loadtest",
   "AWSRegion": "us-east-1",
-  "AWSAvailabilityZone": "us-east-1a",
+  "AWSAvailabilityZone": "us-east-1c",
   "AWSAMI": "ami-003d3d03cfe1b0468",
   "ClusterName": "loadtest",
   "ClusterVpcID": "",

--- a/config/deployer.sample.toml
+++ b/config/deployer.sample.toml
@@ -2,7 +2,7 @@
 AWSAMI = 'ami-003d3d03cfe1b0468'
 AWSProfile = 'mm-loadtest'
 AWSRegion = 'us-east-1'
-AWSAvailabilityZone = 'us-east-1a'
+AWSAvailabilityZone = 'us-east-1c'
 
 # Mattermost configuration
 AdminEmail = 'sysadmin@sample.mattermost.com'

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	AWSRegion string `default:"us-east-1"`
 	// AWSAvailabilityZone defines the Availability Zone
 	// in which instances should be deployed.
-	AWSAvailabilityZone string `default:"us-east-1a"`
+	AWSAvailabilityZone string `default:"us-east-1c"`
 	// AWSAMI is the AMI to use for all EC2 instances.
 	AWSAMI string `default:"ami-0fa37863afb290840"`
 	// ClusterName is the name of the cluster.

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -129,8 +129,9 @@ func TestTerraformMapString(t *testing.T) {
 	emptyMap := make(TerraformMap)
 
 	testCases := []struct {
-		actual   TerraformMap
-		expected string
+		actual    TerraformMap
+		expected  string
+		expected2 string
 	}{
 		{
 			actual: TerraformMap{
@@ -143,7 +144,8 @@ func TestTerraformMapString(t *testing.T) {
 				"uno": "1",
 				"dos": "2",
 			},
-			expected: "{uno = \"1\", dos = \"2\"}",
+			expected:  "{uno = \"1\", dos = \"2\"}",
+			expected2: "{dos = \"2\", uno = \"1\"}",
 		},
 		{
 			actual:   nilMap,
@@ -156,7 +158,10 @@ func TestTerraformMapString(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		require.Equal(t, testCase.expected, testCase.actual.String())
-	}
+		actual := testCase.actual.String()
 
+		// map order is non deterministic
+		equals := testCase.expected == actual || (testCase.expected2 != "" && testCase.expected2 == actual)
+		require.True(t, equals)
+	}
 }


### PR DESCRIPTION
#### Summary

Defaulting on `us-east-1c` since it was proven to work, while others may have issues (especially 1a and 1b).


Still undecided on whether we should force the default if unset (empty). Let me know if you have any thoughts.

