### PR TITLE
MM-63542: Add load-test coverage for new RHS loading pattern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/gliderlabs/ssh v0.1.1
 	github.com/grafana/alloy/syntax v0.1.0
 	github.com/graph-gophers/graphql-go v1.6.0
-	github.com/mattermost/mattermost/server/public v0.1.11-0.20250317155315-c95968c380be
+	github.com/mattermost/mattermost/server/public v0.1.11-0.20250319140854-a87c4ec9be66
 	github.com/mattermost/mattermost/server/v8 v8.0.0-20250317155315-c95968c380be
 	github.com/opensearch-project/opensearch-go/v4 v4.4.0
 	github.com/pelletier/go-toml/v2 v2.2.3

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/gliderlabs/ssh v0.1.1
 	github.com/grafana/alloy/syntax v0.1.0
 	github.com/graph-gophers/graphql-go v1.6.0
-	github.com/mattermost/mattermost/server/public v0.1.11-0.20250319140854-a87c4ec9be66
+	github.com/mattermost/mattermost/server/public v0.1.12-0.20250424064128-131cf039bbd5
 	github.com/mattermost/mattermost/server/v8 v8.0.0-20250317155315-c95968c380be
 	github.com/opensearch-project/opensearch-go/v4 v4.4.0
 	github.com/pelletier/go-toml/v2 v2.2.3
