### PR TITLE
Fix validation of sample JSON files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,22 @@ verify-gomod: ## Run go mod verify.
 	$(GO) mod download
 	$(GO) mod verify
 
-check-style: golangci-lint ## Check the style of the code.
+check-style: golangci-lint validate-json-configs ## Check the style of the code.
 
 golangci-lint:
 	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64
 
 	@echo Running golangci-lint
 	$(GOBIN)/golangci-lint run ./...
+
+validate-json-configs:
+	$(GO) run ./scripts/json_validator.go config/config.sample.json
+	$(GO) run ./scripts/json_validator.go config/coordinator.sample.json
+	$(GO) run ./scripts/json_validator.go config/deployer.sample.json
+	$(GO) run ./scripts/json_validator.go config/comparison.sample.json
+	$(GO) run ./scripts/json_validator.go config/gencontroller.sample.json
+	$(GO) run ./scripts/json_validator.go config/simplecontroller.sample.json
+	$(GO) run ./scripts/json_validator.go config/simulcontroller.sample.json
 
 test: ## Run all tests.
 	$(GO) test -v -mod=readonly -failfast -race -tags=integration ./...

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -73,7 +73,7 @@
     "DataSource": "",
     "DataSourceReplicas": [],
     "DataSourceSearchReplicas": [],
-    "ClusterIdentifier": "",
+    "ClusterIdentifier": ""
   },
   "ExternalBucketSettings": {
     "AmazonS3AccessKeyId": "",

--- a/scripts/json_validator.go
+++ b/scripts/json_validator.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run ./scripts/json_validator.go <path-to-json-file>")
+		os.Exit(1)
+	}
+
+	filePath := os.Args[1]
+
+	// Read the JSON file
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		fmt.Printf("Error reading file: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Validate JSON
+	var jsonData interface{}
+	if err := json.Unmarshal(fileContent, &jsonData); err != nil {
+		fmt.Printf("Invalid JSON: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("The JSON is valid.")
+	os.Exit(0)
+}


### PR DESCRIPTION
#### Summary

Looks like `deployer.sample.json` wasn't valid JSON (due to an extra comma). I added a script to run as part of `check-style` to avoid merging invalid JSON files in the future.



