### PR TITLE
feat: Add support for AWS role assumption in deployment configuration

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -24,6 +24,8 @@ var esDomainNameRe = regexp.MustCompile(`^[a-z][a-z0-9\-]{2,27}$`)
 type Config struct {
 	// AWSProfile is the optional name of the AWS profile to use for all AWS commands
 	AWSProfile string `default:""`
+	// AWSRoleARN is the optional ARN of an IAM role to assume for AWS operations
+	AWSRoleARN string `default:""`
 	// AWSRegion is the region used to deploy all resources.
 	AWSRegion string `default:"us-east-1"`
 	// AWSAvailabilityZone defines the Availability Zone

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
@@ -349,19 +350,25 @@ func getServerURL(output *Output, deploymentConfig *deployment.Config) string {
 }
 
 // GetAWSConfig returns the AWS config, using the profile configured in the
-// deployer if present, and defaulting to the default credential chain otherwise
+// deployer if present, and defaulting to the default credential chain otherwise.
+// If a role ARN is provided, it will assume that role.
 func (t *Terraform) GetAWSConfig() (aws.Config, error) {
 	regionOpt := awsconfig.WithRegion(t.config.AWSRegion)
+	var opts []func(*awsconfig.LoadOptions) error
 
-	if t.config.AWSProfile == "" {
-		return awsconfig.LoadDefaultConfig(
-			context.Background(),
-			regionOpt,
-		)
+	opts = append(opts, regionOpt)
+
+	if t.config.AWSProfile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(t.config.AWSProfile))
 	}
 
-	profileOpt := awsconfig.WithSharedConfigProfile(t.config.AWSProfile)
-	return awsconfig.LoadDefaultConfig(context.Background(), profileOpt, regionOpt)
+	if t.config.AWSRoleARN != "" {
+		opts = append(opts, awsconfig.WithAssumeRoleCredentialOptions(func(options *stscreds.AssumeRoleOptions) {
+			options.RoleARN = t.config.AWSRoleARN
+		}))
+	}
+
+	return awsconfig.LoadDefaultConfig(context.Background(), opts...)
 }
 
 // GetAWSCreds returns the AWS config, using the profile configured in the


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This change introduces an optional AWSRoleARN field to the deployment Config struct, allowing users to specify an IAM role to assume during AWS operations. The GetAWSConfig method in the Terraform utility has been updated to support role assumption using AWS SDK v2 credentials.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-8926
