### PR TITLE
[MM-61911] yace: use deployer config region

### DIFF
--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -204,6 +204,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 		"Period":      yaceDurationSeconds,
 		"Length":      yaceDurationSeconds,
 		"Delay":       yaceDurationSeconds,
+		"AWSRegion":   t.Config().AWSRegion,
 	})
 	if err != nil {
 		return fmt.Errorf("error rendering YACE configuration template: %w", err)

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -360,7 +360,7 @@ discovery:
   jobs:
     - type: AWS/RDS
       regions:
-        - us-east-1
+        - {{.AWSRegion}}
       period: {{.Period}}
       length: {{.Length}}
       delay: {{.Delay}}
@@ -391,7 +391,7 @@ discovery:
           statistics: [Average]
     - type: AWS/ES
       regions:
-        - us-east-1
+        - {{.AWSRegion}}
       period: {{.Period}}
       length: {{.Length}}
       delay: {{.Delay}}
@@ -432,7 +432,7 @@ discovery:
           statistics: [Maximum]
     - type: AWS/EC2
       regions:
-        - us-east-1
+        - {{.AWSRegion}}
       period: {{.Period}}
       length: {{.Length}}
       delay: {{.Delay}}


### PR DESCRIPTION
#### Summary
Use the region in the deployer configuration inside the YACE template, instead of forcing it to `us-east-1`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61911