### PR TITLE
fix: escape keycloak password to improve shell compat

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -283,7 +283,7 @@ type ExternalAuthProviderSettings struct {
 	// KeycloakAdminUser is the username of the keycloak admin interface (admin on the master realm)
 	KeycloakAdminUser string `default:"mmuser" validate:"notempty"`
 	// KeycloakAdminPassword is the password of the keycloak admin interface (admin on the master realm)
-	KeycloakAdminPassword string `default:"mmpass" validate:"notempty"`
+	KeycloakAdminPassword string `default:"mmpass" validate:"alpha"`
 	// KeycloakRealmFilePath is the path to the realm file to be uploaded to the keycloak instance.
 	// If empty, a default realm file will be used.
 	KeycloakRealmFilePath string `default:""`

--- a/deployment/terraform/keycloak.go
+++ b/deployment/terraform/keycloak.go
@@ -171,7 +171,12 @@ func (t *Terraform) setupKeycloak(extAgent *ssh.ExtAgent) error {
 	}
 
 	// Authenticate as admin to execute keycloak commands
-	_, err = sshc.RunCommand(fmt.Sprintf(`%s/kcadm.sh config credentials --server http://127.0.0.1:8080 --user "%s" --password '%s' --realm master`, keycloakBinPath, t.config.ExternalAuthProviderSettings.KeycloakAdminUser, strings.ReplaceAll(t.config.ExternalAuthProviderSettings.KeycloakAdminPassword, "'", "\\'")))
+	_, err = sshc.RunCommand(
+		fmt.Sprintf(`%s/kcadm.sh config credentials --server http://127.0.0.1:8080 --user %q --password %q --realm master`,
+			keycloakBinPath,
+			t.config.ExternalAuthProviderSettings.KeycloakAdminUser,
+			t.config.ExternalAuthProviderSettings.KeycloakAdminPassword,
+		))
 	if err != nil {
 		return fmt.Errorf("failed to authenticate keycloak admin: %w", err)
 	}

--- a/deployment/terraform/keycloak.go
+++ b/deployment/terraform/keycloak.go
@@ -171,7 +171,7 @@ func (t *Terraform) setupKeycloak(extAgent *ssh.ExtAgent) error {
 	}
 
 	// Authenticate as admin to execute keycloak commands
-	_, err = sshc.RunCommand(fmt.Sprintf("%s/kcadm.sh config credentials --server http://127.0.0.1:8080 --user %s --password %s --realm master", keycloakBinPath, t.config.ExternalAuthProviderSettings.KeycloakAdminUser, t.config.ExternalAuthProviderSettings.KeycloakAdminPassword))
+	_, err = sshc.RunCommand(fmt.Sprintf(`%s/kcadm.sh config credentials --server http://127.0.0.1:8080 --user "%s" --password '%s' --realm master`, keycloakBinPath, t.config.ExternalAuthProviderSettings.KeycloakAdminUser, strings.ReplaceAll(t.config.ExternalAuthProviderSettings.KeycloakAdminPassword, "'", "\\'")))
 	if err != nil {
 		return fmt.Errorf("failed to authenticate keycloak admin: %w", err)
 	}


### PR DESCRIPTION
#### Summary
Use a naive approach to password escaping for keycloak if the tilde character is included in the password.

An improvement for this would be to limit the characters in the field validation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61278