### PR TITLE
MM-62365: Fix errors in submitPerformanceReport

### DIFF
--- a/loadtest/user/userentity/report.go
+++ b/loadtest/user/userentity/report.go
@@ -23,9 +23,8 @@ func (ue *UserEntity) ObserveClientMetric(t model.MetricType, v float64) error {
 		}
 
 		report.Histograms = append(report.Histograms, &model.MetricSample{
-			Metric:    t,
-			Value:     v,
-			Timestamp: float64(time.Now().UnixMilli()) / 1000,
+			Metric: t,
+			Value:  v,
 		})
 	default:
 		// server also ignores the unkown typed metrics
@@ -38,14 +37,15 @@ func (ue *UserEntity) SubmitPerformanceReport() error {
 	if err != nil {
 		return err
 	}
-	report.End = float64(time.Now().UnixMilli()) / 1000
+	report.End = float64(time.Now().UnixMilli())
+	report.Version = "0.1.0"
 
 	_, err = ue.client.SubmitClientMetrics(context.Background(), report)
 	if err != nil {
 		return err
 	}
 	ue.store.SetPerformanceReport(&model.PerformanceReport{
-		Start: float64(time.Now().UnixMilli()) / 1000,
+		Start: report.End,
 	})
 
 	return nil

--- a/loadtest/user/userentity/user.go
+++ b/loadtest/user/userentity/user.go
@@ -158,7 +158,7 @@ func New(setup Setup, config Config) *UserEntity {
 			"agent":    "other",
 		},
 		ClientID: model.NewId(),
-		Start:    float64(time.Now().UnixMilli()) / 1000,
+		Start:    float64(time.Now().UnixMilli()),
 	})
 
 	return &ue


### PR DESCRIPTION
There were various bugs in the implmentation logic.
1. Start and End are ms, not s.
2. The Version field is compulsory to be set in the
report struct.
3. The timestamp field is unused entirely in the server.
So we remove it here and will remove from server
as well.

https://mattermost.atlassian.net/browse/MM-62365
