### PR TITLE
Properly set the Stdout/StdErr field for commands

### DIFF
--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -67,7 +67,7 @@ type cmdLogger struct {
 }
 
 func (*cmdLogger) Write(in []byte) (int, error) {
-	mlog.Info(string(in))
+	mlog.Info(strings.TrimSpace(string(in)))
 	return len(in), nil
 }
 

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -4,13 +4,11 @@
 package terraform
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
-	"sync"
 
 	"time"
 
@@ -65,6 +63,14 @@ func (t *Terraform) runAWSCommand(ctx context.Context, args []string, dst io.Wri
 	return _runCommand(cmd, dst)
 }
 
+type cmdLogger struct {
+}
+
+func (*cmdLogger) Write(in []byte) (int, error) {
+	mlog.Info(string(in))
+	return len(in), nil
+}
+
 func _runCommand(cmd *exec.Cmd, dst io.Writer) error {
 	// If dst is set, that means we want to capture the output.
 	// We write a simple case to handle that using CombinedOutput.
@@ -77,46 +83,10 @@ func _runCommand(cmd *exec.Cmd, dst io.Writer) error {
 		return err
 	}
 
-	// From here, we want to stream the output concurrently from stderr and stdout
-	// to mlog.
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
+	cmd.Stdout = &cmdLogger{}
+	cmd.Stderr = cmd.Stdout
 
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			mlog.Info(scanner.Text())
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			mlog.Info(scanner.Text())
-		}
-	}()
-
-	// No need to check for scanner.Error as cmd.Wait() already does that.
-	wg.Wait()
-
-	if err := cmd.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return cmd.Run()
 }
 
 func checkTerraformVersion() error {

--- a/deployment/terraform/engine.go
+++ b/deployment/terraform/engine.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 
 	"time"
 


### PR DESCRIPTION
We were incorrectly using the Pipe functions
and logging it by parsing each newline. Simply
setting the Stdout/StdErr fields is the correct way
and avoids detecting newlines.

This also improves logging by not splitting every
single newline into a separate log line. Rather
logging a whole string from Terraform in one shot.

Fixes https://github.com/mattermost/mattermost-load-test-ng/issues/835
