### PR TITLE
MM-60501: Remove import of the restored RDS cluster

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -119,21 +119,6 @@ func (t *Terraform) Create(initData bool) error {
 		return err
 	}
 
-	// If we are using a restored cluster, first we need to import
-	// it into Terraform state.
-	if t.config.TerraformDBSettings.ClusterIdentifier != "" {
-		var params []string
-		params = append(params, "import")
-		params = append(params, t.getParams()...)
-		params = append(params, "-state="+t.getStatePath())
-		params = append(params, "aws_rds_cluster.db_cluster", t.config.TerraformDBSettings.ClusterIdentifier)
-
-		err = t.runCommand(nil, params...)
-		if err != nil {
-			return err
-		}
-	}
-
 	var uploadPath string
 	var uploadBinary bool
 	var uploadRelease bool


### PR DESCRIPTION
#### Summary
It turns out that this import has been silently failing forever. Starting with Terraform v1.9, though, it started triggering an error that made the deployment fail: `Configuration for import target does not exist`. For more information, see https://developer.hashicorp.com/terraform/language/upgrade-guides#invalid-import-blocks

But the thing is that we don't actually need it! We already create the RDS cluster conditionally, skipping it if `ClusterIdentifier` is specified. Also, the DB instances are attached to the new cluster if one is created but, again, if `ClusterIdentifier` is specified, they are attached to that one.

That's why the whole thing has always worked despite the import command failing: we don't actually need it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60501