### PR TITLE
[MM-61280] disable init data if providing external database

### DIFF
--- a/cmd/ltctl/main.go
+++ b/cmd/ltctl/main.go
@@ -34,7 +34,7 @@ func RunCreateCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create SSH agent: %w", err)
 	}
 
-	initData := config.DBDumpURI == ""
+	initData := config.DBDumpURI == "" || config.ExternalDBSettings.DataSource != ""
 	if err = t.Create(extAgent, initData); err != nil {
 		return fmt.Errorf("failed to create terraform env: %w", err)
 	}

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -399,7 +399,7 @@ func (c *Config) IsValid() error {
 	}
 
 	if c.ExternalDBSettings.DataSource != "" && c.DBDumpURI != "" {
-		return errors.New("both ExternalDBSettings.DataSource and DbdumpURI are set, only one can be set")
+		return fmt.Errorf("both ExternalDBSettings.DataSource and DBDumpURI are set, only one can be set")
 	}
 
 	if err := c.validateElasticSearchConfig(); err != nil {

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -398,6 +398,10 @@ func (c *Config) IsValid() error {
 		return fmt.Errorf("load-test download url is not in correct format: %q", c.LoadTestDownloadURL)
 	}
 
+	if c.ExternalDBSettings.DataSource != "" && c.DBDumpURI != "" {
+		return errors.New("both ExternalDBSettings.DataSource and DbdumpURI are set, only one can be set")
+	}
+
 	if err := c.validateElasticSearchConfig(); err != nil {
 		return err
 	}

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -556,6 +556,10 @@ The file is expected to be gzip compressed.
 This can also point to a local file if prefixed with "file://".
 In such case, the dump file will be uploaded to the app servers.
 
+Loading a dump into a database only work for terraform created databases.
+If you are using an existing database by relying on [`ExternalDBSettings`](#ExternalDBSettings)
+you need to load the dump manually.
+
 ## SiteURL
 
 *string*


### PR DESCRIPTION
#### Summary
Avoid running the database initialization commands if providing an external database since the `IngestDump` only works for terraform created databases. External databases are usually already populated and ready to use as they come from backups.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61280
