### PR TITLE
MM-63724: Remove excessive calls to GetChannelsForTeam

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	client "github.com/mattermost/mattermost-load-test-ng/api/client/agent"
 	"github.com/mattermost/mattermost-load-test-ng/defaults"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
@@ -352,12 +353,16 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 	}
 
 	var err error
-	serverVersion := config.UserControllerConfiguration.ServerVersion
-	if serverVersion == "" {
-		serverVersion, err = getServerVersion(config.ConnectionConfiguration.ServerURL)
+	serverVersionStr := config.UserControllerConfiguration.ServerVersion
+	if serverVersionStr == "" {
+		serverVersionStr, err = getServerVersion(config.ConnectionConfiguration.ServerURL)
 		if err != nil {
 			mlog.Error("Failed to get server version", mlog.Err(err))
 		}
+	}
+	serverVersion, err := semver.Parse(serverVersionStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse server version %q: %w", serverVersionStr, err)
 	}
 
 	creds, err := getUserCredentials(config.UsersConfiguration.UsersFilePath, config)

--- a/api/agent_client_test.go
+++ b/api/agent_client_test.go
@@ -24,7 +24,7 @@ import (
 
 func createFakeMMServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Version-Id", "dev")
+		w.Header().Set("X-Version-Id", "1.0.0")
 		switch r.URL.Path {
 		case "/api/v4/users/login":
 			u := model.User{}

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -807,12 +807,12 @@ func Reload(u user.User) UserActionResponse {
 		teamId = team.Id
 	}
 
-	if teamId != "" {
-		err = u.GetTeamMembersForUser(u.Store().Id())
-		if err != nil {
-			return UserActionResponse{Err: NewUserError(err)}
-		}
+	err = u.GetTeamMembersForUser(u.Store().Id())
+	if err != nil {
+		return UserActionResponse{Err: NewUserError(err)}
+	}
 
+	if teamId != "" {
 		if tm, err := u.Store().TeamMember(teamId, u.Store().Id()); err == nil && tm.UserId != "" {
 			if err := u.GetChannelsForTeam(teamId, true); err != nil {
 				return UserActionResponse{Err: NewUserError(err)}
@@ -822,12 +822,11 @@ func Reload(u user.User) UserActionResponse {
 				return UserActionResponse{Err: NewUserError(err)}
 			}
 		}
+	}
 
-		_, err = u.GetChannelsForUser(userId)
-		if err != nil {
-			return UserActionResponse{Err: NewUserError(err)}
-
-		}
+	_, err = u.GetChannelsForUser(userId)
+	if err != nil {
+		return UserActionResponse{Err: NewUserError(err)}
 	}
 
 	err = u.GetAllChannelMembersForUser(userId)

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -830,6 +830,11 @@ func Reload(u user.User) UserActionResponse {
 		}
 	}
 
+	err = u.GetAllChannelMembersForUser(userId)
+	if err != nil {
+		return UserActionResponse{Err: NewUserError(err)}
+	}
+
 	// Getting unread teams.
 	_, err = u.GetTeamsUnread("", false)
 	if err != nil {

--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -69,20 +69,13 @@ func Login(u user.User) UserActionResponse {
 	}
 
 	// Populate teams and channels.
-	teamIds, err := u.GetAllTeams(0, 100)
+	_, err = u.GetAllTeams(0, 100)
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
 	}
 	err = u.GetTeamMembersForUser(u.Store().Id())
 	if err != nil {
 		return UserActionResponse{Err: NewUserError(err)}
-	}
-	for _, teamId := range teamIds {
-		if tm, err := u.Store().TeamMember(teamId, u.Store().Id()); err == nil && tm.UserId != "" {
-			if err := u.GetChannelsForTeam(teamId, true); err != nil {
-				return UserActionResponse{Err: NewUserError(err)}
-			}
-		}
 	}
 
 	return UserActionResponse{Info: "logged in"}

--- a/loadtest/control/simulcontroller/actions.go
+++ b/loadtest/control/simulcontroller/actions.go
@@ -256,14 +256,6 @@ func loadTeam(u user.User, team *model.Team, gqlEnabled bool) control.UserAction
 				break
 			}
 		}
-	} else {
-		if _, err := u.GetChannelsForTeamForUser(team.Id, u.Store().Id(), true); err != nil {
-			return control.UserActionResponse{Err: control.NewUserError(err)}
-		}
-
-		if err := u.GetChannelMembersForUser(u.Store().Id(), team.Id); err != nil {
-			return control.UserActionResponse{Err: control.NewUserError(err)}
-		}
 	}
 
 	collapsedThreads, resp := control.CollapsedThreadsEnabled(u)

--- a/loadtest/control/simulcontroller/controller.go
+++ b/loadtest/control/simulcontroller/controller.go
@@ -405,23 +405,13 @@ func (c *SimulController) Run() {
 	}()
 
 	// Init controller's server version
-	serverVersionString, err := c.user.Store().ServerVersion()
-	if err != nil {
-		c.sendFailStatus("server version could not be retrieved")
-		return
-	}
-	serverVersion, err := control.ParseServerVersion(serverVersionString)
-	if err != nil {
-		c.sendFailStatus("server version could not be parsed")
-		return
-	}
-	c.serverVersion = serverVersion
+	c.serverVersion = c.user.Store().ServerVersion()
 
 	// Early check that the server version is greater or equal than the initialVersion
 	if !c.isVersionSupported(control.MinSupportedVersion) {
 		c.sendFailStatus(fmt.Sprintf(
 			"server version %q is lower than the minimum supported version %q",
-			serverVersion.String(),
+			c.serverVersion.String(),
 			control.MinSupportedVersion.String(),
 		))
 		return
@@ -458,6 +448,7 @@ func (c *SimulController) Run() {
 	}
 
 	var action *userAction
+	var err error
 
 	// Filter only actions that are available for the current server
 	var supportedActions []userAction

--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -44,7 +45,7 @@ type MemStore struct {
 	currentTeam         *model.Team
 	channelViews        map[string]int64
 	profileImages       map[string]int
-	serverVersion       string
+	serverVersion       semver.Version
 	threads             map[string]*model.ThreadResponse
 	threadsQueue        *CQueue[model.ThreadResponse]
 	sidebarCategories   map[string]map[string]*model.SidebarCategoryWithChannels
@@ -1033,14 +1034,14 @@ func (s *MemStore) SetProfileImage(userId string, lastPictureUpdate int) error {
 }
 
 // ServerVersion returns the server version string.
-func (s *MemStore) ServerVersion() (string, error) {
+func (s *MemStore) ServerVersion() semver.Version {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return s.serverVersion, nil
+	return s.serverVersion
 }
 
 // SetServerVersion stores the given server version.
-func (s *MemStore) SetServerVersion(version string) error {
+func (s *MemStore) SetServerVersion(version semver.Version) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.serverVersion = version

--- a/loadtest/store/store.go
+++ b/loadtest/store/store.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"github.com/blang/semver"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -136,8 +137,8 @@ type UserStore interface {
 	// after a specified timestamp in milliseconds.
 	PostsIdsSince(ts int64) ([]string, error)
 
-	// ServerVersion returns the server version string.
-	ServerVersion() (string, error)
+	// ServerVersion returns the server version
+	ServerVersion() semver.Version
 
 	// Threads
 	Thread(threadId string) (*model.ThreadResponse, error)
@@ -276,7 +277,7 @@ type MutableUserStore interface {
 	SetProfileImage(userId string, lastPictureUpdate int) error
 
 	// SetServerVersion sets the server version string.
-	SetServerVersion(version string) error
+	SetServerVersion(version semver.Version) error
 
 	// Threads
 	// SetThreads stores the given posts.

--- a/loadtest/user/user.go
+++ b/loadtest/user/user.go
@@ -195,6 +195,9 @@ type User interface {
 	GetChannelUnread(channelId string) (*model.ChannelUnread, error)
 	// GetChannelMembers fetches and stores channel members for the specified channel.
 	GetChannelMembers(channelId string, page, perPage int) error
+	// GetAllChannelMembersForUser gets all channel memberships for the
+	// specified user regardless of the team the channels are part of
+	GetAllChannelMembersForUser(userId string) error
 	// GetChannelMembersForUser gets the channel members for the specified user in
 	// the specified team.
 	GetChannelMembersForUser(userId, teamId string) error

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/blang/semver"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -699,8 +700,29 @@ func (ue *UserEntity) GetChannelMembers(channelId string, page, perPage int) err
 // GetAllChannelMembersForUser gets all channel memberships for the
 // specified user regardless of the team the channels are part of
 func (ue *UserEntity) GetAllChannelMembersForUser(userId string) error {
-	perPage := 200
+	serverVersion := ue.Store().ServerVersion()
+	// Versions 10.9.0 and later support streaming all the members by setting
+	// page to -1, so there is no need to paginate
+	if serverVersion.GTE(semver.MustParse("10.9.0")) {
+		membersWithTeamData, _, err := ue.client.GetChannelMembersWithTeamData(context.Background(), userId, -1, 0)
+		if err != nil {
+			return err
+		}
+
+		// Retrieve the embedded ChannelMember struct, we don't store the team data
+		plainMembers := make(model.ChannelMembers, len(membersWithTeamData))
+		for i, memberWithTeamData := range membersWithTeamData {
+			plainMembers[i] = memberWithTeamData.ChannelMember
+		}
+
+		// Set the slice of members we got
+		return ue.store.SetChannelMembers(plainMembers)
+	}
+
+	// Fallback logic for older servers.
+	// Remove this differentiation when 10.8.0 goes out of support.
 	page := 0
+	perPage := 200
 	for {
 		// Get perPage members from /users/$user_id/channel_members
 		membersWithTeamData, _, err := ue.client.GetChannelMembersWithTeamData(context.Background(), userId, page, perPage)
@@ -726,6 +748,7 @@ func (ue *UserEntity) GetAllChannelMembersForUser(userId string) error {
 
 		page++
 	}
+
 }
 
 // GetChannelMembersForUser gets the channel members for the specified user in

--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -743,7 +743,7 @@ func (ue *UserEntity) GetAllChannelMembersForUser(userId string) error {
 		}
 
 		// Stop when we get to the last page
-		if len(membersWithTeamData) < 200 {
+		if len(membersWithTeamData) < perPage {
 			return nil
 		}
 


### PR DESCRIPTION
#### Summary
This PR does a few things now, after Agniva's comments:
- It adds a new function to get *all* the channel memberships of *all* teams using the `/users/$user_id/channel_members` endpoint, named `GetAllChannelMembersForUser`. This is now called from `control.Reload`, right after `GetChannelsForUser`, mimicking [the behaviour in the webapp](https://github.com/mattermost/mattermost/blob/6ae0efd285bfd925e28ce86933c2a4b2170cc093/webapp/channels/src/components/team_controller/team_controller.tsx#L60-L66).
- It removes the calls to `GetChannelsForTeamForUser` both from `control.Login` and from `simulcontroller.loadTeam`. We can do this because we were already calling `GetChannelsForUser` in `control.Reload`: this call retrieves *all* channels from *all* teams.
- It removes the call to `GetChannelMembersForUser` from `simulcontroller.loadTeam` because we already have all channel memberships from the new `GetAllChannelMembersForUser` in `control.Reload`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63724
