### PR TITLE
MM-63827: Generate random password for Grafana admin user

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -326,7 +326,7 @@ func (t *Terraform) Create(extAgent *ssh.ExtAgent, initData bool) error {
 	}
 
 	mlog.Info("Deployment complete.")
-	displayInfo(t.output)
+	displayInfo(*t.GeneratedValues(), t.output)
 	runcmd := "go run ./cmd/ltctl"
 	if strings.HasPrefix(os.Args[0], "ltctl") {
 		runcmd = "ltctl"

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -326,7 +326,7 @@ func (t *Terraform) Create(extAgent *ssh.ExtAgent, initData bool) error {
 	}
 
 	mlog.Info("Deployment complete.")
-	displayInfo(*t.GeneratedValues(), t.output)
+	displayInfo(t.GeneratedValues().Sanitize(), t.output)
 	runcmd := "go run ./cmd/ltctl"
 	if strings.HasPrefix(os.Args[0], "ltctl") {
 		runcmd = "ltctl"

--- a/deployment/terraform/generated_values.go
+++ b/deployment/terraform/generated_values.go
@@ -22,6 +22,11 @@ type GeneratedValues struct {
 	GrafanaAdminPassword string `json:"GrafanaAdminPassword"`
 }
 
+func (v GeneratedValues) Sanitize() GeneratedValues {
+	v.GrafanaAdminPassword = "********"
+	return v
+}
+
 func openValuesFile(cfg deployment.Config) (*os.File, error) {
 	path := path.Join(cfg.TerraformStateDir, genValuesFileName)
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)

--- a/deployment/terraform/generated_values.go
+++ b/deployment/terraform/generated_values.go
@@ -1,0 +1,72 @@
+package terraform
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
+)
+
+const (
+	// Name of the file where the generated values will be persisted.
+	// The directory is always inferred from deployment.Config
+	genValuesFileName = "generatedvalues.json"
+)
+
+// GeneratedValues is a struct containing values generated automatically during
+// the deployment, not user-defined.
+type GeneratedValues struct {
+	GrafanaAdminPassword string `json:"GrafanaAdminPassword"`
+}
+
+func openValuesFile(cfg deployment.Config) (*os.File, error) {
+	path := path.Join(cfg.TerraformStateDir, genValuesFileName)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open file %q: %w", path, err)
+	}
+
+	return file, nil
+}
+
+func readGenValues(cfg deployment.Config) (*GeneratedValues, error) {
+	file, err := openValuesFile(cfg)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	contents, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read contents: %w", err)
+	}
+
+	if len(contents) == 0 {
+		return &GeneratedValues{}, nil
+	}
+
+	var values GeneratedValues
+	if err := json.Unmarshal(contents, &values); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal read content %q: %w", string(contents), err)
+	}
+
+	return &values, nil
+}
+
+func persistGeneratedValues(cfg deployment.Config, genValues *GeneratedValues) error {
+	file, err := openValuesFile(cfg)
+	if err != nil {
+		return fmt.Errorf("unable to open file: %w", err)
+	}
+	defer file.Close()
+
+	enc := json.NewEncoder(file)
+	if err := enc.Encode(genValues); err != nil {
+		return fmt.Errorf("unable to encode generated values: %w", err)
+	}
+
+	return nil
+}

