### PR TITLE
[MM-60297] Fix `loadtest_http_errors_total` metric

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -111,6 +111,22 @@ http {
     default 1;
   }
 
+  log_format json escape=json
+	'{'
+		'"time_local":"$time_local",'
+		'"remote_addr":"$remote_addr",'
+		'"remote_user":"$remote_user",'
+		'"request":"$request",'
+		'"request_time":"$request_time",'
+		'"status": "$status",'
+		'"body_bytes_sent":"$body_bytes_sent",'
+		'"upstream_addr":"$upstream_addr",'
+		'"upstream_status":"$upstream_status",'
+		'"upstream_response_time":"$upstream_response_time",'
+		'"upstream_cache_status":"$upstream_cache_status",'
+		'"http_user_agent":"$http_user_agent"'
+	'}';
+
   sendfile on;
   tcp_nopush on;
   tcp_nodelay {{.tcpNoDelay}};
@@ -120,7 +136,7 @@ http {
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
   ssl_prefer_server_ciphers on;
-  access_log /var/log/nginx/access.log combined if=$loggable;
+  access_log /var/log/nginx/access.log json if=$loggable;
   error_log /var/log/nginx/error.log;
   gzip on;
   include /etc/nginx/sites-enabled/*;

--- a/deployment/terraform/strings_test.go
+++ b/deployment/terraform/strings_test.go
@@ -105,7 +105,7 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
-  filelog/proxy:
+  filelog/proxy_error:
     include: [ /var/log/nginx/error.log ]
     resource:
       service.name: "proxy"
@@ -118,6 +118,17 @@ receivers:
           layout: '%Y/%m/%d %H:%M:%S'
         severity:
           parse_from: attributes.sev
+  filelog/proxy_access:
+    include: [ /var/log/nginx/access.log ]
+    resource:
+      service.name: "proxy"
+      service.instance.id: "instance-name"
+    operators:
+      - type: json_parser
+        timestamp:
+          layout: 's.ms'
+          layout_type: epoch
+          parse_from: attributes.ts
 
 exporters:
   otlphttp/logs:
@@ -132,7 +143,7 @@ exporters:
 service:
   pipelines:
     logs:
-      receivers: [filelog/proxy,]
+      receivers: [filelog/proxy_error,filelog/proxy_access,]
       exporters: [otlphttp/logs,debug]
 `
 )

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
@@ -38,6 +39,8 @@ const (
 	AuthenticationTypeOpenID     = "openid"
 	AuthenticationTypeSAML       = "saml"
 )
+
+var stripIDsRE = regexp.MustCompile(`\b\w{26}\b`)
 
 // Config holds necessary information required by a UserEntity.
 type Config struct {
@@ -104,10 +107,10 @@ func (t *ueTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.transport.RoundTrip(req)
 	t.ue.observeHTTPRequestTimes(time.Since(startTime).Seconds())
 	if os.IsTimeout(err) {
-		t.ue.incHTTPTimeouts(req.URL.Path, req.Method)
+		t.ue.incHTTPTimeouts(stripIDs(req.URL.Path), req.Method)
 	}
 	if resp != nil && resp.StatusCode >= 400 {
-		t.ue.incHTTPErrors(req.URL.Path, req.Method, resp.StatusCode)
+		t.ue.incHTTPErrors(stripIDs(req.URL.Path), req.Method, resp.StatusCode)
 	}
 	return resp, err
 }
@@ -244,4 +247,8 @@ func (ue *UserEntity) getUserFromStore() (*model.User, error) {
 		return nil, errors.New("user was not initialized")
 	}
 	return user, nil
+}
+
+func stripIDs(path string) string {
+	return stripIDsRE.ReplaceAllString(path, "$$ID")
 }

--- a/loadtest/user/userentity/utils_test.go
+++ b/loadtest/user/userentity/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPostsMapToSlice(t *testing.T) {
@@ -23,4 +24,30 @@ func TestPostsMapToSlice(t *testing.T) {
 
 	postsMap = map[string]*model.Post{}
 	assert.Len(t, postsMapToSlice(postsMap), 0)
+}
+
+func TestStripIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:     "no match",
+			input:    "/api/v4/users/me",
+			expected: "/api/v4/users/me",
+		},
+		{
+			name:     "match",
+			input:    "/api/v4/users/w9w9rsucuig4ukzf1tzjzfhy5h/teams/s6kdxh9owfyii8zkq7sianthmh/channels",
+			expected: "/api/v4/users/$ID/teams/$ID/channels",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, stripIDs(tc.input))
+		})
+	}
 }


### PR DESCRIPTION
#### Summary

The issue causing the mismatch in 403 errors was due to the extremely high cardinality of the `path` label used in the `loadtest_http_errors_total` counter vector. The errors were tracked correctly by the client, but the `increase` query would return an empty set. 

![image](https://github.com/user-attachments/assets/10ba1883-8174-4733-bbc8-a2aeddaa62a8)

To address this, we replace the IDs in the request path to keep the cardinality low. 

![image](https://github.com/user-attachments/assets/0f4f2b06-5d25-4b30-b56c-613369644817)

If we need that information, we can always find it in the proxy access logs. Speaking of which, I reviewed what we were logging to include more useful info and using JSON for easier filtering/parsing in Loki.

![image](https://github.com/user-attachments/assets/447fdf0d-f1d6-457b-bfcd-3e3033b0205d)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60297
