### PR TITLE
MM-49059: Fix collect error when no apps are deployed

### DIFF
--- a/cmd/ltctl/collect.go
+++ b/cmd/ltctl/collect.go
@@ -176,13 +176,13 @@ func collect(config deployment.Config, deploymentId string, outputName string) e
 		return err
 	}
 
-	if !output.HasAppServers() {
-		return errors.New("no active deployment found")
-	}
-
 	clients, err := createClients(output)
 	if err != nil {
 		return err
+	}
+
+	if len(clients) == 0 {
+		return errors.New("no active deployment found")
 	}
 
 	var collectFiles []collectFileInfo


### PR DESCRIPTION
#### Summary
Instead of relying on the existence of app nodes, which may not be available in an agents-only deployment, to verify that a deployment is ready, directly get the list of all available clients and then check if we have at least one to collect data from. Otherwise, stop the log collection.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49059