### PR TITLE
[MM-61922] Improve validation and documentation of `RestTimeSec` and `UpdateIntervalMs`

### DIFF
--- a/config/coordinator.sample.json
+++ b/config/coordinator.sample.json
@@ -10,7 +10,7 @@
   },
   "MonitorConfig": {
     "PrometheusURL": "http://localhost:9090",
-    "UpdateIntervalMs": 2000,
+    "UpdateIntervalMs": 1000,
     "Queries": [
       {
         "Description": "Percentage of HTTP 5xx server errors",

--- a/config/coordinator.sample.toml
+++ b/config/coordinator.sample.toml
@@ -5,85 +5,85 @@ RestTimeSec = 2
 [ClusterConfig]
 MaxActiveUsers = 2000
 
-    [[ClusterConfig.Agents]]
-    Id = 'lt0'
-    ApiURL = 'http://localhost:4000'
+[[ClusterConfig.Agents]]
+Id = 'lt0'
+ApiURL = 'http://localhost:4000'
 
 [MonitorConfig]
 PrometheusURL = 'http://localhost:9090'
-UpdateIntervalMs = 2000
+UpdateIntervalMs = 1000
 
-    [[MonitorConfig.Queries]]
-    Description = 'Percentage of HTTP 5xx server errors'
-    Legend = 'Percent'
-    Query = '(sum(rate(mattermost_api_time_count{status_code=~"5.."}[1m]))/sum(rate(mattermost_api_time_count[1m])))*100'
-    Threshold = 0.025
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'Percentage of HTTP 5xx server errors'
+Legend = 'Percent'
+Query = '(sum(rate(mattermost_api_time_count{status_code=~"5.."}[1m]))/sum(rate(mattermost_api_time_count[1m])))*100'
+Threshold = 0.025
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = 'Average client request duration'
-    Legend = 'Avg duration (s)'
-    Query = 'sum(rate(loadtest_http_request_time_sum[1m]))/sum(rate(loadtest_http_request_time_count[1m]))'
-    Threshold = 0.1
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'Average client request duration'
+Legend = 'Avg duration (s)'
+Query = 'sum(rate(loadtest_http_request_time_sum[1m]))/sum(rate(loadtest_http_request_time_count[1m]))'
+Threshold = 0.1
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = '99th percentile of client request duration'
-    Legend = 'P99 duration (s)'
-    Query = 'histogram_quantile(0.99, sum(rate(loadtest_http_request_time_bucket[1m])) by (le))'
-    Threshold = 2
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = '99th percentile of client request duration'
+Legend = 'P99 duration (s)'
+Query = 'histogram_quantile(0.99, sum(rate(loadtest_http_request_time_bucket[1m])) by (le))'
+Threshold = 2
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = 'Percentage of HTTP 5xx client errors'
-    Legend = 'Percent'
-    Query = '(sum(rate(loadtest_http_errors_total{status_code=~"5.."}[1m]))/sum(rate(loadtest_http_request_time_count[1m])))*100'
-    Threshold = 0.025
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'Percentage of HTTP 5xx client errors'
+Legend = 'Percent'
+Query = '(sum(rate(loadtest_http_errors_total{status_code=~"5.."}[1m]))/sum(rate(loadtest_http_request_time_count[1m])))*100'
+Threshold = 0.025
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = 'Percentage of client timeouts'
-    Legend = 'Percent'
-    Query = '(sum(rate(loadtest_http_timeouts_total[1m]))/sum(rate(loadtest_http_request_time_count[1m]))) * 100'
-    Threshold = 0.025
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'Percentage of client timeouts'
+Legend = 'Percent'
+Query = '(sum(rate(loadtest_http_timeouts_total[1m]))/sum(rate(loadtest_http_request_time_count[1m]))) * 100'
+Threshold = 0.025
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = 'CPU utilization - Average of app nodes'
-    Legend = 'Percent'
-    Query = '100 - 100 * (avg(irate(node_cpu_seconds_total{instance=~"app.*",mode="idle"}[5m])))'
-    Threshold = 85
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'CPU utilization - Average of app nodes'
+Legend = 'Percent'
+Query = '100 - 100 * (avg(irate(node_cpu_seconds_total{instance=~"app.*",mode="idle"}[5m])))'
+Threshold = 85
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = 'Memory utilization - Average of app nodes'
-    Legend = 'Percent'
-    Query = '100 - 100 * avg(node_memory_MemAvailable_bytes{instance=~"app.*"} / node_memory_MemTotal_bytes{instance=~"app.*"})'
-    Threshold = 85
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'Memory utilization - Average of app nodes'
+Legend = 'Percent'
+Query = '100 - 100 * avg(node_memory_MemAvailable_bytes{instance=~"app.*"} / node_memory_MemTotal_bytes{instance=~"app.*"})'
+Threshold = 85
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = 'Percentage of TCP retransmissions in the app nodes'
-    Legend = 'Percent'
-    Query = '(avg(rate(node_netstat_Tcp_RetransSegs{instance=~"app.*"}[1m])) / avg(rate(node_netstat_Tcp_OutSegs{instance=~"app.*"}[1m]))) * 100'
-    Threshold = 0.5
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'Percentage of TCP retransmissions in the app nodes'
+Legend = 'Percent'
+Query = '(avg(rate(node_netstat_Tcp_RetransSegs{instance=~"app.*"}[1m])) / avg(rate(node_netstat_Tcp_OutSegs{instance=~"app.*"}[1m]))) * 100'
+Threshold = 0.5
+MinIntervalSec = 60
+Alert = true
 
-    [[MonitorConfig.Queries]]
-    Description = 'Percentage of TCP retransmissions in the proxy node'
-    Legend = 'Percent'
-    Query = '(avg(rate(node_netstat_Tcp_RetransSegs{instance=~"proxy:9100"}[1m])) / avg(rate(node_netstat_Tcp_OutSegs{instance=~"proxy:9100"}[1m]))) * 100'
-    Threshold = 0.5
-    MinIntervalSec = 60
-    Alert = true
+[[MonitorConfig.Queries]]
+Description = 'Percentage of TCP retransmissions in the proxy node'
+Legend = 'Percent'
+Query = '(avg(rate(node_netstat_Tcp_RetransSegs{instance=~"proxy:9100"}[1m])) / avg(rate(node_netstat_Tcp_OutSegs{instance=~"proxy:9100"}[1m]))) * 100'
+Threshold = 0.5
+MinIntervalSec = 60
+Alert = true
 
 [LogSettings]
 EnableConsole = true

--- a/coordinator/config_test.go
+++ b/coordinator/config_test.go
@@ -1,0 +1,68 @@
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-load-test-ng/coordinator/performance"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigIsValid(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		cfg := Config{
+			NumUsersInc:   8,
+			NumUsersDec:   8,
+			RestTimeSec:   2,
+			MonitorConfig: performance.MonitorConfig{UpdateIntervalMs: 1000},
+		}
+		require.NoError(t, cfg.IsValid())
+	})
+
+	t.Run("invalid NumUsersInc", func(t *testing.T) {
+		cfg := Config{
+			NumUsersInc:   0, // Invalid: should be > 0
+			NumUsersDec:   8,
+			RestTimeSec:   2,
+			MonitorConfig: performance.MonitorConfig{UpdateIntervalMs: 1000},
+		}
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "NumUsersInc should be greater than 0", err.Error())
+	})
+
+	t.Run("invalid NumUsersDec", func(t *testing.T) {
+		cfg := Config{
+			NumUsersInc:   8,
+			NumUsersDec:   0, // Invalid: should be > 0
+			RestTimeSec:   2,
+			MonitorConfig: performance.MonitorConfig{UpdateIntervalMs: 1000},
+		}
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "NumUsersDec should be greater than 0", err.Error())
+	})
+
+	t.Run("invalid RestTimeSec", func(t *testing.T) {
+		cfg := Config{
+			NumUsersInc:   8,
+			NumUsersDec:   8,
+			RestTimeSec:   0, // Invalid: should be > 0
+			MonitorConfig: performance.MonitorConfig{UpdateIntervalMs: 1000},
+		}
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "RestTimeSec should be greater than 0", err.Error())
+	})
+
+	t.Run("RestTimeSec less than UpdateIntervalMs/1000", func(t *testing.T) {
+		cfg := Config{
+			NumUsersInc:   8,
+			NumUsersDec:   8,
+			RestTimeSec:   1, // Invalid: less than UpdateIntervalMs/1000
+			MonitorConfig: performance.MonitorConfig{UpdateIntervalMs: 2000},
+		}
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "RestTimerSec should greater than MonitorConfig.UpdateIntervalMs/1000 (2)", err.Error())
+	})
+}

