### PR TITLE
MM-52099: Be more gentle with comparison failures

### DIFF
--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -67,6 +67,13 @@ func writeResults(results []comparison.Result, writer io.Writer) error {
 	var content string
 
 	for i, res := range results {
+		if len(res.LoadTests) < 2 || res.LoadTests[0].Failed || res.LoadTests[1].Failed {
+			content += "==================================================\n"
+			content += fmt.Sprintf("Deployment %d: No results generated\n", i)
+			content += "==================================================\n\n"
+			continue
+		}
+
 		content += "=================================================="
 		content += "Comparison result:"
 		content += fmt.Sprintf("Report: %s\n", getReportFilename(i, res))

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -101,18 +101,24 @@ func (c *Comparison) Run() (Output, error) {
 					mlog.Debug("initializing load-test")
 					// initialize instance state
 					if err := initLoadTest(t, buildCfg, dumpFilename, s3BucketURI); err != nil {
+						res.LoadTests[i] = LoadTestResult{Failed: true}
 						errsCh <- err
-						return
+						break
 					}
 					mlog.Debug("load-test init done")
 
 					status, err := runLoadTest(t, lt)
 					if err != nil {
+						res.LoadTests[i] = LoadTestResult{Failed: true}
 						errsCh <- err
-						return
+						break
 					}
-					res.LoadTests[i] = LoadTestResult{loadTestID: ltID,
-						Label: buildCfg.Label, Config: lt, Status: status}
+					res.LoadTests[i] = LoadTestResult{
+						loadTestID: ltID,
+						Label:      buildCfg.Label,
+						Config:     lt,
+						Status:     status,
+					}
 				}
 
 				resultsCh <- res

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -26,7 +26,6 @@ type Comparison struct {
 	config         *Config
 	deploymentInfo DeploymentInfo
 	deployments    map[string]*deploymentConfig
-	cancelCh       chan struct{}
 }
 
 // New creates and initializes a new Comparison object to be used to run
@@ -40,7 +39,6 @@ func New(cfg *Config, deployerCfg *deployment.Config) (*Comparison, error) {
 		config:         cfg,
 		deploymentInfo: getDeploymentInfo(deployerCfg),
 		deployments:    map[string]*deploymentConfig{},
-		cancelCh:       make(chan struct{}),
 	}
 
 	var i int
@@ -102,13 +100,13 @@ func (c *Comparison) Run() (Output, error) {
 				for i, buildCfg := range []BuildConfig{c.config.BaseBuild, c.config.NewBuild} {
 					mlog.Debug("initializing load-test")
 					// initialize instance state
-					if err := initLoadTest(t, buildCfg, dumpFilename, s3BucketURI, c.cancelCh); err != nil {
+					if err := initLoadTest(t, buildCfg, dumpFilename, s3BucketURI); err != nil {
 						errsCh <- err
 						return
 					}
 					mlog.Debug("load-test init done")
 
-					status, err := runLoadTest(t, lt, c.cancelCh)
+					status, err := runLoadTest(t, lt)
 					if err != nil {
 						errsCh <- err
 						return
@@ -128,14 +126,13 @@ func (c *Comparison) Run() (Output, error) {
 		close(errsCh)
 	}()
 
-	if err := <-errsCh; err != nil {
-		mlog.Error("an error has occurred, cancelling", mlog.Err(err))
-		close(c.cancelCh)
-		wg.Wait()
-		return output, err
+	for err := range errsCh {
+		if err != nil {
+			mlog.Error("an error has occurred", mlog.Err(err))
+		}
 	}
 
-	mlog.Info("load-tests have completed, going to generate some results")
+	mlog.Info("load-tests have completed, generating results")
 
 	output.DeploymentInfo = c.deploymentInfo
 	// do actual comparisons and generate some results

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -62,10 +62,6 @@ func runBoundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Config,
 
 	mlog.Info("bounded load-test has completed")
 
-	// TODO: remove this once MM-30326 has been merged and a new release
-	// published.
-	status.StopTime = time.Now()
-
 	return status, nil
 }
 

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -33,8 +33,7 @@ func (c *Comparison) getLoadTestsCount() int {
 	return count
 }
 
-func runBoundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Config,
-	d time.Duration, cancelCh <-chan struct{}) (coordinator.Status, error) {
+func runBoundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Config, d time.Duration) (coordinator.Status, error) {
 	var err error
 	var status coordinator.Status
 	mlog.Info("starting bounded load-test")
@@ -42,13 +41,8 @@ func runBoundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Config,
 		return status, err
 	}
 
-	var canceled bool
-	select {
-	case <-cancelCh:
-		mlog.Info("cancelling load-test")
-		canceled = true
-	case <-time.After(d):
-	}
+	// Wait for the specified duration
+	<-time.After(d)
 
 	mlog.Info("stopping bounded load-test")
 	status, err = t.StopCoordinator()
@@ -56,17 +50,12 @@ func runBoundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Config,
 		return status, err
 	}
 
-	if canceled {
-		return status, errors.New("canceled")
-	}
-
 	mlog.Info("bounded load-test has completed")
 
 	return status, nil
 }
 
-func runUnboundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Config,
-	cancelCh <-chan struct{}) (coordinator.Status, error) {
+func runUnboundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Config) (coordinator.Status, error) {
 	var err error
 	var status coordinator.Status
 
@@ -81,9 +70,6 @@ func runUnboundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Confi
 		}
 	}()
 
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-
 	for {
 		status, err = t.GetCoordinatorStatus()
 		if err != nil {
@@ -97,13 +83,6 @@ func runUnboundedLoadTest(t *terraform.Terraform, coordConfig *coordinator.Confi
 
 		if status.State != coordinator.Running {
 			return status, errors.New("coordinator should be running")
-		}
-
-		select {
-		case <-cancelCh:
-			mlog.Info("cancelling load-test")
-			return status, errors.New("canceled")
-		case <-ticker.C:
 		}
 	}
 }
@@ -183,7 +162,7 @@ func populateBucket(ctx context.Context, bucket *s3ClientWrapper, targetBucket, 
 	return nil
 }
 
-func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename string, s3BucketURI string, cancelCh <-chan struct{}) error {
+func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename string, s3BucketURI string) error {
 	tfOutput, err := t.Output()
 	if err != nil {
 		return fmt.Errorf("failed to get terraform output: %w", err)
@@ -314,16 +293,15 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		cmds = append(cmds, loadDBDumpCmd, clearLicensesCmd, startCmd)
 	}
 
-	// Resetting the buckets can happen concurrently with the rest of the remote commands,
-	// but we need to cancel them on return in case we return early (as when we receive from cancelCh)
-	resetBucketCtx, resetBucketCancel := context.WithCancel(context.Background())
-	defer resetBucketCancel()
+	// Resetting the buckets can happen concurrently with the rest of the remote commands
 	resetBucketErrCh := make(chan error, 1)
 	go func() {
 		if s3BucketURI != "" && tfOutput.HasS3Bucket() {
 			mlog.Info("Emptying S3 bucket")
 
-			err := emptyBucket(resetBucketCtx, &s3client, tfOutput.S3Bucket.Id)
+			ctx := context.Background()
+
+			err := emptyBucket(ctx, &s3client, tfOutput.S3Bucket.Id)
 			if err != nil {
 				resetBucketErrCh <- fmt.Errorf("failed to empty s3 bucket: %w", err)
 				return
@@ -331,7 +309,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 
 			mlog.Info("Pre-populating S3 bucket")
 			srcBucketName := strings.TrimPrefix(s3BucketURI, "s3://")
-			err = populateBucket(resetBucketCtx, &s3client, tfOutput.S3Bucket.Id, srcBucketName)
+			err = populateBucket(ctx, &s3client, tfOutput.S3Bucket.Id, srcBucketName)
 			if err != nil {
 				resetBucketErrCh <- fmt.Errorf("failed to populate bucket: %w", err)
 				return
@@ -344,12 +322,6 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 	for _, c := range cmds {
 		mlog.Info(c.Msg)
 		for _, client := range c.Clients {
-			select {
-			case <-cancelCh:
-				mlog.Info("cancelling load-test init")
-				return errors.New("canceled")
-			default:
-			}
 			if out, err := client.RunCommand(c.Value); err != nil {
 				return fmt.Errorf("failed to run cmd %q: %w %s", c.Value, err, out)
 			}
@@ -360,7 +332,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 	return <-resetBucketErrCh
 }
 
-func runLoadTest(t *terraform.Terraform, lt LoadTestConfig, cancelCh <-chan struct{}) (coordinator.Status, error) {
+func runLoadTest(t *terraform.Terraform, lt LoadTestConfig) (coordinator.Status, error) {
 	var status coordinator.Status
 	coordConfig, err := coordinator.ReadConfig("")
 	if err != nil {
@@ -380,10 +352,10 @@ func runLoadTest(t *terraform.Terraform, lt LoadTestConfig, cancelCh <-chan stru
 		if parseErr != nil {
 			return status, parseErr
 		}
-		return runBoundedLoadTest(t, coordConfig, duration, cancelCh)
+		return runBoundedLoadTest(t, coordConfig, duration)
 	case LoadTestTypeUnbounded:
 		// TODO: cleverly set MaxActiveUsers to (numAgents * UsersConfiguration.MaxActiveUsers)
-		return runUnboundedLoadTest(t, coordConfig, cancelCh)
+		return runUnboundedLoadTest(t, coordConfig)
 	}
 
 	return status, fmt.Errorf("unimplemented LoadTestType %s", lt.Type)


### PR DESCRIPTION
#### Summary
Before this PR, when running a comparison, the tool would cancel all tests if any single one of them would fail. This does not need to be like this, since all runs in a comparison are independent of each other: they're completely different deployments. If one of them fails, we can still try to finish the other ones, so that we only need to retry one of them in a second try.

This PR does exactly that: it makes the independent deployments actually independent by removing the cancel channel, which was used to broadcast the cancel to all deployments in the case of a single failure. Removing this makes the code slightly less complex as well.

And while I was here:
- I've removed an ancient TODO that was fixed four years ago (:shrug:)
- I've added the deployment ID to error log lines to know which test specifically failed

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52099
