### PR TITLE
fix: prometheus exporter setup behind rhel for agents

### DIFF
--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -191,10 +191,6 @@ func (t *Terraform) configureAndRunAgents(extAgent *ssh.ExtAgent) error {
 				return
 			}
 
-			if err := t.setupPrometheusNodeExporter(sshc); err != nil {
-				mlog.Error("error setting up prometheus node exporter", mlog.Err(err), mlog.Int("agent", agentNumber))
-			}
-
 			cmd = "sudo systemctl restart otelcol-contrib && sudo systemctl restart prometheus-node-exporter"
 			if out, err := sshc.RunCommand(cmd); err != nil {
 				mlog.Error("error running ssh command", mlog.Int("agent", agentNumber), mlog.String("cmd", cmd), mlog.String("out", string(out)), mlog.Err(err))

--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"text/template"
 
-	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest"
 
@@ -192,10 +191,8 @@ func (t *Terraform) configureAndRunAgents(extAgent *ssh.ExtAgent) error {
 				return
 			}
 
-			if t.config.OperatingSystemKind == deployment.OperatingSystemKindRHEL {
-				if err := t.setupPrometheusNodeExporter(sshc); err != nil {
-					mlog.Error("error setting up prometheus node exporter", mlog.Err(err), mlog.Int("agent", agentNumber))
-				}
+			if err := t.setupPrometheusNodeExporter(sshc); err != nil {
+				mlog.Error("error setting up prometheus node exporter", mlog.Err(err), mlog.Int("agent", agentNumber))
 			}
 
 			cmd = "sudo systemctl restart otelcol-contrib && sudo systemctl restart prometheus-node-exporter"


### PR DESCRIPTION
#### Summary

Probably caused by #919 

The prometheus setup was locked behind a RHEL check, which I think shouldn't be the case.

