### PR TITLE
Publish prereleases as such

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,5 +44,6 @@ release:
   github:
     owner: mattermost
     name: mattermost-load-test-ng
+  prerelease: auto
   name_template: "{{ .ProjectName }}-v{{ .Version }}"
   disable: false


### PR DESCRIPTION
#### Summary
[The new logic to update the URL pointing to the latest release](https://github.com/mattermost/delivery-platform/pull/255) of the load-test tool gets triggered whenever a new release that is not marked as pre-release is pushed to Github. Our current release process would trigger this for pre-releases as well, since we publish those as production-ready ones, and only after they are published we manually mark them as pre-releases.

We can change this by using the prerelease: auto setting [in goreleaser](https://goreleaser.com/customization/release/#github), that is documented as follows:
> If set to auto, will mark the release as not ready for production in case there is an indicator for this in the tag e.g. v1.0.0-rc1.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63295
