### PR TITLE
MM-62026: Fix comparison build filenames

### DIFF
--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -79,7 +79,7 @@ func (c *Comparison) Run() (Output, error) {
 		if err := t.Create(extAgent, false); err != nil {
 			return err
 		}
-		return provisionFiles(t, dpConfig, c.config.BaseBuild.URL, c.config.NewBuild.URL)
+		return provisionFiles(t, dpConfig, c.config.BaseBuild, c.config.NewBuild)
 	})
 	if err != nil {
 		return output, err

--- a/comparison/config.go
+++ b/comparison/config.go
@@ -109,6 +109,11 @@ func (c *Config) IsValid() error {
 			return err
 		}
 	}
+
+	if c.BaseBuild.Label == c.NewBuild.Label {
+		return fmt.Errorf("the labels for the base and new build must be unique")
+	}
+
 	return nil
 }
 

--- a/comparison/config_test.go
+++ b/comparison/config_test.go
@@ -1,0 +1,25 @@
+package comparison
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValid(t *testing.T) {
+	t.Run("default config with different label values is valid", func(t *testing.T) {
+		cfg := Config{}
+		cfg.BaseBuild.Label = "base"
+		cfg.NewBuild.Label = "new"
+
+		require.NoError(t, cfg.IsValid())
+	})
+
+	t.Run("config with same labels for both build is not valid", func(t *testing.T) {
+		cfg := Config{}
+		cfg.BaseBuild.Label = "label"
+		cfg.NewBuild.Label = "label"
+
+		require.Error(t, cfg.IsValid())
+	})
+}

--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -47,7 +47,7 @@ func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpConf
 // If the URL is an HTTP URL then the file is directly downloaded into the
 // servers. If the URL is prefixed by `file://` then the file is uploaded
 // from the local filesystem.
-func provisionFiles(t *terraform.Terraform, dpConfig *deploymentConfig, baseBuildURL, newBuildURL string) error {
+func provisionFiles(t *terraform.Terraform, dpConfig *deploymentConfig, baseBuildCfg, newBuildCfg BuildConfig) error {
 	output, err := t.Output()
 	if err != nil {
 		return err
@@ -78,12 +78,16 @@ func provisionFiles(t *terraform.Terraform, dpConfig *deploymentConfig, baseBuil
 				}
 			}
 		}
-		for _, url := range []string{baseBuildURL, newBuildURL} {
-			if err := deployment.ProvisionURL(client, url, filepath.Base(url)); err != nil {
+		for _, cfg := range []BuildConfig{baseBuildCfg, newBuildCfg} {
+			if err := deployment.ProvisionURL(client, cfg.URL, getBuildFilename(cfg)); err != nil {
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+func getBuildFilename(buildCfg BuildConfig) string {
+	return buildCfg.Label + "_" + filepath.Base(buildCfg.URL)
 }

--- a/comparison/loadtest.go
+++ b/comparison/loadtest.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -200,7 +199,7 @@ func initLoadTest(t *terraform.Terraform, buildCfg BuildConfig, dumpFilename str
 		Clients: appClients,
 	}
 
-	buildFileName := filepath.Base(buildCfg.URL)
+	buildFileName := getBuildFilename(buildCfg)
 	installCmd := deployment.Cmd{
 		Msg:     "Installing app",
 		Value:   fmt.Sprintf("cd /home/ubuntu && tar xzf %s && cp /opt/mattermost/config/config.json . && sudo rm -rf /opt/mattermost && sudo mv mattermost /opt/ && mv config.json /opt/mattermost/config/", buildFileName),


### PR DESCRIPTION
#### Summary
This PR makes sure that we use a unique filename for each build file we need in comparisons by:
1. Using a new `getBuildFilename` function to get the filename of each build given the configuration. The function adds the config's label to the filename.
2. Ensuring the labels for both the base and new builds are different.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62026
