### PR TITLE
MM-64881: Initialize map in MemStore.Clear

### DIFF
--- a/loadtest/store/memstore/store.go
+++ b/loadtest/store/memstore/store.go
@@ -138,6 +138,8 @@ func (s *MemStore) Clear() {
 	s.channelBookmarks = map[string]*model.ChannelBookmarkWithFileInfo{}
 	clear(s.scheduledPosts)
 	s.scheduledPosts = map[string]map[string][]*model.ScheduledPost{}
+	clear(s.customAttributeValues)
+	s.customAttributeValues = map[string]map[string]json.RawMessage{}
 }
 
 func (s *MemStore) setupQueues(config *Config) error {

--- a/loadtest/store/memstore/store_test.go
+++ b/loadtest/store/memstore/store_test.go
@@ -4,6 +4,7 @@
 package memstore
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -817,4 +818,66 @@ func TestPostsWithAckRequests(t *testing.T) {
 	posts, err := s.PostsWithAckRequests()
 	require.NoError(t, err)
 	assert.ElementsMatch(t, ackPosts, posts)
+}
+
+func TestCPAValues(t *testing.T) {
+	t.Run("SetCPAFields", func(t *testing.T) {
+		s := newStore(t)
+
+		err := s.SetCPAFields(nil)
+		require.NoError(t, err)
+
+		err = s.SetCPAFields([]*model.PropertyField{})
+		require.NoError(t, err)
+
+		err = s.SetCPAFields([]*model.PropertyField{
+			{ID: "an id"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("GetCPAFields", func(t *testing.T) {
+		s := newStore(t)
+
+		expected := []*model.PropertyField{
+			{ID: "an id"},
+		}
+
+		err := s.SetCPAFields(expected)
+		require.NoError(t, err)
+
+		actual := s.GetCPAFields()
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("SetCPAValues", func(t *testing.T) {
+		s := newStore(t)
+		userID := model.NewId()
+
+		err := s.SetCPAValues(userID, nil)
+		require.NoError(t, err)
+
+		err = s.SetCPAValues(userID, map[string]json.RawMessage{})
+		require.NoError(t, err)
+
+		err = s.SetCPAValues(userID, map[string]json.RawMessage{
+			"field": json.RawMessage(`"Field Value"`),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("GetCPAValues", func(t *testing.T) {
+		s := newStore(t)
+		userID := model.NewId()
+
+		expected := map[string]json.RawMessage{
+			"field": json.RawMessage(`"Field Value"`),
+		}
+
+		err := s.SetCPAValues(userID, expected)
+		require.NoError(t, err)
+
+		actual := s.GetCPAValues(userID)
+		require.Equal(t, expected, actual)
+	})
 }


### PR DESCRIPTION
#### Summary
Fix a `panic: assignment to entry in nil map` by properly initializing the map.

```
goroutine 76389 [running]:
github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore.(*MemStore).SetCPAValues(0xc008fe76c0, {0xc00312ec60, 0x1a}, 0xc00321a180)
        github.com/mattermost/mattermost-load-test-ng/loadtest/store/memstore/store.go:1471 +0x85
github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity.(*UserEntity).GetCPAValues(0xc005a98820, {0xc00312ec60, 0x1a})
        github.com/mattermost/mattermost-load-test-ng/loadtest/user/userentity/custom_profile_attributes.go:35 +0x6f
github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller.(*SimulController).openUserProfile(0x7fa4f3f1d180?, {0x17bc220, 0xc005a98820})
        github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller/actions.go:2052 +0x568
github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller.(*SimulController).runAction(0xc005a989c0, 0x32?)
        github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller/controller.go:495 +0x45
github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller.(*SimulController).Run(0xc005a989c0)
        github.com/mattermost/mattermost-load-test-ng/loadtest/control/simulcontroller/controller.go:478 +0xf4b
github.com/mattermost/mattermost-load-test-ng/loadtest.(*LoadTester).addUser.func1()
        github.com/mattermost/mattermost-load-test-ng/loadtest/loadtest.go:131 +0x1c
created by github.com/mattermost/mattermost-load-test-ng/loadtest.(*LoadTester).addUser in goroutine 873
        github.com/mattermost/mattermost-load-test-ng/loadtest/loadtest.go:130 +0x36e
panic: assignment to entry in nil map
```

While I was here, I added basic tests to the CPA-related `MemStore` functions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64881
