### PR TITLE
MM-63351: Use latest URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,33 +100,7 @@ BRANCH_EXISTS=$(shell git rev-parse $(BRANCH_NAME) >/dev/null 2>&1; echo $$?)
 PR_URL=https://github.com/mattermost/mattermost-load-test-ng/compare/master...$(BRANCH_NAME)?quick_pull=1&labels=2:+Dev+Review
 CURR_BRANCH=$(shell git branch --show-current)
 
-prepare-release: ## Release step 1: Prepare the PR needed before releasing a new version, identified by the envvar NEXT_VER.
-ifndef NEXT_VER
-	@echo "Error: NEXT_VER must be defined"
-else
-ifeq ($(TAG_EXISTS), 0)
-	@echo "Error: tag ${NEXT_VER} already exists"
-else
-ifeq ($(BRANCH_EXISTS), 0)
-	@echo "Error: branch ${BRANCH_NAME} already exists"
-else
-	@echo $(NEXT_VER) | grep -Eq ^v[0-9]+\.[0-9]+\.[0-9]+$ || (echo "The next version, '$(NEXT_VER)' is not of the form vMAJOR.MINOR.PATCH" && exit 1)
-	@echo -n "Release will be prepared from branch $(CURR_BRANCH). "
-	@echo -n "Do you want to continue? [y/N] " && read ans && if [ $${ans:-'N'} != 'y' ]; then exit 1; fi
-	git checkout -b $(BRANCH_NAME) $(CURR_BRANCH)
-	@echo "Applying changes"
-	@for file in $(shell grep -rPl --include="*.go" --include="*.json" --include="*.toml" $(MATCH)); do \
-		sed -r -i 's/$(MATCH)/$(REPLACE)/g' $$file; \
-	done
-	git commit -a -m "Bump version to $(NEXT_VER)"
-	git push --set-upstream origin $(BRANCH_NAME)
-	git checkout $(CURR_BRANCH)
-	@echo "Visit the following URL to create a PR: ${PR_URL}\nWhen merged, run make release NEXT_VER=$(NEXT_VER)."
-endif
-endif
-endif
-
-release: ## Release step 2: Perform the release of a new version, identified by the envvar NEXT_VER. Install goreleaser if needed.
+release: ## Perform the release of a new version, identified by the envvar NEXT_VER. Install goreleaser if needed.
 ifndef NEXT_VER
 	@echo "Error: NEXT_VER must be defined"
 else

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -99,7 +99,7 @@
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",
-  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.25.0/mattermost-load-test-ng-v1.25.0-linux-amd64.tar.gz",
+  "LoadTestDownloadURL": "https://latest.mattermost.com/mattermost-load-test-ng-linux",
   "LogSettings": {
     "EnableConsole": true,
     "ConsoleLevel": "INFO",

--- a/config/deployer.sample.toml
+++ b/config/deployer.sample.toml
@@ -38,7 +38,7 @@ ClusterVpcID = ''
 DBDumpURI = ''
 
 # Load test configuration
-LoadTestDownloadURL = 'https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.25.0/mattermost-load-test-ng-v1.25.0-linux-amd64.tar.gz'
+LoadTestDownloadURL = 'https://latest.mattermost.com/mattermost-load-test-ng-linux'
 SSHPublicKey = '~/.ssh/id_rsa.pub'
 TerraformStateDir = '/var/lib/mattermost-load-test-ng'
 

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -91,7 +91,7 @@ type Config struct {
 	// URL from where to download load-test-ng binaries and configuration files.
 	// The configuration files provided in the package will be overridden in
 	// the deployment process.
-	LoadTestDownloadURL   string `default:"https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.25.0/mattermost-load-test-ng-v1.25.0-linux-amd64.tar.gz" validate:"url"`
+	LoadTestDownloadURL   string `default:"https://latest.mattermost.com/mattermost-load-test-ng-linux" validate:"url"`
 	ElasticSearchSettings ElasticSearchSettings
 	RedisSettings         RedisSettings
 	JobServerSettings     JobServerSettings

--- a/deployment/config_test.go
+++ b/deployment/config_test.go
@@ -12,7 +12,7 @@ func TestConfigIsValid(t *testing.T) {
 	baseConfig := func() Config {
 		return Config{
 			MattermostDownloadURL: "https://latest.mattermost.com/mattermost-enterprise-linux",
-			LoadTestDownloadURL:   "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.25.0/mattermost-load-test-ng-v1.25.0-linux-amd64.tar.gz",
+			LoadTestDownloadURL:   "https://latest.mattermost.com/mattermost-load-test-ng-linux",
 		}
 	}
 
@@ -79,7 +79,7 @@ func TestValidateElasticSearchConfig(t *testing.T) {
 			ClusterVpcID:          "vpc-01234567890abcdef",
 			ClusterName:           "clustername",
 			MattermostDownloadURL: "https://latest.mattermost.com/mattermost-enterprise-linux",
-			LoadTestDownloadURL:   "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.25.0/mattermost-load-test-ng-v1.25.0-linux-amd64.tar.gz",
+			LoadTestDownloadURL:   "https://latest.mattermost.com/mattermost-load-test-ng-linux",
 			ElasticSearchSettings: ElasticSearchSettings{
 				InstanceCount:      1,
 				Version:            "OpenSearch_2.7",

--- a/examples/config/ci/deployer.json
+++ b/examples/config/ci/deployer.json
@@ -80,7 +80,7 @@
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",
-  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.25.0/mattermost-load-test-ng-v1.25.0-linux-amd64.tar.gz",
+  "LoadTestDownloadURL": "https://latest.mattermost.com/mattermost-load-test-ng-linux",
   "LogSettings": {
     "EnableConsole": true,
     "ConsoleLevel": "INFO",


### PR DESCRIPTION
#### Summary
Now that https://mattermost.atlassian.net/browse/CLD-7570 is resolved, we have https://latest.mattermost.com/mattermost-load-test-ng-linux, which will always point to the latest release of the tool. This PR removes the hardcoded versions in the URLs in favour of this new URL, and removes the Makefile rule `prepare-release`, which is no longer needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63351
