### PR TITLE
[MM 65580] Add simulation test timeouts as configurable property in config.json

### DIFF
--- a/browser/src/lib/browser_manager.ts
+++ b/browser/src/lib/browser_manager.ts
@@ -7,7 +7,7 @@ import {join} from 'path';
 import {log} from '../app.js';
 import {testManager} from '../lib/test_manager.js';
 import {SimulationIds} from '../simulations/registry.js';
-import {findScreenshotsDir} from '../utils/config.js';
+import {findScreenshotsDir, getSimulationTimeoutMs} from '../utils/config.js';
 
 const CLEANUP_TIMEOUT_MS = 4_000;
 
@@ -164,6 +164,7 @@ export class BrowserTestSessionManager {
     // Try to create the page after the context is created
     try {
       const page = await instance.context!.newPage();
+      page.setDefaultTimeout(getSimulationTimeoutMs());
 
       instance = {...instance, page};
       this.activeBrowserSessions.set(userId, instance);

--- a/browser/src/simulations/go_to_channel.ts
+++ b/browser/src/simulations/go_to_channel.ts
@@ -13,6 +13,9 @@ export async function goToChannel(page: Page, channelId: string): Promise<void> 
     await channel.waitFor({state: 'visible'});
     await channel.click();
 
+    // # Wait until the loading screen is gone and the channel is loaded
+    await page.locator('#virtualizedPostListContent').waitFor({state: 'visible'});
+
     log.info('pass--goToChannel');
   } catch (error) {
     throw {error, testId: 'goToChannel'};

--- a/browser/src/simulations/post_in_channel.ts
+++ b/browser/src/simulations/post_in_channel.ts
@@ -19,6 +19,9 @@ export async function postInChannel({page}: {page: Page}): Promise<void> {
     await postButton.waitFor({state: 'visible'});
     await postButton.click();
 
+    // # Wait until textbox is cleared
+    await textbox.evaluate((el) => (el as HTMLTextAreaElement).value === '');
+
     log.info('pass--postInChannel');
   } catch (error) {
     throw {error, testId: 'postInChannel'};

--- a/browser/src/utils/config.ts
+++ b/browser/src/utils/config.ts
@@ -15,6 +15,7 @@ const SliceOfConfigJsonSchema = zod.object({
   }),
   BrowserConfiguration: zod.object({
     Headless: zod.boolean(),
+    SimulationTimeoutMs: zod.number().gte(0, 'SimulationTimeoutMs must be greater than 0, If you want to disable the timeout, set it to 0'),
   }),
   BrowserLogSettings: zod.object({
     EnableConsole: zod.boolean(),
@@ -37,6 +38,12 @@ export function getMattermostServerURL(): string {
 
 export function isBrowserHeadless(): boolean {
   return configJson.BrowserConfiguration.Headless;
+}
+
+const DEFAULT_SIMULATION_TIMEOUT_MS = 60_000;
+
+export function getSimulationTimeoutMs(): number {
+  return configJson.BrowserConfiguration.SimulationTimeoutMs || DEFAULT_SIMULATION_TIMEOUT_MS;
 }
 
 export function isConsoleLoggingEnabled(): boolean {

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -54,7 +54,8 @@
     "PercentOfUsersAreAdmin": 0.0005
   },
   "BrowserConfiguration": {
-    "Headless": true
+    "Headless": true,
+    "SimulationTimeoutMs": 60000
   },
   "LogSettings": {
     "EnableConsole": true,

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -69,3 +69,4 @@ UsersFilePath = ''
 
 [BrowserConfiguration]
 Headless = true
+SimulationTimeoutMs = 60000

--- a/docs/config/coordinator.md
+++ b/docs/config/coordinator.md
@@ -46,7 +46,7 @@ The URL to the load-test API server that will run the agent. Since this is an ag
 
 *int*
 
-The maximum number of concurrently active browser users to be run across the entire load-agent cluster. Note that there is also a MaxActiveBrowserUsers setting in config/config.json which limits the number of browser users per individual agent, while this setting limits the total number of browser users across all agents in the cluster. The MaxActiveBrowserUsers value in the cluster configuration should be less than the product of MaxActiveBrowserUsers per browser agent multiplied by the number of browser agents. This value cannot be larger than `MaxActiveUsers`, since `MaxActiveUsers` is the cap of total users connected across the load-agent cluster.
+The maximum number of concurrently active browser users to be run across the entire load-agent cluster. Note that there is also a MaxActiveBrowserUsers setting in config/config.json which limits the number of browser users per individual agent, while this setting limits the total number of browser users across all agents in the cluster. The MaxActiveBrowserUsers value in the cluster configuration should be less than the product of MaxActiveBrowserUsers per browser agent multiplied by the number of browser agents.
 
 ## MonitorConfig
 


### PR DESCRIPTION
#### Summary
* Added a new `SimulationTimeoutMs` parameter to the browser configuration schema, with validation to ensure it is a non-negative number. 
* Set the default timeout for all Playwright page actions in `BrowserTestSessionManager` to the configured `SimulationTimeoutMs` value.
* In `goToChannel`, added a wait for the `#virtualizedPostListContent` element to ensure the channel is fully loaded before proceeding.
* In `postInChannel`, added a check to wait until the message textbox is cleared after posting, ensuring the post action is complete.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-65580