--- a/deployment/terraform/generated_values_test.go
+++ b/deployment/terraform/generated_values_test.go
@@ -1,0 +1,180 @@
+package terraform
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mattermost/mattermost-load-test-ng/deployment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestDir creates a temporary directory for testing and returns a config with it
+func setupTestDir(t *testing.T) deployment.Config {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "generated_values_test")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	cfg := deployment.Config{
+		TerraformStateDir: tempDir,
+	}
+
+	return cfg
+}
+
+func TestOpenValuesFile(t *testing.T) {
+	cfg := setupTestDir(t)
+
+	// Test successful file opening
+	t.Run("Open values file successfully", func(t *testing.T) {
+		file, err := openValuesFile(cfg)
+		require.NoError(t, err)
+		defer file.Close()
+		assert.NotNil(t, file)
+	})
+
+	// Test with invalid directory
+	t.Run("Invalid directory", func(t *testing.T) {
+		invalidCfg := deployment.Config{
+			TerraformStateDir: "/path/that/does/not/exist",
+		}
+		_, err := openValuesFile(invalidCfg)
+		assert.Error(t, err)
+	})
+}
+
+func TestReadGenValues(t *testing.T) {
+	cfg := setupTestDir(t)
+	tempDir := cfg.TerraformStateDir
+
+	// Test reading from an empty/non-existent file
+	t.Run("Read empty file", func(t *testing.T) {
+		values, err := readGenValues(cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, values)
+		assert.Empty(t, values.GrafanaAdminPassword)
+	})
+
+	// Test reading malformed JSON
+	t.Run("Read malformed JSON", func(t *testing.T) {
+		// Write malformed JSON to the file
+		filePath := filepath.Join(tempDir, genValuesFileName)
+		err := os.WriteFile(filePath, []byte("this is not valid json"), 0644)
+		require.NoError(t, err)
+
+		// Try to read the values
+		_, err = readGenValues(cfg)
+		assert.Error(t, err)
+	})
+
+	// Test reading valid JSON
+	t.Run("Read valid JSON", func(t *testing.T) {
+		// Write valid JSON to the file
+		filePath := filepath.Join(tempDir, genValuesFileName)
+		testValues := &GeneratedValues{
+			GrafanaAdminPassword: "test-password",
+		}
+		jsonData, err := json.Marshal(testValues)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filePath, jsonData, 0644))
+
+		// Read the values
+		readValues, err := readGenValues(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, testValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
+	})
+}
+
+func TestPersistGeneratedValues(t *testing.T) {
+	cfg := setupTestDir(t)
+	tempDir := cfg.TerraformStateDir
+
+	// Test persisting values to a new file
+	t.Run("Persist to new file", func(t *testing.T) {
+		// Create test values
+		testValues := &GeneratedValues{
+			GrafanaAdminPassword: "test-password",
+		}
+
+		// Persist the values
+		err := persistGeneratedValues(cfg, testValues)
+		require.NoError(t, err)
+
+		// Verify the file exists
+		filePath := filepath.Join(tempDir, genValuesFileName)
+		_, err = os.Stat(filePath)
+		require.NoError(t, err)
+
+		// Read the file directly and verify JSON content
+		fileContent, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		var parsedValues GeneratedValues
+		err = json.Unmarshal(fileContent, &parsedValues)
+		require.NoError(t, err)
+		assert.Equal(t, testValues.GrafanaAdminPassword, parsedValues.GrafanaAdminPassword)
+	})
+
+	// Test updating existing values
+	t.Run("Update existing values", func(t *testing.T) {
+		// Create initial values
+		initialValues := &GeneratedValues{
+			GrafanaAdminPassword: "initial-password",
+		}
+
+		// Persist the initial values
+		err := persistGeneratedValues(cfg, initialValues)
+		require.NoError(t, err)
+
+		// Update with new values
+		updatedValues := &GeneratedValues{
+			GrafanaAdminPassword: "updated-password",
+		}
+
+		// Persist the updated values
+		err = persistGeneratedValues(cfg, updatedValues)
+		require.NoError(t, err)
+
+		// Read the values back
+		readValues, err := readGenValues(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, updatedValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
+	})
+}
+
+func TestIntegration(t *testing.T) {
+	cfg := setupTestDir(t)
+
+	// Test the full workflow: persist, read, update
+	t.Run("Full workflow", func(t *testing.T) {
+		// Create and persist initial values
+		initialValues := &GeneratedValues{
+			GrafanaAdminPassword: "initial-password",
+		}
+		err := persistGeneratedValues(cfg, initialValues)
+		require.NoError(t, err)
+
+		// Read the values back
+		readValues, err := readGenValues(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, initialValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
+
+		// Update the values
+		updatedValues := &GeneratedValues{
+			GrafanaAdminPassword: "updated-password",
+		}
+		err = persistGeneratedValues(cfg, updatedValues)
+		require.NoError(t, err)
+
+		// Read the updated values
+		readUpdatedValues, err := readGenValues(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, updatedValues.GrafanaAdminPassword, readUpdatedValues.GrafanaAdminPassword)
+	})
+}

--- a/deployment/terraform/info.go
+++ b/deployment/terraform/info.go
@@ -16,12 +16,12 @@ func (t *Terraform) Info() error {
 		return err
 	}
 
-	displayInfo(output)
+	displayInfo(*t.GeneratedValues(), output)
 
 	return nil
 }
 
-func displayInfo(output *Output) {
+func displayInfo(genValues GeneratedValues, output *Output) {
 	fmt.Println("==================================================")
 	fmt.Println("Deployment information:")
 
@@ -66,6 +66,9 @@ func displayInfo(output *Output) {
 
 	if output.HasMetrics() {
 		fmt.Println("Grafana URL: http://" + output.MetricsServer.GetConnectionIP() + ":3000")
+		fmt.Println("Grafana credentials:")
+		fmt.Println("  - User: admin")
+		fmt.Println("  - Pass: " + genValues.GrafanaAdminPassword)
 		fmt.Println("Prometheus URL: http://" + output.MetricsServer.GetConnectionIP() + ":9090")
 		fmt.Println("Pyroscope URL: http://" + output.MetricsServer.GetConnectionIP() + ":4040")
 	}

--- a/deployment/terraform/metrics.go
+++ b/deployment/terraform/metrics.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -313,14 +312,7 @@ func (t *Terraform) setupMetrics(extAgent *ssh.ExtAgent) error {
 	mlog.Info("Setting up Grafana", mlog.String("host", t.output.MetricsServer.GetConnectionIP()))
 
 	// Change Grafana admin password
-	// No need to be cryptographically secure here, we just need a new password
-	passLen := 32
-	chars := []rune("abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789")
-	s := make([]rune, passLen)
-	for j := 0; j < passLen; j++ {
-		s[j] = chars[rand.Intn(len(chars))]
-	}
-	password := string(s)
+	password := generatePseudoRandomPassword(32)
 	cmd = fmt.Sprintf("sudo grafana-cli --homepath \"/usr/share/grafana\" admin reset-admin-password %q", password)
 	if out, err := sshc.RunCommand(cmd); err != nil {
 		return fmt.Errorf("error running ssh command: cmd: %s, output: %s, err: %v", cmd, out, err)

--- a/deployment/terraform/utils.go
+++ b/deployment/terraform/utils.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -374,4 +375,15 @@ func (t *Terraform) GetAWSCreds() (aws.Credentials, error) {
 	}
 
 	return cfg.Credentials.Retrieve(context.Background())
+}
+
+// generatePseudoRandomPassword returns a pseudo-random string containing
+// lower-case letters, upper-case letter and numbers
+func generatePseudoRandomPassword(length int) string {
+	chars := []rune("abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789")
+	s := make([]rune, length)
+	for j := 0; j < length; j++ {
+		s[j] = chars[rand.Intn(len(chars))]
+	}
+	return string(s)
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -97,7 +97,7 @@ Yes, you can do so by using the feature to [publish a snapshot to Raintank](http
 
 Two considerations:
 
-- Due to [this issue](https://github.com/grafana/grafana/issues/32585), you need to be logged in to access the Snapshot option in the Share dialog. Although logging in is not usually needed in these temporal instances, you can still do so for this purpose with the credentials `admin`/`admin`.
+- Due to [this issue](https://github.com/grafana/grafana/issues/32585), you need to be logged in to access the Snapshot option in the Share dialog. Although logging in is not usually needed in these temporary instances, you can still do so for this purpose with the credentials for the `admin` user, that are listed under the Grafana URL when running `deployment info`.
 - Note that a snapshot, although very useful for reference, is not a fully-functioning dashboard, so you will not be able to query new data using it. Take a look at the example above to understand how it works.
 
 ### Can I stress test the ElasticSearch jobs?

--- a/docs/load-test-how-to-use.md
+++ b/docs/load-test-how-to-use.md
@@ -61,7 +61,7 @@ The steps to load-test a new feature in production, after testing new actions lo
     - Start the load test with `go run ./cmd/ltctl loadtest start`.
         - Once a loadtest is running, its status can be checked with `go run ./cmd/ltctl loadtest status`.
         - `ssh` into one of the agent machines, and `cat ~/mattermost-load-test-ng/logs/ltagent.log` to verify the load-test is working without errors.
-        - Open the Grafana deployment with the URL from `go run ./cmd/ltctl deployment info`. 
+        - Open the Grafana deployment with the URL from `go run ./cmd/ltctl deployment info`. The anonymous access has the `Viewer` role. If you need to edit the dashboards or do something that requires login, the `deployment info` command shows the credentials for the `admin` user.
         - It takes some time for the deployment to stabilize. Until the loadtest tool connects the `MaxActiveUsers` count of users to the app, there might be a big count of HTTP 4xx errors during this time.
             
             A sample error count vs time graph: ![error-vs-time](https://i.imgur.com/RSH1Szl.png)


### PR DESCRIPTION
#### Summary
Second part of https://mattermost.atlassian.net/browse/MM-63827, in addition to #909. This PR generates a random password for Grafana's `admin` user.

The less pretty part is that we need to store the password locally to persist it between calls to `ltctl` commands, so that we can show it on `deployment info`. As this flow is only needed when deploying to Terraform, I've created a new `GeneratedValues` struct that stores values generated during deployment that are not user-specified (only this Grafana admin pass for now). I added a field of that type to the `Terraform` struct, and then I persist that struct to disk in a new file inside `TerraformStateDir`, which is already a directory that `ltctl` controls and that stores Terraform-related state.

I first though about implementing a full reader/writer for this struct, so that the caller simply needs to do something like Get/Set, but I ended up coding only the minimal interface I need ( (in `generated_values.go`) to get from and write to disk, so for example, the caller is required to call `PersistGeneratedValues` if needed. If we see that we need something more advanced in the future, we can generalize it from here, but for now, I'd say that this is enough.

The tests are mostly written by aider.

Output when `deployment create` finishes (sanitized so that it is not shown in CI and similar)
```
Grafana URL: http://35.153.175.63:3000
Grafana credentials:
  - User: admin
  - Pass: ********
```
Output of `deployment info` (explicit so that the user can get the credentials they need)
```
Grafana URL: http://35.153.175.63:3000
Grafana credentials:
  - User: admin
  - Pass: GZLqB1rPWvlyIgq20DVZDvJiM0nrH8zH
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63827