### PR TITLE
Cherry-pick of #849: Use os.MkdirAll, which is thread-safe

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -83,20 +83,7 @@ func New(id string, cfg deployment.Config) (*Terraform, error) {
 }
 
 func ensureTerraformStateDir(dir string) error {
-	// Make sure that the state directory exists
-	_, err := os.Stat(dir)
-	if err == nil {
-		return nil
-	}
-
-	// Return any error different than the one showing
-	// that the directory does not exist
-	if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-
-	// If it does not exist, create it
-	return os.Mkdir(dir, 0700)
+	return os.MkdirAll(dir, 0700)
 }
 
 // Create creates a new load test environment.


### PR DESCRIPTION
#### Summary
Cherry-pick #849 to `release-1.23`. Even though I have not released the RC-1 version yet, the branch is protected and I cannot force-push to it (I should have cut it *after* #849 was merged, but alas). Anyway, we need to cherry-pick that now.

#### Ticket Link
--