@@ -139,6 +139,7 @@ require (
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect
+	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
 github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy52be4=
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
-github.com/mattermost/mattermost/server/public v0.1.11-0.20250317155315-c95968c380be h1:X6NVyWfUh4pLurRy/Sngk+WL80h5SBrD/Wnu9BhJjcg=
-github.com/mattermost/mattermost/server/public v0.1.11-0.20250317155315-c95968c380be/go.mod h1:SL08n/wfDuFH7Y89nzlstJ1y/oPrqh4ptDRE2fJbt2o=
+github.com/mattermost/mattermost/server/public v0.1.11-0.20250319140854-a87c4ec9be66 h1:8nwCI5ODzZDU1jbuknknCRTptTrP/MigH4zqPelr3/E=
+github.com/mattermost/mattermost/server/public v0.1.11-0.20250319140854-a87c4ec9be66/go.mod h1:dHN9zBNP5/PxtnpwOeMaQfuSp6S4Tedja674xRI1Ry4=
 github.com/mattermost/mattermost/server/v8 v8.0.0-20250317155315-c95968c380be h1:x6jb3PK5taTdpN6l4Tu1+8soSHsXg7CSisECUdYkg9M=
 github.com/mattermost/mattermost/server/v8 v8.0.0-20250317155315-c95968c380be/go.mod h1:x6MOsMh1D/DCD6+9M/E8kbebghOzgyDCd5ydsqjhoxQ=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/mattermost/ldap v3.0.4+incompatible h1:SOeNnz+JNR+foQ3yHkYqijb9MLPhXN
 github.com/mattermost/ldap v3.0.4+incompatible/go.mod h1:b4reDCcGpBxJ4WX0f224KFY+OR0npin7or7EFpeIko4=
 github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy52be4=
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
-github.com/mattermost/mattermost/server/public v0.1.11-0.20250319140854-a87c4ec9be66 h1:8nwCI5ODzZDU1jbuknknCRTptTrP/MigH4zqPelr3/E=
-github.com/mattermost/mattermost/server/public v0.1.11-0.20250319140854-a87c4ec9be66/go.mod h1:dHN9zBNP5/PxtnpwOeMaQfuSp6S4Tedja674xRI1Ry4=
+github.com/mattermost/mattermost/server/public v0.1.12-0.20250424064128-131cf039bbd5 h1:NezdIqeekA+rFTGke1pdV/fYw5QU+KSpfr3vvTGliM0=
+github.com/mattermost/mattermost/server/public v0.1.12-0.20250424064128-131cf039bbd5/go.mod h1:h/rage94cF+ZWqDdVRaROXFUEPVyO3Wbq8tfKRPRL0s=
 github.com/mattermost/mattermost/server/v8 v8.0.0-20250317155315-c95968c380be h1:x6jb3PK5taTdpN6l4Tu1+8soSHsXg7CSisECUdYkg9M=
 github.com/mattermost/mattermost/server/v8 v8.0.0-20250317155315-c95968c380be/go.mod h1:x6MOsMh1D/DCD6+9M/E8kbebghOzgyDCd5ydsqjhoxQ=
 github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6Cw=

--- a/loadtest/control/simulcontroller/utils.go
+++ b/loadtest/control/simulcontroller/utils.go
@@ -227,3 +227,18 @@ func getPostFromEvent(ev *model.WebSocketEvent) (*model.Post, error) {
 
 	return post, nil
 }
+
+func getLatestUpdateAt(postIds []string, getPost func(string) (*model.Post, error)) (int64, error) {
+	var latestUpdateAt int64 = -1
+	for _, postId := range postIds {
+		p, err := getPost(postId)
+		if err != nil {
+			return 0, err
+		}
+		if latestUpdateAt < p.UpdateAt {
+			latestUpdateAt = p.UpdateAt
+		}
+	}
+
+	return latestUpdateAt, nil
+}

--- a/loadtest/store/memstore/random.go
+++ b/loadtest/store/memstore/random.go
@@ -413,15 +413,15 @@ func pickRandomKeyFromMap[K comparable, V any](m map[K]V) (K, error) {
 }
 
 // RandomThread returns a random post.
-func (s *MemStore) RandomThread() (model.ThreadResponse, error) {
+func (s *MemStore) RandomThread() (store.ThreadResponseWrapped, error) {
 	s.lock.RLock()
 	threads, err := s.getThreads(false)
 	s.lock.RUnlock()
 	if err != nil {
-		return model.ThreadResponse{}, err
+		return store.ThreadResponseWrapped{}, err
 	}
 	if len(threads) == 0 {
-		return model.ThreadResponse{}, ErrThreadNotFound
+		return store.ThreadResponseWrapped{}, ErrThreadNotFound
 	}
 	return *threads[rand.Intn(len(threads))], nil
 }

--- a/loadtest/store/memstore/random_test.go
+++ b/loadtest/store/memstore/random_test.go
@@ -1130,11 +1130,10 @@ func TestRandomThread(t *testing.T) {
 		s := newStore(t)
 		id1 := model.NewId()
 		id2 := model.NewId()
-		err := s.SetThreads([]*model.ThreadResponse{
-			{PostId: id1},
-			{PostId: id2},
+		err := s.SetThreads([]*store.ThreadResponseWrapped{
+			{ThreadResponse: model.ThreadResponse{PostId: id1}},
+			{ThreadResponse: model.ThreadResponse{PostId: id2}},
 		})
-		fmt.Println(id1, id2)
 		require.NoError(t, err)
 		th, err := s.RandomThread()
 		require.NoError(t, err)

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -45,8 +46,8 @@ type MemStore struct {
 	channelViews        map[string]int64
 	profileImages       map[string]int
 	serverVersion       string
-	threads             map[string]*model.ThreadResponse
-	threadsQueue        *CQueue[model.ThreadResponse]
+	threads             map[string]*store.ThreadResponseWrapped
+	threadsQueue        *CQueue[store.ThreadResponseWrapped]
 	sidebarCategories   map[string]map[string]*model.SidebarCategoryWithChannels
 	drafts              map[string]map[string]*model.Draft
 	featureFlags        map[string]bool
@@ -122,7 +123,7 @@ func (s *MemStore) Clear() {
 	clear(s.channelViews)
 	s.channelViews = map[string]int64{}
 	clear(s.threads)
-	s.threads = map[string]*model.ThreadResponse{}
+	s.threads = map[string]*store.ThreadResponseWrapped{}
 	s.threadsQueue.Reset()
 	clear(s.sidebarCategories)
 	s.sidebarCategories = map[string]map[string]*model.SidebarCategoryWithChannels{}
@@ -157,7 +158,7 @@ func (s *MemStore) setupQueues(config *Config) error {
 		return fmt.Errorf("memstore: status queue creation failed %w", err)
 	}
 
-	s.threadsQueue, err = NewCQueue[model.ThreadResponse](config.MaxStoredThreads)
+	s.threadsQueue, err = NewCQueue[store.ThreadResponseWrapped](config.MaxStoredThreads)
 	if err != nil {
 		return fmt.Errorf("memstore: threads queue creation failed %w", err)
 	}
@@ -1048,7 +1049,7 @@ func (s *MemStore) SetServerVersion(version string) error {
 }
 
 // SetThread stores the given thread reponse.
-func (s *MemStore) SetThread(thread *model.ThreadResponse) error {
+func (s *MemStore) SetThread(thread *store.ThreadResponseWrapped) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if thread == nil {
@@ -1068,8 +1069,22 @@ func (s *MemStore) SetThread(thread *model.ThreadResponse) error {
 	return nil
 }
 
+// SetThreadLastUpdateAt stores the lastUpdateAt value of the given root post.
+func (s *MemStore) SetThreadLastUpdateAt(threadID string, lastUpdateAt int64) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.threads[threadID] == nil {
+		return ErrThreadNotFound
+	}
+
+	s.threads[threadID].LastUpdateAt = lastUpdateAt
+
+	return nil
+}
+
 // SetThreads stores the given thread response as a thread.
-func (s *MemStore) SetThreads(trs []*model.ThreadResponse) error {
+func (s *MemStore) SetThreads(trs []*store.ThreadResponseWrapped) error {
 	if len(trs) == 0 {
 		return nil
 	}
@@ -1093,19 +1108,19 @@ func (s *MemStore) SetCategories(teamID string, sidebarCategories *model.Ordered
 	return nil
 }
 
-func (s *MemStore) getThreads(unreadOnly bool) ([]*model.ThreadResponse, error) {
-	var threads []*model.ThreadResponse
+func (s *MemStore) getThreads(unreadOnly bool) ([]*store.ThreadResponseWrapped, error) {
+	var threads []*store.ThreadResponseWrapped
 	for _, thread := range s.threads {
 		if unreadOnly && thread.UnreadReplies == 0 {
 			continue
 		}
-		threads = append(threads, cloneThreadResponse(thread, &model.ThreadResponse{}))
+		threads = append(threads, cloneThreadResponse(thread, &store.ThreadResponseWrapped{}))
 	}
 	return threads, nil
 }
 
 // ThreadsSorted returns all threads, sorted by LastReplyAt
-func (s *MemStore) ThreadsSorted(unreadOnly, asc bool) ([]*model.ThreadResponse, error) {
+func (s *MemStore) ThreadsSorted(unreadOnly, asc bool) ([]*store.ThreadResponseWrapped, error) {
 	s.lock.RLock()
 	threads, err := s.getThreads(unreadOnly)
 	s.lock.RUnlock()
@@ -1127,7 +1142,7 @@ func (s *MemStore) ThreadsSorted(unreadOnly, asc bool) ([]*model.ThreadResponse,
 // 1. directly call this function in the parent's return statement, i.e. return cloneThreadResponse(...)
 // 2. use inplace, e.g. append(threads, cloneThreadResponse(thread, &model.ThreadResponse{}))
 // 3. pass the threadResponse object in the case where we need to update an existing object
-func cloneThreadResponse(src *model.ThreadResponse, dst *model.ThreadResponse) *model.ThreadResponse {
+func cloneThreadResponse(src *store.ThreadResponseWrapped, dst *store.ThreadResponseWrapped) *store.ThreadResponseWrapped {
 	dst.PostId = src.PostId
 	dst.ReplyCount = src.ReplyCount
 	dst.LastReplyAt = src.LastReplyAt
@@ -1141,6 +1156,7 @@ func cloneThreadResponse(src *model.ThreadResponse, dst *model.ThreadResponse) *
 	}
 	dst.UnreadReplies = src.UnreadReplies
 	dst.UnreadMentions = src.UnreadMentions
+	dst.LastUpdateAt = src.LastUpdateAt
 	return dst
 }
 
@@ -1170,11 +1186,11 @@ func (s *MemStore) MarkAllThreadsInTeamAsRead(teamId string) error {
 }
 
 // Thread returns the thread for the given the threadId.
-func (s *MemStore) Thread(threadId string) (*model.ThreadResponse, error) {
+func (s *MemStore) Thread(threadId string) (*store.ThreadResponseWrapped, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if thread, ok := s.threads[threadId]; ok {
-		return cloneThreadResponse(thread, &model.ThreadResponse{}), nil
+		return cloneThreadResponse(thread, &store.ThreadResponseWrapped{}), nil
 	}
 	return nil, ErrThreadNotFound
 }

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -666,7 +666,7 @@ func TestThreads(t *testing.T) {
 		require.Equal(t, *thread, *th)
 	})
 
-	t.Run("SetThreads", func(t *testing.T) {
+	t.Run("SetThreadLastUpdateAt", func(t *testing.T) {
 		s := newStore(t)
 		id := model.NewId()
 		thread := &store.ThreadResponseWrapped{

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -666,7 +666,7 @@ func TestThreads(t *testing.T) {
 		require.Equal(t, *thread, *th)
 	})
 
-		t.Run("SetThreads", func(t *testing.T) {
+	t.Run("SetThreads", func(t *testing.T) {
 		s := newStore(t)
 		id := model.NewId()
 		thread := &store.ThreadResponseWrapped{

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -23,6 +23,13 @@ const (
 	SelectAny = SelectMemberOf | SelectNotMemberOf
 )
 
+// ThreadResponseWrapped is a client side struct which adds a new computed field
+// to store the lastUpdateAt value of all posts in the thread.
+type ThreadResponseWrapped struct {
+	model.ThreadResponse
+	LastUpdateAt int64
+}
+
 // UserStore is a read-only interface which provides access to various
 // data belonging to a user.
 type UserStore interface {
@@ -113,7 +120,7 @@ type UserStore interface {
 	// RandomTeamMember returns a random team member for a team.
 	RandomTeamMember(teamId string) (model.TeamMember, error)
 	// RandomThread returns a random thread.
-	RandomThread() (model.ThreadResponse, error)
+	RandomThread() (ThreadResponseWrapped, error)
 	// RandomCategory returns a random category from a team
 	RandomCategory(teamID string) (model.SidebarCategoryWithChannels, error)
 	// RandomDraftForTeam returns a random draft id for a team for the current user
@@ -140,9 +147,9 @@ type UserStore interface {
 	ServerVersion() (string, error)
 
 	// Threads
-	Thread(threadId string) (*model.ThreadResponse, error)
+	Thread(threadId string) (*ThreadResponseWrapped, error)
 	// ThreadsSorted returns all threads, sorted by LastReplyAt
-	ThreadsSorted(unreadOnly, asc bool) ([]*model.ThreadResponse, error)
+	ThreadsSorted(unreadOnly, asc bool) ([]*ThreadResponseWrapped, error)
 
 	// PostsWithAckRequests returns IDs of the posts that asked for acknowledgment.
 	PostsWithAckRequests() ([]string, error)
@@ -280,9 +287,11 @@ type MutableUserStore interface {
 
 	// Threads
 	// SetThreads stores the given posts.
-	SetThreads(threads []*model.ThreadResponse) error
+	SetThreads(threads []*ThreadResponseWrapped) error
 	// MarkAllThreadsInTeamAsRead marks all threads in the given team as read
 	MarkAllThreadsInTeamAsRead(teamId string) error
+	// SetThreadLastUpdateAt sets the lastUpdateAt of a given thread.
+	SetThreadLastUpdateAt(threadID string, lastUpdateAt int64) error
 
 	// SidebarCategories
 	SetCategories(teamID string, sidebarCategories *model.OrderedSidebarCategories) error

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -297,9 +297,11 @@ type User interface {
 
 	// Threads
 	// GetUserThreads fetches and stores threads. It returns a list of thread ids.
-	GetUserThreads(teamId string, options *model.GetUserThreadsOpts) ([]*model.ThreadResponse, error)
+	GetUserThreads(teamId string, options *model.GetUserThreadsOpts) ([]*store.ThreadResponseWrapped, error)
 	// UpdateThreadFollow updates the follow state of the thread
 	UpdateThreadFollow(teamId, threadId string, state bool) error
+	// UpdateThreadLastUpdateAt updates the lastUpdateAt of the given thread
+	UpdateThreadLastUpdateAt(threadId string, lastUpdateAt int64) error
 	// GetPostThread gets a post with all the other posts in the same thread.
 	GetPostThreadWithOpts(threadId, etag string, opts model.GetPostsOptions) ([]string, bool, error)
 	// MarkAllThreadsInTeamAsRead marks all threads in a team as read

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -301,6 +301,8 @@ type User interface {
 	// UpdateThreadFollow updates the follow state of the thread
 	UpdateThreadFollow(teamId, threadId string, state bool) error
 	// UpdateThreadLastUpdateAt updates the lastUpdateAt of the given thread
+	// This simply forwards the call to the store, but we use the User interface
+	// because direct access to the store is via the UserStore interface, not MutableUserStore.
 	UpdateThreadLastUpdateAt(threadId string, lastUpdateAt int64) error
 	// GetPostThread gets a post with all the other posts in the same thread.
 	GetPostThreadWithOpts(threadId, etag string, opts model.GetPostsOptions) ([]string, bool, error)

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -1362,7 +1363,7 @@ func (ue *UserEntity) MessageExport() error {
 
 // GetPostsAfter fetches and stores posts in a given channelId that were made after
 // a given postId.
-func (ue *UserEntity) GetUserThreads(teamId string, options *model.GetUserThreadsOpts) ([]*model.ThreadResponse, error) {
+func (ue *UserEntity) GetUserThreads(teamId string, options *model.GetUserThreadsOpts) ([]*store.ThreadResponseWrapped, error) {
 	user, err := ue.getUserFromStore()
 	if err != nil {
 		return nil, err
@@ -1372,10 +1373,17 @@ func (ue *UserEntity) GetUserThreads(teamId string, options *model.GetUserThread
 		return nil, err
 	}
 
-	return threads.Threads, ue.store.SetThreads(threads.Threads)
+	tWrapped := make([]*store.ThreadResponseWrapped, len(threads.Threads))
+	for i := range threads.Threads {
+		tWrapped[i] = &store.ThreadResponseWrapped{
+			ThreadResponse: *threads.Threads[i],
+		}
+	}
+
+	return tWrapped, ue.store.SetThreads(tWrapped)
 }
 
-// UpdateThreadFollow updates the follow state of the the given thread
+// UpdateThreadFollow updates the follow state of the given thread
 func (ue *UserEntity) UpdateThreadFollow(teamId, threadId string, state bool) error {
 	user, err := ue.getUserFromStore()
 	if err != nil {
@@ -1383,6 +1391,11 @@ func (ue *UserEntity) UpdateThreadFollow(teamId, threadId string, state bool) er
 	}
 	_, err = ue.client.UpdateThreadFollowForUser(context.Background(), user.Id, teamId, threadId, state)
 	return err
+}
+
+// UpdateThreadLastUpdateAt updates the lastUpdateAt of the given thread
+func (ue *UserEntity) UpdateThreadLastUpdateAt(threadId string, lastUpdateAt int64) error {
+	return ue.store.SetThreadLastUpdateAt(threadId, lastUpdateAt)
 }
 
 // GetPostThread gets a post with all the other posts in the same thread.
@@ -1429,7 +1442,13 @@ func (ue *UserEntity) UpdateThreadRead(teamId, threadId string, timestamp int64)
 	if err != nil {
 		return err
 	}
-	return ue.store.SetThreads([]*model.ThreadResponse{thread})
+
+	tWrapped := make([]*store.ThreadResponseWrapped, 1)
+	tWrapped[0] = &store.ThreadResponseWrapped{
+		ThreadResponse: *thread,
+	}
+
+	return ue.store.SetThreads(tWrapped)
 }
 
 // GetSidebarCategories fetches and stores the sidebar categories for an user.

--- a/loadtest/user/userentity/utils.go
+++ b/loadtest/user/userentity/utils.go
@@ -32,6 +32,9 @@ func postsMapToSlice(postsMap map[string]*model.Post) []*model.Post {
 func postListToSlice(list *model.PostList) []*model.Post {
 	posts := make([]*model.Post, len(list.Order))
 	for i, id := range list.Order {
+		// This assumes that list.Posts will always contain
+		// posts in list.Order. Need to improve. Otherwise, there is a
+		// possibility of nil pointers getting inserted.
 		posts[i] = list.Posts[id]
 	}
 	return posts

--- a/loadtest/utils_test.go
+++ b/loadtest/utils_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestRandomFutureTimeSuite(t *testing.T) {
+	now := time.Now().UnixMilli()
 	tests := []struct {
 		name        string
 		deltaStart  time.Duration
@@ -27,8 +28,8 @@ func TestRandomFutureTimeSuite(t *testing.T) {
 			name:        "Zero Durations",
 			deltaStart:  0 * time.Second,
 			maxUntil:    0 * time.Second,
-			expectedMin: time.Now().UnixMilli(),
-			expectedMax: time.Now().UnixMilli(),
+			expectedMin: now,
+			expectedMax: now,
 		},
 		{
 			name:       "Negative Durations",
@@ -61,7 +62,7 @@ func TestRandomFutureTimeSuite(t *testing.T) {
 			randomTime := RandomFutureTime(tt.deltaStart, tt.maxUntil)
 
 			if tt.expectedMin != 0 && tt.expectedMax != 0 {
-				require.Equal(t, randomTime, tt.expectedMin)
+				require.LessOrEqual(t, tt.expectedMin, randomTime)
 			} else {
 				// checking both ways to allow for negative values
 				isBetweenBounds := (randomTime >= start.UnixMilli() && randomTime <= end.UnixMilli()) || (randomTime <= start.UnixMilli() && randomTime >= end.UnixMilli())


### PR DESCRIPTION
Our existing viewThread implementation was incorrect. It used
to load pages of posts in a thread as a user scrolls up or down.

That is the ideal way, but our webapp actually loads the entire
thread. That is the first change done here.

Then, we apply the performance optimization where for subsequent
loads of a thread, we use the lastUpdateAt of a thread and pass
that to the API call.

https://mattermost.atlassian.net/browse/MM-63542
