### PR TITLE
chore: get aws client with region set up in config

### DIFF
--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -342,12 +342,17 @@ func getServerURL(output *Output, deploymentConfig *deployment.Config) string {
 // GetAWSConfig returns the AWS config, using the profile configured in the
 // deployer if present, and defaulting to the default credential chain otherwise
 func (t *Terraform) GetAWSConfig() (aws.Config, error) {
+	regionOpt := awsconfig.WithRegion(t.config.AWSRegion)
+
 	if t.config.AWSProfile == "" {
-		return awsconfig.LoadDefaultConfig(context.Background())
+		return awsconfig.LoadDefaultConfig(
+			context.Background(),
+			regionOpt,
+		)
 	}
 
-	profile := awsconfig.WithSharedConfigProfile(t.config.AWSProfile)
-	return awsconfig.LoadDefaultConfig(context.Background(), profile)
+	profileOpt := awsconfig.WithSharedConfigProfile(t.config.AWSProfile)
+	return awsconfig.LoadDefaultConfig(context.Background(), profileOpt, regionOpt)
 }
 
 // GetAWSCreds returns the AWS config, using the profile configured in the


### PR DESCRIPTION
#### Summary

We have the AWS Region parameter but that can conflict with the default values or the profile values (specifically if region is not set there).

This pull request adds the region option when creating the AWS Client to match the one in the configuration.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61279

