### PR TITLE
MM-65048: Fix toset call

### DIFF
--- a/deployment/terraform/assets/cluster.tf
+++ b/deployment/terraform/assets/cluster.tf
@@ -125,7 +125,7 @@ resource "aws_efs_file_system" "efs_shared" {
 }
 
 resource "aws_efs_mount_target" "efs_mount" {
-  for_each = (var.create_efs ? toset(data.aws_subnets.lt_selected.ids) : toset({}))
+  for_each = (var.create_efs ? toset(data.aws_subnets.lt_selected.ids) : toset([]))
   file_system_id = aws_efs_file_system.efs_shared.0.id
   subnet_id      = each.value
   security_groups = [aws_security_group.efs[0].id]


### PR DESCRIPTION
#### Summary
`toset` needs an array, not a map :shrug: There's also no way to write a set literal (at least that I know of).

This needs to be cherry-picked to `release-1.29` because v1.29-rc1 is currently broken because of this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65048