### PR TITLE
[MM-61912] Download and install latest Dashboard v2 automatically

### DIFF
--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -370,10 +370,10 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	// Removes the DS_PROMETHEUS variable requirement to allow grafana to use the only prometheus
 	// datasource available in the load-test envionment.
 	re := regexp.MustCompile(`,\r?\n\s+\"uid\":\s?\"\$\{DS_PROMETHEUS\}\"`)
-	result := re.ReplaceAll(dashboardV2Contents.Bytes(), []byte(``))
+	result := re.ReplaceAllString(dashboardV2Contents.String(), "")
 
-	if out, err := sshc.Upload(bytes.NewReader(result), "/var/lib/grafana/dashboards/dashboard_v2.json", true); err != nil {
-		return fmt.Errorf("error while uploading dashboard v2: output: %s, error: %w", out, err)
+	if _, err := t.UploadDashboard(result); err != nil {
+		return fmt.Errorf("error while uploading dashboard: %w", err)
 	}
 
 	// Upload coordinator metrics dashboard

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -353,7 +353,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 		return fmt.Errorf("error while uploading dashboard_json: output: %s, error: %w", out, err)
 	}
 
-	// Download dashboard v2 from grafama.com and upload it
+	// Download dashboard v2 from grafana.com and upload it
 	dashboardv2Resp, err := http.Get("https://grafana.com/api/dashboards/15582/revisions/latest/download")
 	if err != nil {
 		return fmt.Errorf("error downloading latest grafana v2 dashboard: %w", err)

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -353,7 +353,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 		return fmt.Errorf("error while uploading dashboard_json: output: %s, error: %w", out, err)
 	}
 
-	// Download dashboard v2 from and upload it
+	// Download dashboard v2 from grafama.com and upload it
 	dashboardv2Resp, err := http.Get("https://grafana.com/api/dashboards/15582/revisions/latest/download")
 	if err != nil {
 		return fmt.Errorf("error downloading latest grafana v2 dashboard: %w", err)


### PR DESCRIPTION
 #### Summary
Downloads the latest Dashboard v2 revision from the Grafana gallery and installs it into the environment automatically. It naively removes the DS_PROMETHEUS variable from the JSON dashboard code so it automatically uses the primary prometheus source present in the deployment.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61912

