### PR TITLE
MM-63312: Use a single Terraform instance per deployment in comparisons

### DIFF
--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
-func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpConfig *deploymentConfig) error) error {
+func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpID string, dpConfig *deploymentConfig) error) error {
 	var wg sync.WaitGroup
 	wg.Add(len(c.deployments))
 	errsCh := make(chan error, len(c.deployments))
@@ -28,7 +28,7 @@ func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpConf
 				errsCh <- fmt.Errorf("failed to create terraform engine: %w", err)
 				return
 			}
-			if err := action(t, dp); err != nil {
+			if err := action(t, id, dp); err != nil {
 				errsCh <- fmt.Errorf("deployment action failed: %w", err)
 			}
 		}(id, dp)

--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -25,11 +25,11 @@ func (c *Comparison) deploymentAction(action func(t *terraform.Terraform, dpID s
 			defer wg.Done()
 			t, err := terraform.New(id, dp.config)
 			if err != nil {
-				errsCh <- fmt.Errorf("failed to create terraform engine: %w", err)
+				errsCh <- fmt.Errorf("failed to create terraform engine in deployment with ID %q: %w", id, err)
 				return
 			}
 			if err := action(t, id, dp); err != nil {
-				errsCh <- fmt.Errorf("deployment action failed: %w", err)
+				errsCh <- fmt.Errorf("action in deployment with ID %q failed: %w", id, err)
 			}
 		}(id, dp)
 	}


### PR DESCRIPTION
#### Summary
The solution I came up with to the credentials issue that causes https://mattermost.atlassian.net/browse/MM-63312 is to have a goroutine refreshing the credentials in the background. Although that is a CI-specifc problem, I needed to tweak a couple of things in the base logic of the comparisons. That is what this PR is about.

The obstacle for that solution was that we were kind of misusing the `deploymentAction` function. That function creates a Terraform instance per deployment and calls the function provided by the caller in each deployment concurrently. However, we were repeating that logic for running the same action in each deployment three times. Simplifying, the code looked like this:
```go
// 1. Create the deployments
c.deploymentAction(func(t *terraform.Terraform, dpConfig *deploymentConfig) error {
	t.Create()
}

// 2. Run the tests
for dpID, dp := range c.deployments {
	go func(dpID string, dp *deploymentConfig) {
		t, err := terraform.New(dpID, dp.config)
		for ltID, lt := range dp.loadTests {
			for i, buildCfg := range []BuildConfig{c.config.BaseBuild, c.config.NewBuild} {
				res.LoadTests[i] = runLoadTest(t, lt)
			}
			resultsCh <- res
		}
	}
}

// 3. Compare the results and generate the report
getResults(resultsCh)
```

The problem here is that 1., 2. and 3. were all running that loop that looks like
```go
for range c.deployments {
	go func() {
		t, err := terraform.New()
		// Do something
	}
}
```

Re-creating the `Terraform` instance is a problem for the solution for https://mattermost.atlassian.net/browse/MM-63312 because the state needed by the goroutine refreshing the credentials needs to be stored there. As the credentials in the environment are expired, we need to maintain the same Terraform instance throughout the whole comparison. Otherwise, we try to authenticate with expired credentials.

What this PR does is converting the previous code into something like this:
```go
c.deploymentAction(func(t *terraform.Terraform, dpConfig *deploymentConfig) error {
	// 1. Create the deployments
	t.Create()

	// 2. Run the tests
	for ltID, lt := range dp.loadTests {
		for i, buildCfg := range []BuildConfig{c.config.BaseBuild, c.config.NewBuild} {
			res.LoadTests[i] = runLoadTest(t, lt)
		}

		// 3. Compare the results of this deployment only and generate the report
		resultsCh <- getResults(t, res)
	}
}
```

For this, I had to refactor both the `Comparison.Run` and the `Comparison.getResults` function, removing the unneeded `terraform.New` and putting everything inside a single `deploymentAction` function, with `getResults` now comparing the two builds of a single deployment. Hopefully (and my tests show this), without changing the semantic of the whole comparison.

I'll open a new PR with the actual fix of the bug in a bit.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63312
