### PR TITLE
Use v1.24.1 for the CI pipeline, not latest

### DIFF
--- a/examples/config/ci/deployer.json
+++ b/examples/config/ci/deployer.json
@@ -80,7 +80,7 @@
   "AdminEmail": "sysadmin@sample.mattermost.com",
   "AdminUsername": "sysadmin",
   "AdminPassword": "Sys@dmin-sample1",
-  "LoadTestDownloadURL": "https://latest.mattermost.com/mattermost-load-test-ng-linux",
+  "LoadTestDownloadURL": "https://github.com/mattermost/mattermost-load-test-ng/releases/download/v1.24.1/mattermost-load-test-ng-v1.24.1-linux-amd64.tar.gz",
   "LogSettings": {
     "EnableConsole": true,
     "ConsoleLevel": "INFO",


### PR DESCRIPTION
#### Summary
Fixing what I broke with #895: the config files for CI should not have been updated. Will cherry-pick this to `release-1.24` as soon as it's merged to release a new v1.24.2 :man_facepalming: 

#### Ticket Link
--