--- a/coordinator/performance/config.go
+++ b/coordinator/performance/config.go
@@ -14,7 +14,7 @@ type MonitorConfig struct {
 	// The URL of the Prometheus server to query.
 	PrometheusURL string `default:"http://localhost:9090" validate:"url"`
 	// The time interval in milliseconds to wait before querying again.
-	UpdateIntervalMs int `default:"2000" validate:"range:[1000,]"`
+	UpdateIntervalMs int `default:"1000" validate:"range:[1000,]"`
 	// The slice of queries to run.
 	Queries []prometheus.Query `default_size:"0"`
 }

--- a/coordinator/performance/monitor.go
+++ b/coordinator/performance/monitor.go
@@ -101,7 +101,6 @@ func (m *Monitor) runQueries() Status {
 				mlog.String("query_threshold", fmt.Sprintf("%2.8f", query.Threshold)),
 			)
 			status = Status{Alert: true}
-			break
 		}
 	}
 	return status

--- a/docs/config/coordinator.md
+++ b/docs/config/coordinator.md
@@ -40,7 +40,11 @@ The URL to the [Prometheus](https://prometheus.io/docs/introduction/overview/) A
 
 *int*
 
-The amount of time (in milliseconds) to wait before each query update.
+The delay (in milliseconds) between each query update.
+This value also indirectly controls how often new users are added during the ramp-up phase, assuming there is no performance degradation (i.e., no query has exceeded its threshold).
+If performance degradation is detected, `coordinator.Config.RestTimeSec` determines the rate at which users are added or removed.
+
+**Note**: This value cannot exceed `coordinator.Config.RestTimeSec * 1000`.
 
 ### Queries
 
@@ -95,6 +99,8 @@ It should be proportional to the maximum number of users expected to test.
 *int*
 
 The number of seconds to wait after a performance degradation event before starting to increment or decrement users again.
+
+**Note**: The actual time waited before an increment or decrement action can be up to (`RestTimeSec + MonitorConfig.UpdateIntervalMs/1000`) seconds.
 
 ## LogSettings
 


### PR DESCRIPTION
#### Summary

I reviewed the ticket and related logic, and as a result, improved the documentation and configuration.

The initial login (user increment) rate is effectively fixed as of [mattermost-load-test-ng#862](https://github.com/mattermost/mattermost-load-test-ng/pull/862). I tested several configurations, and as long as sufficient resources are allocated, the rate remains constant and aligns with expectations.

`RestTimeSec` only takes effect after a degradation event occurs (i.e., once the query hit threshold is reached). At that point, the coordinator enters a different phase/state, and `RestTimeSec` determines the new rate of user increment/decrement (with some jitter introduced by the `UpdateIntervalMs`-based ticker).

I still believe `UpdateIntervalMs` could be deprecated, as making it configurable doesn't seem to add much value. A default of 1000 makes logical sense since it aligns with computing login rates per second. Let me know if you agree or if you'd prefer to keep it configurable to avoid introducing a breaking change. (If needed, we could ignore the value from the config and log a warning instead.)

![image](https://github.com/user-attachments/assets/bee75d30-ce25-4122-aa66-60246061fd13)

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61922