### PR TITLE
Bump Go version to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
           cache: true
 
       - name: ci/pre-init

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/mattermost/mattermost-load-test-ng
 
-go 1.21.0
+go 1.22
 
-toolchain go1.21.8
+toolchain go1.22.8
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
#### Summary
Bump the Go version to 1.22, using the latest minor version for the toolchain.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61011