### PR TITLE
MM-61944: Decouple vacuum step from Terraform.Create and use it in Comparison

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
+	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 	"github.com/mattermost/mattermost-load-test-ng/logger"
 	"github.com/mattermost/mattermost/server/public/model"
 
@@ -28,10 +29,18 @@ func RunCreateCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create terraform engine: %w", err)
 	}
 
-	initData := config.DBDumpURI == ""
-	err = t.Create(initData)
+	extAgent, err := ssh.NewAgent()
 	if err != nil {
+		return fmt.Errorf("failed to create SSH agent: %w", err)
+	}
+
+	initData := config.DBDumpURI == ""
+	if err = t.Create(extAgent, initData); err != nil {
 		return fmt.Errorf("failed to create terraform env: %w", err)
+	}
+
+	if err := t.PostProcessDatabase(extAgent); err != nil {
+		return fmt.Errorf("failed to post-process database: %w", err)
 	}
 
 	return nil

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -87,7 +87,7 @@ func ensureTerraformStateDir(dir string) error {
 }
 
 // Create creates a new load test environment.
-func (t *Terraform) Create(initData bool) error {
+func (t *Terraform) Create(extAgent *ssh.ExtAgent, initData bool) error {
 	if err := t.preFlightCheck(); err != nil {
 		return err
 	}
@@ -98,11 +98,6 @@ func (t *Terraform) Create(initData bool) error {
 		if err := validateLicense(t.config.MattermostLicenseFile); err != nil {
 			return fmt.Errorf("license validation failed: %w", err)
 		}
-	}
-
-	extAgent, err := ssh.NewAgent()
-	if err != nil {
-		return err
 	}
 
 	var uploadPath string
@@ -149,7 +144,7 @@ func (t *Terraform) Create(initData bool) error {
 		"-input=false",
 		"-state="+t.getStatePath())
 
-	err = t.runCommand(nil, params...)
+	err := t.runCommand(nil, params...)
 	if err != nil {
 		return err
 	}
@@ -275,49 +270,20 @@ func (t *Terraform) Create(initData bool) error {
 		errorsChan <- nil
 	}()
 
-	// Ingest DB dump
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// Note: This MUST be done after app servers have been set up.
-		// Otherwise, the vacuuming command will fail because no tables would
-		// have been created by then.
-		if t.output.HasDB() {
-			// Load the dump if specified
-			if !initData && t.config.DBDumpURI != "" {
-				err = t.IngestDump()
-				if err != nil {
-					errorsChan <- fmt.Errorf("failed to create ingest dump: %w", err)
-					return
-				}
-			}
-
-			if len(t.config.DBExtraSQL) > 0 {
-				// Run extra SQL commands if specified
-				if err := t.ExecuteCustomSQL(); err != nil {
-					errorsChan <- fmt.Errorf("failed to execute custom SQL: %w", err)
-					return
-				}
-			}
-
-			// Clear licenses data
-			if err := t.ClearLicensesData(); err != nil {
-				errorsChan <- fmt.Errorf("failed to clear old licenses data: %w", err)
+	// Ingest DB dump if specified
+	if t.output.HasDB() && !initData && t.config.DBDumpURI != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err = t.IngestDump()
+			if err != nil {
+				errorsChan <- fmt.Errorf("failed to create ingest dump: %w", err)
 				return
 			}
 
-			if t.config.TerraformDBSettings.InstanceEngine == "aurora-postgresql" {
-				// updatePostgresSettings does some housekeeping stuff like setting
-				// default_search_config and vacuuming tables.
-				if err := t.updatePostgresSettings(extAgent); err != nil {
-					errorsChan <- fmt.Errorf("could not modify default_search_text_config: %w", err)
-					return
-				}
-			}
-		}
-
-		errorsChan <- nil
-	}()
+			errorsChan <- nil
+		}()
+	}
 
 	// Fail on any errors from the two goroutines above
 	wg.Wait()
@@ -345,6 +311,35 @@ func (t *Terraform) Create(initData bool) error {
 		runcmd = "ltctl"
 	}
 	fmt.Printf("To start coordinator, you can use %q command.\n", runcmd+" loadtest start")
+	return nil
+}
+
+func (t *Terraform) PostProcessDatabase(extAgent *ssh.ExtAgent) error {
+	// If the deployment has no DB, do nothing
+	if !t.output.HasDB() {
+		return nil
+	}
+
+	if len(t.config.DBExtraSQL) > 0 {
+		// Run extra SQL commands if specified
+		if err := t.ExecuteCustomSQL(); err != nil {
+			return fmt.Errorf("failed to execute custom SQL: %w", err)
+		}
+	}
+
+	// Clear licenses data
+	if err := t.ClearLicensesData(); err != nil {
+		return fmt.Errorf("failed to clear old licenses data: %w", err)
+	}
+
+	if t.config.TerraformDBSettings.InstanceEngine == "aurora-postgresql" {
+		// updatePostgresSettings does some housekeeping stuff like setting
+		// default_search_config and vacuuming tables.
+		if err := t.updatePostgresSettings(extAgent); err != nil {
+			return fmt.Errorf("could not modify default_search_text_config: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### Summary
Last week, @streamer45 realized that we're not running the `vacuum` step in comparison runs. Actually, we do run it, but we do it *before* loading the database dump, which is of course completely useless.

This PR refactors that step (and the rest of post-processing we do after the DB is ready: clear licenses data and run extra SQL commands) out from `Terraform.Create`, so we can call it when needed in both usages of that function: in the usual `deployment create` command and in the `comparison run` command.
 
There's still a lot of work to decouple everything going on in `Terraform.Create`, but this is a baby step in that direction.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61944
