### PR TITLE
MM-63536: Use ErrScheduledPostStoreEmpty for empty store err

### DIFF
--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -455,7 +455,7 @@ func (s *MemStore) GetRandomScheduledPost() (*model.ScheduledPost, error) {
 
 	// Check if scheduledPosts is empty
 	if len(s.scheduledPosts) == 0 {
-		return &model.ScheduledPost{}, errors.New("no scheduled posts available")
+		return &model.ScheduledPost{}, ErrScheduledPostStoreEmpty
 	}
 
 	var keys []string


### PR DESCRIPTION
#### Summary
Just an oversight in the error returned, which should use the common `ErrScheduledPostStoreEmpty`.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63536

