### PR TITLE
[MM-61910] refactor: log users by email

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -494,15 +494,13 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 		password := split[1]
 		// Quick and dirty hack to extract username from email.
 		// This is not terribly important to be correct.
-		username := strings.Split(email, "@")[0]
-		username = strings.Replace(username, "+", "-", -1)
 		authService := userentity.AuthenticationTypeMattermost
 
 		// Check if the user has a custom authentication type. Custom authentication types are
 		// specified by prepending the email with the authentication type followed by a colon.
 		// Example: "openid:email1@xample.com"
-		if strings.Contains(username, ":") {
-			split := strings.Split(username, ":")
+		if strings.Contains(email, ":") {
+			split := strings.Split(email, ":")
 			if len(split) != 2 {
 				return nil, fmt.Errorf("invalid custom authentication found in %q", email)
 			}
@@ -515,9 +513,15 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 				return nil, fmt.Errorf("invalid custom authentication type %q", authService)
 			}
 
-			username = split[1]
 			email = strings.Replace(email, authService+":", "", 1)
 		}
+
+		emailParts := strings.Split(email, "@")
+		if len(emailParts) != 2 {
+			return nil, fmt.Errorf("invalid email %q", email)
+		}
+
+		username := emailParts[0]
 
 		users = append(users, user{
 			email:       email,

--- a/api/agent.go
+++ b/api/agent.go
@@ -522,6 +522,7 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 		// Quick and dirty hack to extract username from email.
 		// This is not terribly important to be correct.
 		username := emailParts[0]
+		username = strings.Replace(username, "+", "-", -1)
 
 		users = append(users, user{
 			email:       email,

--- a/api/agent.go
+++ b/api/agent.go
@@ -492,8 +492,6 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 		}
 		email := split[0]
 		password := split[1]
-		// Quick and dirty hack to extract username from email.
-		// This is not terribly important to be correct.
 		authService := userentity.AuthenticationTypeMattermost
 
 		// Check if the user has a custom authentication type. Custom authentication types are
@@ -521,6 +519,8 @@ func getUserCredentials(usersFilePath string, _ *loadtest.Config) ([]user, error
 			return nil, fmt.Errorf("invalid email %q", email)
 		}
 
+		// Quick and dirty hack to extract username from email.
+		// This is not terribly important to be correct.
 		username := emailParts[0]
 
 		users = append(users, user{

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -47,9 +47,9 @@ func (ue *UserEntity) SignUp(email, username, password string) error {
 			return fmt.Errorf("error while signing up using %s: %w", ue.config.AuthenticationType, err)
 		}
 
-		newUser, _, err = ue.client.GetUserByUsername(context.Background(), username, "")
+		newUser, _, err = ue.client.GetUserByEmail(context.Background(), email, "")
 		if err != nil {
-			return fmt.Errorf("error while getting user by username: %w", err)
+			return fmt.Errorf("error while getting user by email: %w", err)
 		}
 
 	default:
@@ -194,9 +194,9 @@ func (ue *UserEntity) Login() error {
 			return fmt.Errorf("error while logging in using %s: %w", ue.config.AuthenticationType, err)
 		}
 
-		loggedUser, _, err = ue.client.GetUserByUsername(context.Background(), user.Username, "")
+		loggedUser, _, err = ue.client.GetUserByEmail(context.Background(), user.Email, "")
 		if err != nil {
-			return fmt.Errorf("error while getting user by username through %s: %w", ue.config.AuthenticationType, err)
+			return fmt.Errorf("error while getting user by email through %s: %w", ue.config.AuthenticationType, err)
 		}
 	default:
 		loggedUser, _, err = ue.client.Login(context.Background(), user.Email, user.Password)


### PR DESCRIPTION
#### Summary
Refactors the way the users log in to use login by email instead of by username. The problem with this was that when providing a txt file with a list of email/passwords the login flow used the username extracted from the email and that may not be accurate for non-synthetic dumps.

This pull request changes the login flow to use `GetLoginByEmail` instead of `GetLoginByUsername` but still returns the internal `user` object with the extracted username from the email.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61910
