### PR TITLE
MM-64443: Revert change from #908

### DIFF
--- a/loadtest/control/actions.go
+++ b/loadtest/control/actions.go
@@ -822,11 +822,11 @@ func Reload(u user.User) UserActionResponse {
 				return UserActionResponse{Err: NewUserError(err)}
 			}
 		}
-	}
 
-	_, err = u.GetChannelsForUser(userId)
-	if err != nil {
-		return UserActionResponse{Err: NewUserError(err)}
+		_, err = u.GetChannelsForUser(userId)
+		if err != nil {
+			return UserActionResponse{Err: NewUserError(err)}
+		}
 	}
 
 	err = u.GetAllChannelMembersForUser(userId)


### PR DESCRIPTION
#### Summary
This reverts [the change done in PR #908](https://github.com/mattermost/mattermost-load-test-ng/pull/908/files#diff-479d42d6d0bd9a8b205d37f19edf53481b8dea27e367fe8670a2f1f1d8877951L833-R830) that made the GetChannelsForUser call to be executed unconditionally. This prevented new users with no team membership to finish the Reload function. We need a better solution here, but we're going back to the old behaviour to unblock the performance comparison for v10.9-rc1.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64443

