### PR TITLE
goreleaser: Use -version:creatordate to pick latest tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,6 @@
+git:
+  # If there are more than one tag in the same commit, pick the newest one
+  tag_sort: -version:creatordate
 before:
   hooks:
     - go mod download


### PR DESCRIPTION
#### Summary
When there is more than one tag in a commit, git sorts them lexicographically by default, so v1.26.0-rc1 is listed *after* v1.26.0. As goreleaser picks the latest one listed by git, we need to change the sorting method, so that v1.26.0 is listed after v1.26.0-rc1. We do this by setting `tag_sort` to -`version:creatordate`, so that they are sorted by creation date. As the stable tag will always be created after the release candidate tag, this will work as expected.

More info in the docs: https://goreleaser.com/customization/git/

This had never been a problem until now because we always had at least one commit between the RC tag and the stable tag: the commit changing the latest URL strings. As we don't need that anymore (yay!), we've encountered this issue for the first time now. I'll need to cherry-pick this commit to `release-1.26` to unblock the release of v1.26.0, although that will ironically make it unneeded, since there will be one more commit there :)

#### Ticket Link
--

