### PR TITLE
MM-65977: Add new MattermostPlugins setting

### DIFF
--- a/comparison/deployment.go
+++ b/comparison/deployment.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/mattermost/mattermost-load-test-ng/deployment"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform"
 	"github.com/mattermost/mattermost-load-test-ng/deployment/terraform/ssh"
 
@@ -73,13 +72,13 @@ func provisionFiles(t *terraform.Terraform, dpConfig *deploymentConfig, baseBuil
 	for _, client := range clients {
 		for id, ltConfig := range dpConfig.loadTests {
 			if ltConfig.DBDumpURL != "" {
-				if err := deployment.ProvisionURL(client, ltConfig.DBDumpURL, ltConfig.getDumpFilename(id)); err != nil {
+				if _, err := t.ProvisionURL(client, ltConfig.DBDumpURL, ltConfig.getDumpFilename(id)); err != nil {
 					return err
 				}
 			}
 		}
 		for _, cfg := range []BuildConfig{baseBuildCfg, newBuildCfg} {
-			if err := deployment.ProvisionURL(client, cfg.URL, getBuildFilename(cfg)); err != nil {
+			if _, err := t.ProvisionURL(client, cfg.URL, getBuildFilename(cfg)); err != nil {
 				return err
 			}
 		}

--- a/config/deployer.sample.json
+++ b/config/deployer.sample.json
@@ -182,5 +182,8 @@
     "BlockProfileRate": 0
   },
   "CustomTags": {
+  },
+  "Plugins": {
+    "playbooks": "https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.4.1-linux-amd64.tar.gz"
   }
 }

--- a/config/deployer.sample.toml
+++ b/config/deployer.sample.toml
@@ -185,3 +185,6 @@ Password = 'mostest80098bigpass_'
 UserName = 'mmuser'
 
 [CustomTags]
+
+[[MattermostPlugins]]
+playbooks = "https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.4.1-linux-amd64.tar.gz"

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -96,6 +96,9 @@ type Config struct {
 	MattermostConfigPatchFile string `default:""`
 	// Mattermost instance sysadmin e-mail.
 	AdminEmail string `default:"sysadmin@sample.mattermost.com" validate:"email"`
+	// MattermostPlugins maps each specified plugin ID to an URL (or local file if
+	// prepended with file://) from which to download and install it
+	MattermostPlugins map[string]string
 	// Mattermost instance sysadmin user name.
 	AdminUsername string `default:"sysadmin" validate:"notempty"`
 	// Mattermost instance sysadmin password.

--- a/deployment/terraform/dump.go
+++ b/deployment/terraform/dump.go
@@ -109,7 +109,7 @@ func (t *Terraform) IngestDump() error {
 	dumpURI := t.config.DBDumpURI
 	fileName := filepath.Base(dumpURI)
 	mlog.Info("Provisioning dump file", mlog.String("uri", dumpURI))
-	if err := deployment.ProvisionURL(appClients[0], dumpURI, fileName); err != nil {
+	if _, err := t.ProvisionURL(appClients[0], dumpURI, fileName); err != nil {
 		return err
 	}
 
@@ -169,7 +169,7 @@ func (t *Terraform) ExecuteCustomSQL() error {
 	for _, sqlURI := range t.config.DBExtraSQL {
 		fileName := filepath.Base(sqlURI)
 		mlog.Info("Provisioning SQL file", mlog.String("uri", sqlURI))
-		if err := deployment.ProvisionURL(client, sqlURI, fileName); err != nil {
+		if _, err := t.ProvisionURL(client, sqlURI, fileName); err != nil {
 			return err
 		}
 

--- a/deployment/terraform/ssh/ssh.go
+++ b/deployment/terraform/ssh/ssh.go
@@ -142,7 +142,7 @@ func (sshc *Client) Upload(src io.Reader, dst string, sudo bool) ([]byte, error)
 	// Direct upload without sudo
 	dstFile, err := sftpClient.Create(dst)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create destination file: %w", err)
+		return nil, fmt.Errorf("failed to create destination file %q: %w", dst, err)
 	}
 	defer dstFile.Close()
 

--- a/deployment/utils.go
+++ b/deployment/utils.go
@@ -6,7 +6,6 @@ package deployment
 import (
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -26,35 +25,6 @@ type DBSettings struct {
 	DBName   string
 	Host     string
 	Engine   string
-}
-
-// ProvisionURL takes a URL pointing to a file to be provisioned.
-// It works on both local files prefixed with file:// or remote files.
-// In case of local files, they are uploaded to the server.
-func ProvisionURL(client *ssh.Client, url, filename string) error {
-	filePrefix := "file://"
-	if strings.HasPrefix(url, filePrefix) {
-		// upload file from local filesystem
-		path := strings.TrimPrefix(url, filePrefix)
-		info, err := os.Stat(path)
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("build file %s has to be a regular file", path)
-		}
-		if out, err := client.UploadFile(path, fmt.Sprintf("$HOME/%s", filename), false); err != nil {
-			return fmt.Errorf("error uploading build: %w %s", err, out)
-		}
-	} else {
-		// download build file from URL
-		cmd := fmt.Sprintf("wget -O %s %s", filename, url)
-		if out, err := client.RunCommand(cmd); err != nil {
-			return fmt.Errorf("failed to run cmd %q: %w %s", cmd, err, out)
-		}
-	}
-
-	return nil
 }
 
 func dbConnString(dbInfo DBSettings) (string, error) {

--- a/docs/config/deployer.md
+++ b/docs/config/deployer.md
@@ -493,6 +493,14 @@ The location of the Mattermost Enterprise Edition license file.
 
 An optional path to a partial Mattermost config file to be applied as patch during app server deployment.
 
+## MattermostPlugins
+
+*map[string]string*
+
+A map of plugin identifiers to a string indicating where to download the plugin tarball (expecting a `.tar.gz`) from. This string can be:
+- A URL: the plugin tarball will be downloaded into the app nodes from this URL.
+- A `file://` prefixed path: the plugin tarball will be uploaded from your local filesystem to the app nodes.
+
 ## AdminEmail
 
 *string*


### PR DESCRIPTION
#### Summary
This PR introduces a new `MattermostPlugins` setting, which lets users specify the exact set of plugins to install in the deployment, with the possibility to specify either officially released plugins through their release URL (or any URL, for that matter), or locally built ones through a local filesystem path.

Note that this was kept as simple as possible: just a map of plugin IDs to their tarballs. On our meeting, @M-ZubairAhmed and I discussed about adding all sorts of bells and whistles here: a common way of setting plugin-specific configuration, some validation to only allow specific plugins (since we will need data to our datasets for each that we add), some way of specifying just the plugin and the version, to retrieve the officially released ones... I left all that aside for now, and implemented the most simple solution, we can iterate in the future if needed.

There's a couple of additional commits here:
1. I had to move the `ProvisionURL` function under the `Terraform` struct, since it had a bug with locally built files and to fix it I needed to have access to the home directory. While I was there, I also changed the signature so that it returned the path of the provisioned file.
2. A random improvement to an error log line that would have helped me in a debugging session.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65977