### PR TITLE
MM-64214: Fix server version string parsing

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -360,6 +360,15 @@ func NewControllerWrapper(config *loadtest.Config, controllerConfig interface{},
 			mlog.Error("Failed to get server version", mlog.Err(err))
 		}
 	}
+
+	// The server version string looks something like
+	// 10.8.0.-14635315842.c5915cb6b6a40c3468ba242e5742cf35.true
+	// but we are only interested in the first part, 10.8.0, which is semver-compatible
+	serverVersionParts := strings.Split(serverVersionStr, ".")
+	if len(serverVersionParts) < 3 {
+		return nil, fmt.Errorf("unable to extract the semver-compatible version from the string %q; expecting something like 10.5.3.someotherstuff", serverVersionStr)
+	}
+	serverVersionStr = strings.Join(serverVersionParts[:3], ".")
 	serverVersion, err := semver.Parse(serverVersionStr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse server version %q: %w", serverVersionStr, err)


### PR DESCRIPTION
#### Summary
The string [returned by the server in the `X-Version-ID` header](https://github.com/mattermost/mattermost/blob/1bca62dc838811dd1d20b9f25f9d57f8d1c74376/server/channels/web/handlers.go#L222) is a semver-compatible version followed by other strings separated by more dots. We need to extract the version itself for the parsing to succeed.

This bug was introduced in #908.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64214

