### PR TITLE
Use latest minor version for Postgres v14

### DIFF
--- a/deployment/terraform/assets/variables.tf
+++ b/deployment/terraform/assets/variables.tf
@@ -124,7 +124,7 @@ variable "db_engine_version" {
   type = map(any)
   default = {
     "aurora-mysql"      = "8.0.mysql_aurora.3.05.2"
-    "aurora-postgresql" = "14.9"
+    "aurora-postgresql" = "14.18"
   }
 }
 


### PR DESCRIPTION
#### Summary
Aurora Postgres v14.9 EOL was last month! From [the support schedule](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/aurorapostgresql-release-calendar.html#aurorapostgresql.minor.versions.supported):

<img width="2095" height="1259" alt="image" src="https://github.com/user-attachments/assets/d324318a-9dcd-47c1-868c-d0b83dfcb257" />

I realized this when trying to stop the DB for the weekend in a deployment I have around and I got this warning:

```
info  [2025-10-03 15:22:27.197 Z] An error occurred (InvalidDBClusterStateFault) when calling the StopDBCluster operation: This DB cluster uses an engine version that has reached its end of life. Upgrade your DB cluster to version 14.15 or higher before stopping. caller="deployment/utils.go:119"
```

#### Ticket Link
--

