### PR TITLE
Remove OpenTelemetry collector's debug exporter

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -594,16 +594,12 @@ exporters:
     endpoint: "http://{{.MetricsIP}}:3100/otlp"
     tls:
       insecure: true
-  debug:
-    verbosity: detailed
-    sampling_initial: 5
-    sampling_thereafter: 200
 
 service:
   pipelines:
     logs:
       receivers: [{{range .Receivers}}{{.Name}},{{end}}]
-      exporters: [otlphttp/logs,debug]
+      exporters: [otlphttp/logs]
 `
 
 type otelcolReceiver struct {

--- a/deployment/terraform/strings_test.go
+++ b/deployment/terraform/strings_test.go
@@ -80,16 +80,12 @@ exporters:
     endpoint: "http://127.0.0.1:3100/otlp"
     tls:
       insecure: true
-  debug:
-    verbosity: detailed
-    sampling_initial: 5
-    sampling_thereafter: 200
 
 service:
   pipelines:
     logs:
       receivers: [filelog/app,]
-      exporters: [otlphttp/logs,debug]
+      exporters: [otlphttp/logs]
 `
 
 	expectedProxyConf = `
@@ -131,16 +127,12 @@ exporters:
     endpoint: "http://127.0.0.1:3100/otlp"
     tls:
       insecure: true
-  debug:
-    verbosity: detailed
-    sampling_initial: 5
-    sampling_thereafter: 200
 
 service:
   pipelines:
     logs:
       receivers: [filelog/proxy_error,filelog/proxy_access,]
-      exporters: [otlphttp/logs,debug]
+      exporters: [otlphttp/logs]
 `
 )
 

--- a/deployment/terraform/strings_test.go
+++ b/deployment/terraform/strings_test.go
@@ -46,16 +46,12 @@ exporters:
     endpoint: "http://127.0.0.1:3100/otlp"
     tls:
       insecure: true
-  debug:
-    verbosity: detailed
-    sampling_initial: 5
-    sampling_thereafter: 200
 
 service:
   pipelines:
     logs:
       receivers: [filelog/agent,filelog/coordinator,]
-      exporters: [otlphttp/logs,debug]
+      exporters: [otlphttp/logs]
 `
 	expectedAppConfg = `
 receivers:


### PR DESCRIPTION
#### Summary
The debug exporter logs whatever payload the collector sends to Loki to the syslog, so it's easier to... well, debug the collector itself :) This was really useful when setting the whole logging system up, but it's no longer needed, and if there's any unrelated error (like an agent being down), `/var/log/syslog` can quickly end up consuming the whole disk (which is what motivated this change). The logs will still be sent to Loki if there's such an error, so it's not like we're removing useful info for debugging potential issues.

#### Ticket Link
--
