### PR TITLE
MM-64729: Remove new logic for GetChannelMembersWithTeamData

### DIFF
--- a/loadtest/user/userentity/actions.go
+++ b/loadtest/user/userentity/actions.go
@@ -16,7 +16,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/blang/semver"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/store"
 	"github.com/mattermost/mattermost-load-test-ng/loadtest/user"
@@ -701,27 +700,6 @@ func (ue *UserEntity) GetChannelMembers(channelId string, page, perPage int) err
 // GetAllChannelMembersForUser gets all channel memberships for the
 // specified user regardless of the team the channels are part of
 func (ue *UserEntity) GetAllChannelMembersForUser(userId string) error {
-	serverVersion := ue.Store().ServerVersion()
-	// Versions 10.9.0 and later support streaming all the members by setting
-	// page to -1, so there is no need to paginate
-	if serverVersion.GTE(semver.MustParse("10.9.0")) {
-		membersWithTeamData, _, err := ue.client.GetChannelMembersWithTeamData(context.Background(), userId, -1, 0)
-		if err != nil {
-			return err
-		}
-
-		// Retrieve the embedded ChannelMember struct, we don't store the team data
-		plainMembers := make(model.ChannelMembers, len(membersWithTeamData))
-		for i, memberWithTeamData := range membersWithTeamData {
-			plainMembers[i] = memberWithTeamData.ChannelMember
-		}
-
-		// Set the slice of members we got
-		return ue.store.SetChannelMembers(plainMembers)
-	}
-
-	// Fallback logic for older servers.
-	// Remove this differentiation when 10.8.0 goes out of support.
 	page := 0
 	perPage := 200
 	for {


### PR DESCRIPTION
#### Summary
The new streaming logic for `model.Client4.GetChannelMembersWithTeamData` makes `UserEntity.GetAllChannelMembersForUser` to fail with the error 

```
control.Reload github.com/mattermost/mattermost-load-test-ng/loadtest/control/actions.go:834 No channel member found for that user ID and channel ID.
```

The cause is still unknown, but I've decided to remove it for three main reasons:
1. We need a quick fix in place to unblock the performance comparison of v10.10
2. We were not really *streaming* anything per se, but receiving everything in one go. This code path was added to match the new client, but the difference in performance should be negligible.
3. The new logic had been already released in v10.9, the latest stable release, so it should not a bug in the server, but in our tooling.

Once this is merged I'll backport it to `release-1.27` so we can release v1.27.3.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64729