### PR TITLE
chore: create latest.tar.gz when packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ endif
 	$(eval PACKAGE_NAME=mattermost-load-test-ng-$(DIST_VER)-$(PLATFORM))
 	cp -r $(PLATFORM_DIST_PATH) $(DIST_PATH)/$(PACKAGE_NAME)
 	tar -C $(DIST_PATH) -czf $(DIST_PATH)/$(PACKAGE_NAME).tar.gz $(PACKAGE_NAME)
+	rm -rf $(DIST_ROOT)/latest.tar.gz
+	cp $(DIST_PATH)/$(PACKAGE_NAME).tar.gz $(DIST_ROOT)/latest.tar.gz
 	rm -rf $(DIST_PATH)/$(PACKAGE_NAME)
 
 verify-gomod: ## Run go mod verify.


### PR DESCRIPTION
#### Summary

This allows to use that path in the deployer configuration file while making changes to the load test without the need to update the field each time you create a new package.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61294