### PR TITLE
MM-63743: Add flag to maintain metrics instance

### DIFF
--- a/cmd/ltctl/comparison.go
+++ b/cmd/ltctl/comparison.go
@@ -234,10 +234,15 @@ func DestroyComparisonCmdF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read comparison config: %w", err)
 	}
 
+	maintainMetrics, err := cmd.Flags().GetBool("do-not-destroy-metrics-instance")
+	if err != nil {
+		return fmt.Errorf("failed getting the --do-not-destroy-metrics-instance flag: %w", err)
+	}
+
 	cmp, err := comparison.New(cfg, &deployerConfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize comparison object: %w", err)
 	}
 
-	return cmp.Destroy()
+	return cmp.Destroy(maintainMetrics)
 }

--- a/cmd/ltctl/utils.go
+++ b/cmd/ltctl/utils.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func askForConfirmation(prompt string) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print(prompt)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("unable to read answer from user: %w", err)
+	}
+
+	return strings.ToLower(answer) != "y", nil
+}
+
+// checkDoNotDestroyMetricsInstanceFlag asks for confirmation if the
+// --do-not-destroy-metrics-instance flag is passed
+func checkDoNotDestroyMetricsInstanceFlag(cmd *cobra.Command, args []string) error {
+	maintainMetrics, err := cmd.Flags().GetBool("do-not-destroy-metrics-instance")
+	if err != nil {
+		return fmt.Errorf("failed getting the --do-not-destroy-metrics-instance flag: %w", err)
+	}
+
+	if maintainMetrics {
+		confirmed, err := askForConfirmation("CAUTION! The --do-not-destroy-metrics-instance flag will keep the metrics instance alive by removing it from Terraform state. This means that you will need to manually clean it up when you are done with it. Do you want to continue? [y/n] ")
+		if err != nil {
+			return err
+		}
+
+		if !confirmed {
+			return fmt.Errorf("Aborting this destroy. Remove the --do-not-destroy-metrics-instance flag if you want to destroy everything.")
+		}
+	}
+
+	return nil
+}

--- a/comparison/comparison.go
+++ b/comparison/comparison.go
@@ -156,11 +156,23 @@ func (c *Comparison) Run() (Output, error) {
 
 // Destroy destroys all resources associated with the deployments for the
 // current automated load-test comparisons.
-func (c *Comparison) Destroy() error {
+func (c *Comparison) Destroy(maintainMetrics bool) error {
+	resourcesToMaintain := []string{
+		"aws_instance.metrics_server[0]",
+		"aws_security_group.metrics[0]",
+		"aws_security_group_rule.metrics-egress[0]",
+		"aws_security_group_rule.metrics-grafana[0]",
+	}
+
 	return c.deploymentAction(func(t *terraform.Terraform, _ *deploymentConfig) error {
 		if err := t.Sync(); err != nil {
 			return err
 		}
+
+		if maintainMetrics {
+			return t.Destroy(resourcesToMaintain...)
+		}
+
 		return t.Destroy()
 	})
 }

--- a/deployment/terraform/destroy.go
+++ b/deployment/terraform/destroy.go
@@ -11,7 +11,10 @@ import (
 )
 
 // Destroy destroys the created load-test environment.
-func (t *Terraform) Destroy() error {
+// If the resourcesToMaintain variadic argument has at least one element, the
+// specified resources are removed from the state, meaning that they will not
+// be destroyed, and that Terraform will ignore them from now on.
+func (t *Terraform) Destroy(resourcesToMaintain ...string) error {
 	if err := t.preFlightCheck(); err != nil {
 		return err
 	}
@@ -20,6 +23,18 @@ func (t *Terraform) Destroy() error {
 	// bucket to destroy
 	if err := t.loadOutput(); err != nil {
 		return err
+	}
+
+	if len(resourcesToMaintain) > 0 {
+		mlog.Info("Removing resources from state; these resources will *not* be destroyed, and they will no longer be under Terraform control. You will have to manually clean them up when needed.", mlog.Array("list of resource addresses", resourcesToMaintain))
+		var params []string
+		params = append(params, "state")
+		params = append(params, "rm")
+		params = append(params, resourcesToMaintain...)
+
+		if err := t.runCommand(nil, params...); err != nil {
+			return err
+		}
 	}
 
 	// Empty the S3 bucket concurrently with the main terraform destroy command


### PR DESCRIPTION
#### Summary
This PR proposes a way to destroy everything but the metrics instance. If the `--do-not-destroy-metrics-instance` flag is passed, then:
1. The command runs `terraform rm <list of resources>`, where `<list of resources>` is a list containing the metrics instance and the security groups and rules that are needed.
2. Then the command runs `terraform destroy` as usual.

This has an important consequence: the resources that are passed to `rm` are completely ignored by Terraform from that moment on, meaning that the user will need to clean them up manually at some point. To make this very clear, I've added a confirmation step explaining the consequences of using the flag, which stops the command if the user does not answer `y`.

I'm open to discussions on how to approach this differently, but the idea of this flag is that it should only be used by people that know what they are doing, and it is of course a workaround while we find the time to tackle https://mattermost.atlassian.net/browse/MM-63249, which would be the proper solution.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63743