### PR TITLE
[AI assisted for tests] MM-64392: Fix grafana pass generation in comparisons

### DIFF
--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -77,7 +77,7 @@ func New(id string, cfg deployment.Config) (*Terraform, error) {
 		return nil, fmt.Errorf("unable to create Terraform state directory %q: %w", cfg.TerraformStateDir, err)
 	}
 
-	genValues, err := readGenValues(cfg)
+	genValues, err := readGenValues(id, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get generated values: %w", err)
 	}
@@ -98,7 +98,7 @@ func (t *Terraform) GeneratedValues() *GeneratedValues {
 }
 
 func (t *Terraform) PersistGeneratedValues() error {
-	return persistGeneratedValues(*t.config, t.genValues)
+	return persistGeneratedValues(t.id, *t.config, t.genValues)
 }
 
 // Create creates a new load test environment.

--- a/deployment/terraform/generated_values.go
+++ b/deployment/terraform/generated_values.go
@@ -27,13 +27,16 @@ func (v GeneratedValues) Sanitize() GeneratedValues {
 	return v
 }
 
-func getValuesPath(cfg deployment.Config) string {
+func getValuesPath(id string, cfg deployment.Config) string {
 	fileName := genValuesFileName
+	if id != "" {
+		fileName = id + "_" + genValuesFileName
+	}
 	return path.Join(cfg.TerraformStateDir, fileName)
 }
 
-func openValuesFile(cfg deployment.Config) (*os.File, error) {
-	path := getValuesPath(cfg)
+func openValuesFile(id string, cfg deployment.Config) (*os.File, error) {
+	path := getValuesPath(id, cfg)
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open file %q: %w", path, err)
@@ -42,8 +45,8 @@ func openValuesFile(cfg deployment.Config) (*os.File, error) {
 	return file, nil
 }
 
-func readGenValues(cfg deployment.Config) (*GeneratedValues, error) {
-	file, err := openValuesFile(cfg)
+func readGenValues(id string, cfg deployment.Config) (*GeneratedValues, error) {
+	file, err := openValuesFile(id, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +69,8 @@ func readGenValues(cfg deployment.Config) (*GeneratedValues, error) {
 	return &values, nil
 }
 
-func persistGeneratedValues(cfg deployment.Config, genValues *GeneratedValues) error {
-	file, err := openValuesFile(cfg)
+func persistGeneratedValues(id string, cfg deployment.Config, genValues *GeneratedValues) error {
+	file, err := openValuesFile(id, cfg)
 	if err != nil {
 		return fmt.Errorf("unable to open file: %w", err)
 	}

--- a/deployment/terraform/generated_values.go
+++ b/deployment/terraform/generated_values.go
@@ -27,8 +27,13 @@ func (v GeneratedValues) Sanitize() GeneratedValues {
 	return v
 }
 
+func getValuesPath(cfg deployment.Config) string {
+	fileName := genValuesFileName
+	return path.Join(cfg.TerraformStateDir, fileName)
+}
+
 func openValuesFile(cfg deployment.Config) (*os.File, error) {
-	path := path.Join(cfg.TerraformStateDir, genValuesFileName)
+	path := getValuesPath(cfg)
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open file %q: %w", path, err)

--- a/deployment/terraform/generated_values_test.go
+++ b/deployment/terraform/generated_values_test.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,153 +29,197 @@ func setupTestDir(t *testing.T) deployment.Config {
 	return cfg
 }
 
+func TestGetValuesPath(t *testing.T) {
+	cfg := deployment.Config{
+		TerraformStateDir: "/test/path",
+	}
+
+	for _, id := range []string{"", "someid"} {
+		t.Run(fmt.Sprintf("Get values path, id %q", id), func(t *testing.T) {
+			path := getValuesPath(id, cfg)
+
+			expectedFileName := genValuesFileName
+			if id != "" {
+				expectedFileName = id + "_" + genValuesFileName
+			}
+
+			expected := filepath.Join("/test/path", expectedFileName)
+			assert.Equal(t, expected, path)
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	t.Run("Sanitize values", func(t *testing.T) {
+		// Create test values with sensitive data
+		values := GeneratedValues{
+			GrafanaAdminPassword: "secret-password",
+		}
+
+		// Sanitize the values
+		sanitized := values.Sanitize()
+
+		// Verify the original values are unchanged
+		assert.Equal(t, "secret-password", values.GrafanaAdminPassword)
+
+		// Verify the sensitive fields are masked in the sanitized copy
+		assert.Equal(t, "********", sanitized.GrafanaAdminPassword)
+	})
+}
+
 func TestOpenValuesFile(t *testing.T) {
 	cfg := setupTestDir(t)
 
-	// Test successful file opening
-	t.Run("Open values file successfully", func(t *testing.T) {
-		file, err := openValuesFile("", cfg)
-		require.NoError(t, err)
-		defer file.Close()
-		assert.NotNil(t, file)
-	})
+	for _, id := range []string{"", "someid"} {
+		// Test successful file opening
+		t.Run(fmt.Sprintf("Open values file successfully, id %q", id), func(t *testing.T) {
+			file, err := openValuesFile(id, cfg)
+			require.NoError(t, err)
+			defer file.Close()
+			assert.NotNil(t, file)
+		})
 
-	// Test with invalid directory
-	t.Run("Invalid directory", func(t *testing.T) {
-		invalidCfg := deployment.Config{
-			TerraformStateDir: "/path/that/does/not/exist",
-		}
-		_, err := openValuesFile("", invalidCfg)
-		assert.Error(t, err)
-	})
+		// Test with invalid directory
+		t.Run(fmt.Sprintf("Invalid directory, id %q", id), func(t *testing.T) {
+			invalidCfg := deployment.Config{
+				TerraformStateDir: "/path/that/does/not/exist",
+			}
+			_, err := openValuesFile(id, invalidCfg)
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestReadGenValues(t *testing.T) {
 	cfg := setupTestDir(t)
-	tempDir := cfg.TerraformStateDir
 
-	// Test reading from an empty/non-existent file
-	t.Run("Read empty file", func(t *testing.T) {
-		values, err := readGenValues("", cfg)
-		require.NoError(t, err)
-		assert.NotNil(t, values)
-		assert.Empty(t, values.GrafanaAdminPassword)
-	})
+	for _, id := range []string{"", "someid"} {
+		// Test reading from an empty/non-existent file
+		t.Run(fmt.Sprintf("Read empty file, id %q", id), func(t *testing.T) {
+			values, err := readGenValues(id, cfg)
+			require.NoError(t, err)
+			assert.NotNil(t, values)
+			assert.Empty(t, values.GrafanaAdminPassword)
+		})
 
-	// Test reading malformed JSON
-	t.Run("Read malformed JSON", func(t *testing.T) {
-		// Write malformed JSON to the file
-		filePath := filepath.Join(tempDir, genValuesFileName)
-		err := os.WriteFile(filePath, []byte("this is not valid json"), 0644)
-		require.NoError(t, err)
+		// Test reading malformed JSON
+		t.Run(fmt.Sprintf("Read malformed JSON, id %q", id), func(t *testing.T) {
+			// Write malformed JSON to the file
+			filePath := getValuesPath(id, cfg)
+			err := os.WriteFile(filePath, []byte("this is not valid json"), 0644)
+			require.NoError(t, err)
 
-		// Try to read the values
-		_, err = readGenValues("", cfg)
-		assert.Error(t, err)
-	})
+			// Try to read the values
+			_, err = readGenValues(id, cfg)
+			assert.Error(t, err)
+		})
 
-	// Test reading valid JSON
-	t.Run("Read valid JSON", func(t *testing.T) {
-		// Write valid JSON to the file
-		filePath := filepath.Join(tempDir, genValuesFileName)
-		testValues := &GeneratedValues{
-			GrafanaAdminPassword: "test-password",
-		}
-		jsonData, err := json.Marshal(testValues)
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(filePath, jsonData, 0644))
+		// Test reading valid JSON
+		t.Run(fmt.Sprintf("Read valid JSON, id %q", id), func(t *testing.T) {
+			// Write valid JSON to the file
+			filePath := getValuesPath(id, cfg)
+			testValues := &GeneratedValues{
+				GrafanaAdminPassword: "test-password",
+			}
+			jsonData, err := json.Marshal(testValues)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filePath, jsonData, 0644))
 
-		// Read the values
-		readValues, err := readGenValues("", cfg)
-		require.NoError(t, err)
-		assert.Equal(t, testValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
-	})
+			// Read the values
+			readValues, err := readGenValues(id, cfg)
+			require.NoError(t, err)
+			assert.Equal(t, testValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
+		})
+	}
 }
 
 func TestPersistGeneratedValues(t *testing.T) {
 	cfg := setupTestDir(t)
-	tempDir := cfg.TerraformStateDir
 
-	// Test persisting values to a new file
-	t.Run("Persist to new file", func(t *testing.T) {
-		// Create test values
-		testValues := &GeneratedValues{
-			GrafanaAdminPassword: "test-password",
-		}
+	for _, id := range []string{"", "someid"} {
+		// Test persisting values to a new file
+		t.Run(fmt.Sprintf("Persist to new file, id %q", id), func(t *testing.T) {
+			// Create test values
+			testValues := &GeneratedValues{
+				GrafanaAdminPassword: "test-password",
+			}
 
-		// Persist the values
-		err := persistGeneratedValues("", cfg, testValues)
-		require.NoError(t, err)
+			// Persist the values
+			err := persistGeneratedValues(id, cfg, testValues)
+			require.NoError(t, err)
 
-		// Verify the file exists
-		filePath := filepath.Join(tempDir, genValuesFileName)
-		_, err = os.Stat(filePath)
-		require.NoError(t, err)
+			// Verify the file exists
+			filePath := getValuesPath(id, cfg)
+			_, err = os.Stat(filePath)
+			require.NoError(t, err)
 
-		// Read the file directly and verify JSON content
-		fileContent, err := os.ReadFile(filePath)
-		require.NoError(t, err)
+			// Read the file directly and verify JSON content
+			fileContent, err := os.ReadFile(filePath)
+			require.NoError(t, err)
 
-		var parsedValues GeneratedValues
-		err = json.Unmarshal(fileContent, &parsedValues)
-		require.NoError(t, err)
-		assert.Equal(t, testValues.GrafanaAdminPassword, parsedValues.GrafanaAdminPassword)
-	})
+			var parsedValues GeneratedValues
+			err = json.Unmarshal(fileContent, &parsedValues)
+			require.NoError(t, err)
+			assert.Equal(t, testValues.GrafanaAdminPassword, parsedValues.GrafanaAdminPassword)
+		})
 
-	// Test updating existing values
-	t.Run("Update existing values", func(t *testing.T) {
-		// Create initial values
-		initialValues := &GeneratedValues{
-			GrafanaAdminPassword: "initial-password",
-		}
+		// Test updating existing values
+		t.Run(fmt.Sprintf("Update existing values, id %q", id), func(t *testing.T) {
+			// Create initial values
+			initialValues := &GeneratedValues{
+				GrafanaAdminPassword: "initial-password",
+			}
 
-		// Persist the initial values
-		err := persistGeneratedValues("", cfg, initialValues)
-		require.NoError(t, err)
+			// Persist the initial values
+			err := persistGeneratedValues(id, cfg, initialValues)
+			require.NoError(t, err)
 
-		// Update with new values
-		updatedValues := &GeneratedValues{
-			GrafanaAdminPassword: "updated-password",
-		}
+			// Update with new values
+			updatedValues := &GeneratedValues{
+				GrafanaAdminPassword: "updated-password",
+			}
 
-		// Persist the updated values
-		err = persistGeneratedValues("", cfg, updatedValues)
-		require.NoError(t, err)
+			// Persist the updated values
+			err = persistGeneratedValues(id, cfg, updatedValues)
+			require.NoError(t, err)
 
-		// Read the values back
-		readValues, err := readGenValues("", cfg)
-		require.NoError(t, err)
-		assert.Equal(t, updatedValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
-	})
+			// Read the values back
+			readValues, err := readGenValues(id, cfg)
+			require.NoError(t, err)
+			assert.Equal(t, updatedValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
+		})
+	}
 }
 
 func TestIntegration(t *testing.T) {
 	cfg := setupTestDir(t)
 
-	// Test the full workflow: persist, read, update
-	t.Run("Full workflow", func(t *testing.T) {
-		// Create and persist initial values
-		initialValues := &GeneratedValues{
-			GrafanaAdminPassword: "initial-password",
-		}
-		err := persistGeneratedValues("", cfg, initialValues)
-		require.NoError(t, err)
+	for _, id := range []string{"", "someid"} {
+		// Test the full workflow: persist, read, update
+		t.Run(fmt.Sprintf("Full workflow, id %q", id), func(t *testing.T) {
+			// Create and persist initial values
+			initialValues := &GeneratedValues{
+				GrafanaAdminPassword: "initial-password",
+			}
+			err := persistGeneratedValues(id, cfg, initialValues)
+			require.NoError(t, err)
 
-		// Read the values back
-		readValues, err := readGenValues("", cfg)
-		require.NoError(t, err)
-		assert.Equal(t, initialValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
+			// Read the values back
+			readValues, err := readGenValues(id, cfg)
+			require.NoError(t, err)
+			assert.Equal(t, initialValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
 
-		// Update the values
-		updatedValues := &GeneratedValues{
-			GrafanaAdminPassword: "updated-password",
-		}
-		err = persistGeneratedValues("", cfg, updatedValues)
-		require.NoError(t, err)
+			// Update the values
+			updatedValues := &GeneratedValues{
+				GrafanaAdminPassword: "updated-password",
+			}
+			err = persistGeneratedValues(id, cfg, updatedValues)
+			require.NoError(t, err)
 
-		// Read the updated values
-		readUpdatedValues, err := readGenValues("", cfg)
-		require.NoError(t, err)
-		assert.Equal(t, updatedValues.GrafanaAdminPassword, readUpdatedValues.GrafanaAdminPassword)
-	})
+			// Read the updated values
+			readUpdatedValues, err := readGenValues(id, cfg)
+			require.NoError(t, err)
+			assert.Equal(t, updatedValues.GrafanaAdminPassword, readUpdatedValues.GrafanaAdminPassword)
+		})
+	}
 }

--- a/deployment/terraform/generated_values_test.go
+++ b/deployment/terraform/generated_values_test.go
@@ -33,7 +33,7 @@ func TestOpenValuesFile(t *testing.T) {
 
 	// Test successful file opening
 	t.Run("Open values file successfully", func(t *testing.T) {
-		file, err := openValuesFile(cfg)
+		file, err := openValuesFile("", cfg)
 		require.NoError(t, err)
 		defer file.Close()
 		assert.NotNil(t, file)
@@ -44,7 +44,7 @@ func TestOpenValuesFile(t *testing.T) {
 		invalidCfg := deployment.Config{
 			TerraformStateDir: "/path/that/does/not/exist",
 		}
-		_, err := openValuesFile(invalidCfg)
+		_, err := openValuesFile("", invalidCfg)
 		assert.Error(t, err)
 	})
 }
@@ -55,7 +55,7 @@ func TestReadGenValues(t *testing.T) {
 
 	// Test reading from an empty/non-existent file
 	t.Run("Read empty file", func(t *testing.T) {
-		values, err := readGenValues(cfg)
+		values, err := readGenValues("", cfg)
 		require.NoError(t, err)
 		assert.NotNil(t, values)
 		assert.Empty(t, values.GrafanaAdminPassword)
@@ -69,7 +69,7 @@ func TestReadGenValues(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to read the values
-		_, err = readGenValues(cfg)
+		_, err = readGenValues("", cfg)
 		assert.Error(t, err)
 	})
 
@@ -85,7 +85,7 @@ func TestReadGenValues(t *testing.T) {
 		require.NoError(t, os.WriteFile(filePath, jsonData, 0644))
 
 		// Read the values
-		readValues, err := readGenValues(cfg)
+		readValues, err := readGenValues("", cfg)
 		require.NoError(t, err)
 		assert.Equal(t, testValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
 	})
@@ -103,7 +103,7 @@ func TestPersistGeneratedValues(t *testing.T) {
 		}
 
 		// Persist the values
-		err := persistGeneratedValues(cfg, testValues)
+		err := persistGeneratedValues("", cfg, testValues)
 		require.NoError(t, err)
 
 		// Verify the file exists
@@ -129,7 +129,7 @@ func TestPersistGeneratedValues(t *testing.T) {
 		}
 
 		// Persist the initial values
-		err := persistGeneratedValues(cfg, initialValues)
+		err := persistGeneratedValues("", cfg, initialValues)
 		require.NoError(t, err)
 
 		// Update with new values
@@ -138,11 +138,11 @@ func TestPersistGeneratedValues(t *testing.T) {
 		}
 
 		// Persist the updated values
-		err = persistGeneratedValues(cfg, updatedValues)
+		err = persistGeneratedValues("", cfg, updatedValues)
 		require.NoError(t, err)
 
 		// Read the values back
-		readValues, err := readGenValues(cfg)
+		readValues, err := readGenValues("", cfg)
 		require.NoError(t, err)
 		assert.Equal(t, updatedValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
 	})
@@ -157,11 +157,11 @@ func TestIntegration(t *testing.T) {
 		initialValues := &GeneratedValues{
 			GrafanaAdminPassword: "initial-password",
 		}
-		err := persistGeneratedValues(cfg, initialValues)
+		err := persistGeneratedValues("", cfg, initialValues)
 		require.NoError(t, err)
 
 		// Read the values back
-		readValues, err := readGenValues(cfg)
+		readValues, err := readGenValues("", cfg)
 		require.NoError(t, err)
 		assert.Equal(t, initialValues.GrafanaAdminPassword, readValues.GrafanaAdminPassword)
 
@@ -169,11 +169,11 @@ func TestIntegration(t *testing.T) {
 		updatedValues := &GeneratedValues{
 			GrafanaAdminPassword: "updated-password",
 		}
-		err = persistGeneratedValues(cfg, updatedValues)
+		err = persistGeneratedValues("", cfg, updatedValues)
 		require.NoError(t, err)
 
 		// Read the updated values
-		readUpdatedValues, err := readGenValues(cfg)
+		readUpdatedValues, err := readGenValues("", cfg)
 		require.NoError(t, err)
 		assert.Equal(t, updatedValues.GrafanaAdminPassword, readUpdatedValues.GrafanaAdminPassword)
 	})


### PR DESCRIPTION
#### Summary
In #911, we added logic to persist the dynamically generated Grafana password. We do this by storing it locally in the `TerraformStateDir/generated_values.json` file. This works great for single deployments, but when using the `comparison` command, `TerraformStateDir` is shared among all deployments in the comparison. As the filename is hardcoded, only dependant on `TerraformStateDir`, the deployments in a comparison will inevitably override each other's data, so that the `generated_values.json` file ends up containing only the data of the last deployment that edited it. This, in turn, triggers an error when generating the results of the comparison, since dashboards cannot be uploaded without the admin password.

In order to fix this, we prefix the filename with the deployment ID, which is empty in single deployments and something like `deployment%d` in comparison deployments. This will create one file per deployment, making them fully independent.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64392