### PR TITLE
feat: execute commands async to speed up tasks

### DIFF
--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -268,9 +268,7 @@ func (t *Terraform) executeCommands(commands []deployment.Cmd) error {
 		}
 
 		wg.Wait()
-		go func() {
-			close(errors)
-		}()
+		close(errors)
 
 		errorsFound := false
 		for e := range errors {

--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
@@ -70,14 +71,8 @@ func (t *Terraform) ClearLicensesData() error {
 		Clients: appClients,
 	}
 
-	for _, c := range []deployment.Cmd{stopCmd, clearCmd, startCmd} {
-		mlog.Info(c.Msg)
-		for _, client := range c.Clients {
-			mlog.Debug("Running cmd", mlog.String("cmd", c.Value))
-			if out, err := client.RunCommand(c.Value); err != nil {
-				return fmt.Errorf("failed to run cmd %q: %w %s", c.Value, err, out)
-			}
-		}
+	if err := t.executeCommands([]deployment.Cmd{stopCmd, clearCmd, startCmd}); err != nil {
+		return fmt.Errorf("error executing database commands: %w", err)
 	}
 
 	return nil
@@ -257,12 +252,36 @@ func (t *Terraform) executeDatabaseCommands(extraCommands []deployment.Cmd) erro
 func (t *Terraform) executeCommands(commands []deployment.Cmd) error {
 	for _, c := range commands {
 		mlog.Info(c.Msg)
+
+		errors := make(chan error, len(c.Clients))
+		wg := sync.WaitGroup{}
+
 		for _, client := range c.Clients {
-			mlog.Debug("Running cmd", mlog.String("cmd", c.Value))
-			if out, err := client.RunCommand(c.Value); err != nil {
-				return fmt.Errorf("failed to run cmd %q: %w %s", c.Value, err, out)
-			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				mlog.Debug("Running cmd", mlog.String("cmd", c.Value))
+				if out, err := client.RunCommand(c.Value); err != nil {
+					errors <- fmt.Errorf("failed to run cmd %q: %w %s", c.Value, err, out)
+				}
+			}()
 		}
+
+		wg.Wait()
+		go func() {
+			close(errors)
+		}()
+
+		errorsFound := false
+		for e := range errors {
+			errorsFound = true
+			mlog.Error(e.Error())
+		}
+
+		if errorsFound {
+			return fmt.Errorf("errors found during command execution")
+		}
+
 	}
 
 	return nil

--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -260,9 +260,9 @@ func (t *Terraform) executeCommands(commands []deployment.Cmd) error {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				mlog.Debug("Running cmd", mlog.String("cmd", c.Value))
+				mlog.Debug("Running cmd", mlog.String("cmd", c.Value), mlog.String("ip", client.IP))
 				if out, err := client.RunCommand(c.Value); err != nil {
-					errors <- fmt.Errorf("failed to run cmd %q: %w %s", c.Value, err, out)
+					errors <- fmt.Errorf("failed to run cmd %q on %s: %w %s", c.Value, client.IP, err, out)
 				}
 			}()
 		}

--- a/deployment/terraform/ssh/ssh.go
+++ b/deployment/terraform/ssh/ssh.go
@@ -29,6 +29,7 @@ type ExtAgent struct {
 // commands in a single method.
 type Client struct {
 	client *ssh.Client
+	IP     string
 }
 
 // NewAgent connects to the local ssh agent and validates
@@ -68,7 +69,7 @@ func (ea *ExtAgent) NewClientWithPort(ip string, port string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Client{client: sshc}, nil
+	return &Client{client: sshc, IP: ip}, nil
 }
 
 // NewClient returns a Client object by dialing


### PR DESCRIPTION
#### Summary
After I started testing using a huge number of users in the same team/channel combination I experienced slowness on some of the tasks that stop/start the mattermost servers to run jobs. Those commands were being executed in serial, so I changed the function so the commands run in parallel.

#### Ticket Link
