### PR TITLE
fix: use a ticker in the monitor loop

### DIFF
--- a/coordinator/performance/monitor.go
+++ b/coordinator/performance/monitor.go
@@ -47,7 +47,7 @@ func NewMonitor(config MonitorConfig, log *mlog.Logger) (*Monitor, error) {
 // Run will start the performance monitoring process.
 func (m *Monitor) Run() <-chan Status {
 	go func() {
-		ticker := time.NewTicker(time.Duration(m.config.UpdateIntervalMs))
+		ticker := time.NewTicker(time.Duration(m.config.UpdateIntervalMs) * time.Millisecond)
 		defer ticker.Stop()
 
 		m.log.Info("monitor: started")

--- a/coordinator/performance/monitor.go
+++ b/coordinator/performance/monitor.go
@@ -47,6 +47,9 @@ func NewMonitor(config MonitorConfig, log *mlog.Logger) (*Monitor, error) {
 // Run will start the performance monitoring process.
 func (m *Monitor) Run() <-chan Status {
 	go func() {
+		ticker := time.NewTicker(time.Duration(m.config.UpdateIntervalMs))
+		defer ticker.Stop()
+
 		m.log.Info("monitor: started")
 		for {
 			m.statusChan <- m.runQueries()
@@ -54,7 +57,7 @@ func (m *Monitor) Run() <-chan Status {
 			case <-m.stopChan:
 				m.log.Info("monitor: shutting down")
 				return
-			case <-time.After(time.Duration(m.config.UpdateIntervalMs) * time.Millisecond):
+			case <-ticker.C:
 			}
 		}
 	}()


### PR DESCRIPTION
#### Summary

Replaces the datetime calculation with a Ticker in the monitor's main loop

#### Ticket Link

Applies to https://mattermost.atlassian.net/browse/MM-61922

