### PR TITLE
MM-60393: Show error when disk space is less than ES index size

### DIFF
--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -139,7 +139,7 @@
     "App": 10,
     "Metrics": 50,
     "Job": 50,
-    "ElasticSearch": 20
+    "ElasticSearch": 100
   },
   "PyroscopeSettings": {
     "EnableAppProfiling": true,

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -147,7 +147,7 @@ type StorageSizes struct {
 	// Size, in GiB, for the storage of the job server instances
 	Job int `default:"50"`
 	// Size, in GiB, for the storage of the elasticsearch instances
-	ElasticSearch int `default:"20"`
+	ElasticSearch int `default:"100"`
 	// Size, in GiB, for the storage of the keycloak instances
 	KeyCloak int `default:"10"`
 }

--- a/deployment/opensearch/opensearch.go
+++ b/deployment/opensearch/opensearch.go
@@ -280,6 +280,7 @@ type SnapshotIndexShardRecovery struct {
 	Index   string
 	Stage   string
 	Percent string
+	Size    int
 }
 
 // SnapshotIndicesRecovery returns status information for each index shard in
@@ -305,6 +306,7 @@ func (c *Client) SnapshotIndicesRecovery(indices []string) ([]SnapshotIndexShard
 				// We're using the percentage of bytes restored,
 				// not the percentage of files restored
 				Percent: shard.Index.Size.Percent,
+				Size:    shard.Index.Size.TotalInBytes,
 			})
 		}
 	}

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -664,7 +664,7 @@ func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) 
 // timeout is reached
 func (t *Terraform) waitForSnapshot(es *opensearch.Client, snapshotIndices []string) error {
 	dur := time.Duration(t.config.ElasticSearchSettings.RestoreTimeoutMinutes) * time.Minute
-	esDiskSpaceBytes := t.config.StorageSizes.ElasticSearch*1024*1024*1024
+	esDiskSpaceBytes := t.config.StorageSizes.ElasticSearch * 1024 * 1024 * 1024
 	timeout := time.After(dur)
 	for {
 		select {

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -637,8 +637,7 @@ func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) 
 
 	// Wait until the snapshot is completely restored, or the user-specified
 	// timeout is triggered, whatever happens first
-	restoreTimeout := time.Duration(esSettings.RestoreTimeoutMinutes) * time.Minute
-	if err := waitForSnapshot(restoreTimeout, os, snapshotIndices); err != nil {
+	if err := t.waitForSnapshot(os, snapshotIndices); err != nil {
 		return fmt.Errorf("failed to wait for snapshot completion: %w", err)
 	}
 
@@ -663,7 +662,9 @@ func (t *Terraform) setupElasticSearchServer(extAgent *ssh.ExtAgent, ip string) 
 
 // waitForSnapshot blocks until the snapshot is fully restored or the provided
 // timeout is reached
-func waitForSnapshot(dur time.Duration, es *opensearch.Client, snapshotIndices []string) error {
+func (t *Terraform) waitForSnapshot(es *opensearch.Client, snapshotIndices []string) error {
+	dur := time.Duration(t.config.ElasticSearchSettings.RestoreTimeoutMinutes) * time.Minute
+	esDiskSpaceBytes := t.config.StorageSizes.ElasticSearch*1024*1024*1024
 	timeout := time.After(dur)
 	for {
 		select {
@@ -676,13 +677,15 @@ func waitForSnapshot(dur time.Duration, es *opensearch.Client, snapshotIndices [
 			}
 
 			// Compute progress
-			var indicesDone, indicesInProgress, totalPerc int
+			var indicesDone, indicesInProgress, totalPerc, totalIndexSize int
 			for _, i := range indicesRecovery {
 				if i.Stage == "DONE" {
 					indicesDone++
 				} else {
 					indicesInProgress++
 				}
+
+				totalIndexSize += i.Size
 
 				// Remove the trailing "%" and the dot, so 75.8% is converted to 758
 				percString := strings.ReplaceAll(i.Percent[:len(i.Percent)-1], ".", "")
@@ -691,6 +694,10 @@ func waitForSnapshot(dur time.Duration, es *opensearch.Client, snapshotIndices [
 					return fmt.Errorf("percentage %q cannot be parsed: %w", i.Percent, err)
 				}
 				totalPerc += perc
+			}
+
+			if totalIndexSize > esDiskSpaceBytes {
+				return fmt.Errorf("total index size to be restored: %d bytes, greater than configured disk space %d bytes", totalIndexSize, esDiskSpaceBytes)
 			}
 
 			// Finish when all indices are marked as "DONE"
@@ -706,7 +713,9 @@ func waitForSnapshot(dur time.Duration, es *opensearch.Client, snapshotIndices [
 				mlog.String("avg % completed", fmt.Sprintf("%.2f", avgPerc)),
 				mlog.Int("indices waiting", indicesWaiting),
 				mlog.Int("indices in progress", indicesInProgress),
-				mlog.Int("indices recovered", indicesDone))
+				mlog.Int("indices recovered", indicesDone),
+				mlog.Int("total index size", totalIndexSize),
+			)
 		}
 	}
 }


### PR DESCRIPTION
While restoring, we check for the total size of the indices
and throw an error if the total size exceeds the configured disk space.

Ideally, we should have thrown an error pre-deployment. But from what
I could see, there is no way to actually find out the size of the index
before restoring the snapshot.

Let me know if you think there's a better way.

```
info  [2024-10-14 17:40:13.563 +05:30] Vacuuming the tables                          caller="terraform/create.go:917" cmd="psql 'postgres://mmuser:mostest80098bigpass_@agnivalocallt-db-0.c0gzspkyf2r5.us-east-1.rds.amazonaws.com/agnivalocalltdb?sslmode=disable' -c 'vacuum analyze channels, sidebarchannels, sidebarcategories, posts, threads, threadmemberships, channelmembers;'"
info  [2024-10-14 17:40:34.297 +05:30] Restoring ElasticSearch snapshot...           caller="terraform/create.go:712" avg % completed=13.31 indices waiting=8 indices in progress=4 indices recovered=1 total index size=16700652224
info  [2024-10-14 17:41:04.608 +05:30] Restoring ElasticSearch snapshot...           caller="terraform/create.go:712" avg % completed=23.35 indices waiting=7 indices in progress=4 indices recovered=2 total index size=17277979930
info  [2024-10-14 17:41:34.915 +05:30] Restoring ElasticSearch snapshot...           caller="terraform/create.go:712" avg % completed=26.56 indices waiting=7 indices in progress=4 indices recovered=2 total index size=17277979930
info  [2024-10-14 17:42:05.226 +05:30] Restoring ElasticSearch snapshot...           caller="terraform/create.go:712" avg % completed=29.41 indices waiting=7 indices in progress=4 indices recovered=2 total index size=17277979930
info  [2024-10-14 17:42:35.540 +05:30] Restoring ElasticSearch snapshot...           caller="terraform/create.go:712" avg % completed=39.51 indices waiting=7 indices in progress=4 indices recovered=2 total index size=17277979930
info  [2024-10-14 17:43:05.843 +05:30] Restoring ElasticSearch snapshot...           caller="terraform/create.go:712" avg % completed=44.12 indices waiting=6 indices in progress=4 indices recovered=3 total index size=23494105905
Error: failed to create terraform env: unable to setup Elasticsearch server: failed to wait for snapshot completion: total index size to be restored 27375844876 greater than configured disk space 26843545600
exit status 1
```

https://mattermost.atlassian.net/browse/MM-60393
