### PR TITLE
MM-61881: Use os.MkdirAll, which is thread-safe, to ensure Terraform state dir

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -83,20 +83,7 @@ func New(id string, cfg deployment.Config) (*Terraform, error) {
 }
 
 func ensureTerraformStateDir(dir string) error {
-	// Make sure that the state directory exists
-	_, err := os.Stat(dir)
-	if err == nil {
-		return nil
-	}
-
-	// Return any error different than the one showing
-	// that the directory does not exist
-	if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-
-	// If it does not exist, create it
-	return os.Mkdir(dir, 0700)
+	return os.MkdirAll(dir, 0700)
 }
 
 // Create creates a new load test environment.


### PR DESCRIPTION
#### Summary
As explained in the ticket, we concurrently run every deployment inside a `comparison run`. Each of those deployments call `terraform.New()`, which in turn calls `ensureTerraformStateDir`. This function is not thread-safe, since it first calls `os.Stat` to know whether the directory exists, and if it doesn’t, it then calls `os.Makedir`. It can happen that:
1. Routine A checks `os.Stat` and sees the directory doesn’t exist
2. Then routine B does the exact same thing
3. Then routine A runs `os.Makedir`, and succeeds, creating the directory
4. Now routine B runs `os.Makedir, and fails, since the directory already exists

Technically, the same race condition does happen in [the implementation of os.MkdirAll](https://github.com/golang/go/blob/e33f7c42b084182a3a88ef79857e33c11627159a/src/os/path.go#L19-L66), but that code takes it into account and re-checks the second error (the one on `Mkdir`), and it ends up returning `nil` if the directory was already created, thus avoiding the race condition altogether and making it thread-safe.

Also, the code is way cleaner this way, of course :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61881