### PR TITLE
MM-65142: Add AWSAMIUser to output struct

### DIFF
--- a/deployment/terraform/output.go
+++ b/deployment/terraform/output.go
@@ -210,12 +210,17 @@ func (t *Terraform) loadOutput() error {
 		return err
 	}
 
-	var clusterName string
+	var (
+		clusterName string
+		amiUser     string
+	)
 	if t.config != nil {
 		clusterName = t.config.ClusterName
+		amiUser = t.config.AWSAMIUser
 	}
 	outputv2 := &Output{
 		ClusterName:   clusterName,
+		AMIUser:       amiUser,
 		Instances:     o.Instances.Value,
 		Agents:        o.Agents.Value,
 		BrowserAgents: o.BrowserAgents.Value,


### PR DESCRIPTION
#### Summary
The `comparison collect` command does not work because Output.AWSAMIUser is empty. We need to populate it when loading the output.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65142