### PR TITLE
MM-56823: Validate license only when deploying app nodes

### DIFF
--- a/defaults/validate.go
+++ b/defaults/validate.go
@@ -153,14 +153,6 @@ func validate(validation, fieldName string, p, v reflect.Value) error {
 		if s == "" || !isAlphanumeric(s) {
 			return fmt.Errorf("%s is not alphanumeric", fieldName)
 		}
-	case "emptyorfile":
-		s := v.String()
-		if s == "" {
-			return nil
-		}
-		if _, err := os.Stat(s); os.IsNotExist(err) {
-			return fmt.Errorf("%s: %w", fieldName, err)
-		}
 	case "file":
 		s := v.String()
 		if _, err := os.Stat(s); os.IsNotExist(err) {

--- a/defaults/validate.go
+++ b/defaults/validate.go
@@ -11,8 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-
-	"github.com/wiggin77/merror"
 )
 
 var (
@@ -99,7 +97,7 @@ func validate(validation, fieldName string, p, v reflect.Value) error {
 	// Multiple validations separated by a colon (as in "empty;file") behave like an OR clause
 	if strings.Contains(validation, ";") {
 		individualValidations := strings.Split(validation, ";")
-		merr := merror.New()
+		errs := []error{}
 		for _, validation := range individualValidations {
 			err := validate(validation, fieldName, p, v)
 			// Return as soon as one is valid
@@ -107,9 +105,9 @@ func validate(validation, fieldName string, p, v reflect.Value) error {
 				return nil
 			}
 
-			merr.Append(err)
+			errs = append(errs, err)
 		}
-		return fmt.Errorf("%s failed all validations %q: %w", fieldName, individualValidations, merr)
+		return fmt.Errorf("%s failed all validations %q: %w", fieldName, individualValidations, errors.Join(errs...))
 	}
 
 	switch validation {

--- a/defaults/validate.go
+++ b/defaults/validate.go
@@ -94,9 +94,9 @@ func Validate(value interface{}) error {
 }
 
 func validate(validation, fieldName string, p, v reflect.Value) error {
-	// Multiple validations separated by a colon (as in "empty;file") behave like an OR clause
-	if strings.Contains(validation, ";") {
-		individualValidations := strings.Split(validation, ";")
+	// Multiple validations separated by a pipe (as in "empty|file") behave like an OR clause
+	if strings.Contains(validation, "|") {
+		individualValidations := strings.Split(validation, "|")
 		errs := []error{}
 		for _, validation := range individualValidations {
 			err := validate(validation, fieldName, p, v)

--- a/defaults/validate.go
+++ b/defaults/validate.go
@@ -123,6 +123,14 @@ func validate(validation, fieldName string, p, v reflect.Value) error {
 		if s == "" || !isAlphanumeric(s) {
 			return fmt.Errorf("%s is not alphanumeric", fieldName)
 		}
+	case "emptyorfile":
+		s := v.String()
+		if s == "" {
+			return nil
+		}
+		if _, err := os.Stat(s); os.IsNotExist(err) {
+			return fmt.Errorf("%s: %w", fieldName, err)
+		}
 	case "file":
 		s := v.String()
 		if _, err := os.Stat(s); os.IsNotExist(err) {

--- a/defaults/validate_test.go
+++ b/defaults/validate_test.go
@@ -19,7 +19,8 @@ func TestValidate(t *testing.T) {
 		MaxUsers      int    `default:"1000" validate:"range:(0,]"`
 		LogLevel      string `default:"ERROR" validate:"oneof:{TRACE, INFO, WARN, ERROR}"`
 		S3URI         string `default:"" validate:"s3uri"`
-		LicenseFile   string `default:"" validate:"emptyorfile"`
+		LicenseFile   string `default:"" validate:"empty;file"`
+		MultiRange    int    `default:"2" validate:"range:[0,3];range:[6,7]"`
 	}
 
 	t.Run("happy path", func(t *testing.T) {
@@ -374,7 +375,7 @@ func TestValidate(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("empty emptyorfile", func(t *testing.T) {
+	t.Run("empty empty;file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 
@@ -384,7 +385,7 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("valid non-empty emptyorfile", func(t *testing.T) {
+	t.Run("valid non-empty empty;file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 
@@ -398,7 +399,7 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("invalid emptyorfile", func(t *testing.T) {
+	t.Run("invalid file empty;file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 
@@ -408,7 +409,7 @@ func TestValidate(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("not a path for emptyorfile", func(t *testing.T) {
+	t.Run("not a path for empty;file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 
@@ -416,6 +417,26 @@ func TestValidate(t *testing.T) {
 
 		err := Validate(&cfg)
 		require.Error(t, err)
+	})
+
+	t.Run("multirange", func(t *testing.T) {
+		var cfg serverConfiguration
+		Set(&cfg)
+
+		valid := []int{0, 1, 2, 3, 6, 7}
+		invalid := []int{-2, -1, 4, 5, 8, 9}
+
+		for _, v := range valid {
+			cfg.MultiRange = v
+			err := Validate(cfg)
+			require.NoError(t, err)
+		}
+
+		for _, v := range invalid {
+			cfg.MultiRange = v
+			err := Validate(cfg)
+			require.Error(t, err)
+		}
 	})
 }
 

--- a/defaults/validate_test.go
+++ b/defaults/validate_test.go
@@ -19,8 +19,8 @@ func TestValidate(t *testing.T) {
 		MaxUsers      int    `default:"1000" validate:"range:(0,]"`
 		LogLevel      string `default:"ERROR" validate:"oneof:{TRACE, INFO, WARN, ERROR}"`
 		S3URI         string `default:"" validate:"s3uri"`
-		LicenseFile   string `default:"" validate:"empty;file"`
-		MultiRange    int    `default:"2" validate:"range:[0,3];range:[6,7]"`
+		LicenseFile   string `default:"" validate:"empty|file"`
+		MultiRange    int    `default:"2" validate:"range:[0,3]|range:[6,7]"`
 	}
 
 	t.Run("happy path", func(t *testing.T) {
@@ -375,7 +375,7 @@ func TestValidate(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("empty empty;file", func(t *testing.T) {
+	t.Run("empty empty|file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 
@@ -385,7 +385,7 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("valid non-empty empty;file", func(t *testing.T) {
+	t.Run("valid non-empty empty|file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 
@@ -399,7 +399,7 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("invalid file empty;file", func(t *testing.T) {
+	t.Run("invalid file empty|file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 
@@ -409,7 +409,7 @@ func TestValidate(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("not a path for empty;file", func(t *testing.T) {
+	t.Run("not a path for empty|file", func(t *testing.T) {
 		var cfg serverConfiguration
 		Set(&cfg)
 

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	// 3. If it is a file:// pointing to a tar.gz, use that as the Mattermost release.
 	MattermostDownloadURL string `default:"https://latest.mattermost.com/mattermost-enterprise-linux" validate:"url"`
 	// Path to the Mattermost EE license file.
-	MattermostLicenseFile string `default:"" validate:"empty;file"`
+	MattermostLicenseFile string `default:"" validate:"empty|file"`
 	// Optional path to a partial Mattermost config file to be applied as patch during
 	// app server deployment.
 	MattermostConfigPatchFile string `default:""`

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	// 3. If it is a file:// pointing to a tar.gz, use that as the Mattermost release.
 	MattermostDownloadURL string `default:"https://latest.mattermost.com/mattermost-enterprise-linux" validate:"url"`
 	// Path to the Mattermost EE license file.
-	MattermostLicenseFile string `default:"" validate:"file"`
+	MattermostLicenseFile string `default:"" validate:"emptyorfile"`
 	// Optional path to a partial Mattermost config file to be applied as patch during
 	// app server deployment.
 	MattermostConfigPatchFile string `default:""`

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	// 3. If it is a file:// pointing to a tar.gz, use that as the Mattermost release.
 	MattermostDownloadURL string `default:"https://latest.mattermost.com/mattermost-enterprise-linux" validate:"url"`
 	// Path to the Mattermost EE license file.
-	MattermostLicenseFile string `default:"" validate:"emptyorfile"`
+	MattermostLicenseFile string `default:"" validate:"empty;file"`
 	// Optional path to a partial Mattermost config file to be applied as patch during
 	// app server deployment.
 	MattermostConfigPatchFile string `default:""`

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -106,8 +106,12 @@ func (t *Terraform) Create(initData bool) error {
 		return err
 	}
 
-	if err := validateLicense(t.config.MattermostLicenseFile); err != nil {
-		return fmt.Errorf("license validation failed: %w", err)
+	// Validate the license only if we deploy app nodes;
+	// otherwise we don't need a license at all
+	if t.config.AppInstanceCount > 0 {
+		if err := validateLicense(t.config.MattermostLicenseFile); err != nil {
+			return fmt.Errorf("license validation failed: %w", err)
+		}
 	}
 
 	extAgent, err := ssh.NewAgent()


### PR DESCRIPTION
#### Summary
If we are not deploying app nodes (to load-test an already existing Mattermost installation), we don't need to validate the license (first commit). Actually, we don't even need to specify a file in the config at all (second commit).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56823