### PR TITLE
[MM-60412] Fix potentially stuck init process

### DIFF
--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -65,9 +65,18 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	siteURLOverride, err := cmd.Flags().GetString("site-url")
+	if err != nil {
+		return err
+	}
+
 	config, err := loadtest.ReadConfig(configFilePath)
 	if err != nil {
 		return err
+	}
+
+	if siteURLOverride != "" {
+		config.ConnectionConfiguration.ServerURL = siteURLOverride
 	}
 
 	if err := defaults.Validate(*config); err != nil {
@@ -215,6 +224,7 @@ func MakeInitCommand() *cobra.Command {
 		PreRun:       SetupLoadTest,
 	}
 	cmd.PersistentFlags().StringP("user-prefix", "", "testuser", "prefix used when generating usernames and emails")
+	cmd.PersistentFlags().StringP("site-url", "", "", "an optional override for ConnectionConfiguration.ServerURL")
 	return cmd
 }
 

--- a/cmd/ltagent/init.go
+++ b/cmd/ltagent/init.go
@@ -65,7 +65,7 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	siteURLOverride, err := cmd.Flags().GetString("site-url")
+	serverURLOverride, err := cmd.Flags().GetString("server-url")
 	if err != nil {
 		return err
 	}
@@ -75,8 +75,8 @@ func RunInitCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if siteURLOverride != "" {
-		config.ConnectionConfiguration.ServerURL = siteURLOverride
+	if serverURLOverride != "" {
+		config.ConnectionConfiguration.ServerURL = serverURLOverride
 	}
 
 	if err := defaults.Validate(*config); err != nil {
@@ -224,7 +224,7 @@ func MakeInitCommand() *cobra.Command {
 		PreRun:       SetupLoadTest,
 	}
 	cmd.PersistentFlags().StringP("user-prefix", "", "testuser", "prefix used when generating usernames and emails")
-	cmd.PersistentFlags().StringP("site-url", "", "", "an optional override for ConnectionConfiguration.ServerURL")
+	cmd.PersistentFlags().StringP("server-url", "", "", "an optional override for ConnectionConfiguration.ServerURL")
 	return cmd
 }
 

--- a/cmd/ltctl/reset.go
+++ b/cmd/ltctl/reset.go
@@ -89,7 +89,7 @@ func RunResetCmdF(cmd *cobra.Command, args []string) error {
 			clients: []*ssh.Client{appClients[0]},
 		},
 		{
-			msg:     "Restarting app server...",
+			msg:     "Restarting app servers...",
 			value:   "sudo systemctl restart mattermost && until $(curl -sSf http://localhost:8065 --output /dev/null); do sleep 1; done;",
 			clients: appClients,
 		},
@@ -100,8 +100,9 @@ func RunResetCmdF(cmd *cobra.Command, args []string) error {
 			clients: []*ssh.Client{appClients[0]},
 		},
 		{
-			msg:     "Initializing data...",
-			value:   fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s'", output.Agents[0].Tags.Name),
+			msg: "Initializing data...",
+			value: fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --site-url 'http://%s:8065'",
+				output.Agents[0].Tags.Name, output.Instances[0].PrivateIP),
 			clients: []*ssh.Client{agentClient},
 		},
 	}

--- a/cmd/ltctl/reset.go
+++ b/cmd/ltctl/reset.go
@@ -101,7 +101,7 @@ func RunResetCmdF(cmd *cobra.Command, args []string) error {
 		},
 		{
 			msg: "Initializing data...",
-			value: fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --site-url 'http://%s:8065'",
+			value: fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --server-url 'http://%s:8065'",
 				output.Agents[0].Tags.Name, output.Instances[0].PrivateIP),
 			clients: []*ssh.Client{agentClient},
 		},

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -244,8 +244,9 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		Clients: []*ssh.Client{appClients[0]},
 	}
 	initDataCmd := deployment.Cmd{
-		Msg:     "Initializing data",
-		Value:   fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' > /dev/null 2>&1", tfOutput.Agents[0].Tags.Name),
+		Msg: "Initializing data",
+		Value: fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --site-url 'http://%s:8065' > /dev/null 2>&1",
+			tfOutput.Agents[0].Tags.Name, tfOutput.Instances[0].PrivateIP),
 		Clients: []*ssh.Client{agentClient},
 	}
 

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -245,7 +245,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 	}
 	initDataCmd := deployment.Cmd{
 		Msg: "Initializing data",
-		Value: fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --site-url 'http://%s:8065' > /dev/null 2>&1",
+		Value: fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --server-url 'http://%s:8065' > /dev/null 2>&1",
 			tfOutput.Agents[0].Tags.Name, tfOutput.Instances[0].PrivateIP),
 		Clients: []*ssh.Client{agentClient},
 	}

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -233,7 +233,8 @@ func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, initData bool) error {
 
 	if initData && t.config.TerraformDBSettings.ClusterIdentifier == "" {
 		mlog.Info("Populating initial data for load-test", mlog.String("agent", ip))
-		cmd := fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s'", t.output.Agents[0].Tags.Name)
+		cmd := fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --site-url 'http://%s:8065'",
+			t.output.Agents[0].Tags.Name, t.output.Instances[0].PrivateIP)
 		if out, err := sshc.RunCommand(cmd); err != nil {
 			// TODO: make this fully atomic. See MM-23998.
 			// ltagent init should drop teams and channels before creating them.

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -233,7 +233,7 @@ func (t *Terraform) initLoadtest(extAgent *ssh.ExtAgent, initData bool) error {
 
 	if initData && t.config.TerraformDBSettings.ClusterIdentifier == "" {
 		mlog.Info("Populating initial data for load-test", mlog.String("agent", ip))
-		cmd := fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --site-url 'http://%s:8065'",
+		cmd := fmt.Sprintf("cd mattermost-load-test-ng && ./bin/ltagent init --user-prefix '%s' --server-url 'http://%s:8065'",
 			t.output.Agents[0].Tags.Name, t.output.Instances[0].PrivateIP)
 		if out, err := sshc.RunCommand(cmd); err != nil {
 			// TODO: make this fully atomic. See MM-23998.


### PR DESCRIPTION
#### Summary

The high concurrency of the init process could cause some permission errors [when fetching channels for a previously joined team](https://github.com/mattermost/mattermost-load-test-ng/blob/0d94529ac36a34ce004c5561b086d71354438f98/loadtest/control/gencontroller/actions.go#L499-L501). Since we try to fetch the channels right after joining a team, this could naturally happen as a result of replica lag. 

However, certain app nodes could consistently return 403 as somehow the `model.Session.TeamMembers` would be not in sync with the real state (user joined all teams). I couldn't fully understand why that is happening, so it remains something to potentially investigate separately.

The fix on this side is pretty naive: we merely force the init to happen on the first app server, preventing any of the above from happening.

Note: This is technically a breaking change since it requires an updated `ltagent` binary for the deployment step to work. I'm not sure how we want to handle this. We should probably merge this PR when we prepare the next release to minimize the chance of this causing issues. Let me know.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60412