### PR TITLE
Misleading error when generating a report with no deployment

### DIFF
--- a/cmd/ltctl/report.go
+++ b/cmd/ltctl/report.go
@@ -92,7 +92,7 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 		}
 
 		if !output.HasMetrics() {
-			return fmt.Errorf("no active deployment found, use the `--prometheus-url` flag.\nIf you have a local or manually deployed Prometheus server running")
+			return fmt.Errorf("no active deployment found, use the `--prometheus-url` flag. If you have a local or manually deployed Prometheus server running")
 		}
 
 		promURL = "http://" + output.MetricsServer.PublicIP + ":9090"

--- a/cmd/ltctl/report.go
+++ b/cmd/ltctl/report.go
@@ -76,7 +76,7 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if promURL == "" {
-		fmt.Printf("Flag --prometheus-url is not set. Defaulting to the deployment's Prometheus server...")
+		fmt.Println("Flag --prometheus-url is not set. Defaulting to the deployment's Prometheus server...")
 		config, err := getConfig(cmd)
 		if err != nil {
 			return err
@@ -92,7 +92,7 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 		}
 
 		if !output.HasMetrics() {
-			return fmt.Errorf("the output has no metrics, no active deployment found")
+			return fmt.Errorf("no active deployment found, use the `--prometheus-url` flag.\nIf you have a local or manually deployed Prometheus server running")
 		}
 
 		promURL = "http://" + output.MetricsServer.PublicIP + ":9090"

--- a/cmd/ltctl/report.go
+++ b/cmd/ltctl/report.go
@@ -92,7 +92,7 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 		}
 
 		if !output.HasMetrics() {
-			return fmt.Errorf("no active deployment found, use the `--prometheus-url` flag. If you have a local or manually deployed Prometheus server running")
+			return fmt.Errorf("no active deployment found, use the `--prometheus-url` flag if you have a local or manually deployed Prometheus server running")
 		}
 
 		promURL = "http://" + output.MetricsServer.PublicIP + ":9090"

--- a/cmd/ltctl/report.go
+++ b/cmd/ltctl/report.go
@@ -90,6 +90,11 @@ func RunGenerateReportCmdF(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("could not parse output: %w", err)
 		}
+
+		if !output.HasMetrics() {
+			return fmt.Errorf("the output has no metrics, no active deployment found")
+		}
+
 		promURL = "http://" + output.MetricsServer.PublicIP + ":9090"
 	}
 

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -93,7 +93,6 @@ type Config struct {
 	Report                report.Config
 	// Directory under which the .terraform directory and state files are managed.
 	// It will be created if it does not exist
-	// ./ltstate is the default value used when `deployer.json`` is configured at all
 	TerraformStateDir string `default:"./ltstate" validate:"notempty"`
 	// URI of an S3 bucket whose contents are copied to the bucket created in the deployment
 	S3BucketDumpURI string `default:"" validate:"s3uri"`

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -246,7 +246,7 @@ type TerraformDBSettings struct {
 // and provisioned.
 type ExternalDBSettings struct {
 	// Mattermost database driver
-	DriverName string `default:"" validate:"oneof:{mysql, postgres, cockroach}"`
+	DriverName string `default:"postgres" validate:"oneof:{mysql, postgres, cockroach}"`
 	// DSN to connect to the database
 	DataSource string `default:""`
 	// DSN to connect to the database replicas

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -93,7 +93,8 @@ type Config struct {
 	Report                report.Config
 	// Directory under which the .terraform directory and state files are managed.
 	// It will be created if it does not exist
-	TerraformStateDir string `default:"/var/lib/mattermost-load-test-ng" validate:"notempty"`
+	// ./ltstate is the default value used when `deployer.json`` is configured at all
+	TerraformStateDir string `default:"./ltstate" validate:"notempty"`
 	// URI of an S3 bucket whose contents are copied to the bucket created in the deployment
 	S3BucketDumpURI string `default:"" validate:"s3uri"`
 	// An optional URI to a MM server database dump file

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -238,6 +238,9 @@ func TestClusterSubnetIDs(t *testing.T) {
 
 		require.NotNil(t, cfg.ClusterSubnetIDs.Redis)
 		require.Len(t, cfg.ClusterSubnetIDs.Redis, 0)
+
+		require.NotNil(t, cfg.TerraformStateDir)
+		require.Equal(t, "./ltstate", cfg.TerraformStateDir)
 	})
 
 	t.Run("String() of default values", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

The problem is that when running local tests, the report generator errors out with a misleading message instead of explicitly stating that there is no deployment and therefore cannot generate a report. The error message should be clearer.

This pull request changes the error message when there is no ongoing deployment while generating a report. It improves error handling by checking whether the current Terraform state includes the metrics instance and errors out when it doesn't. To implement this, the `ExternalDBSettings.DriverName` configuration was changed to use PostgreSQL by default.

#### Ticket Link

--> https://mattermost.atlassian.net/browse/MM-56949
  Github issue: https://github.com/mattermost/mattermost/issues/29148

