### PR TITLE
Fix Prometheus node exporter path

### DIFF
--- a/deployment/terraform/agent.go
+++ b/deployment/terraform/agent.go
@@ -218,7 +218,6 @@ func (t *Terraform) configureAndRunAgents(extAgent *ssh.ExtAgent) error {
 				{srcData: strings.TrimPrefix(browserBuf.String(), "\n"), dstPath: "/lib/systemd/system/ltbrowserapi.service", msg: "Uploading load-test browser api service file"},
 				{srcData: strings.TrimPrefix(clientSysctlConfig, "\n"), dstPath: "/etc/sysctl.conf"},
 				{srcData: strings.TrimPrefix(limitsConfig, "\n"), dstPath: "/etc/security/limits.conf"},
-				{srcData: strings.TrimPrefix(prometheusNodeExporterConfig, "\n"), dstPath: "/etc/default/prometheus-node-exporter"},
 				{srcData: strings.TrimSpace(otelcolConfigFile), dstPath: "/etc/otelcol-contrib/config.yaml"},
 				{srcData: agentType, dstPath: t.ExpandWithUser(dstAgentTypeFilePath), msg: "Uploading agent type file"},
 			}

--- a/deployment/terraform/create.go
+++ b/deployment/terraform/create.go
@@ -476,7 +476,6 @@ func (t *Terraform) setupAppServer(extAgent *ssh.ExtAgent, ip, siteURL, serviceF
 		{srcData: strings.TrimPrefix(serverSysctlConfig, "\n"), dstPath: "/etc/sysctl.conf"},
 		{srcData: strings.TrimSpace(serviceFileTemplateOutput.String()), dstPath: "/lib/systemd/system/mattermost.service"},
 		{srcData: strings.TrimPrefix(limitsConfig, "\n"), dstPath: "/etc/security/limits.conf"},
-		{srcData: strings.TrimPrefix(prometheusNodeExporterConfig, "\n"), dstPath: "/etc/default/prometheus-node-exporter"},
 		{srcData: strings.TrimSpace(fmt.Sprintf(netpeekServiceFile, gossipPort)), dstPath: "/lib/systemd/system/netpeek.service"},
 		{srcData: strings.TrimSpace(otelcolConfig), dstPath: "/etc/otelcol-contrib/config.yaml"},
 	}
@@ -972,7 +971,6 @@ func (t *Terraform) setupProxyServer(extAgent *ssh.ExtAgent, instance Instance) 
 			{srcData: strings.TrimLeft(serverSysctlConfig, "\n"), dstPath: "/etc/sysctl.conf"},
 			{srcData: strings.TrimLeft(nginxConfig, "\n"), dstPath: "/etc/nginx/nginx.conf"},
 			{srcData: strings.TrimLeft(limitsConfig, "\n"), dstPath: "/etc/security/limits.conf"},
-			{srcData: strings.TrimPrefix(prometheusNodeExporterConfig, "\n"), dstPath: "/etc/default/prometheus-node-exporter"},
 			{srcData: strings.TrimSpace(otelcolConfigFile), dstPath: "/etc/otelcol-contrib/config.yaml"},
 		}
 		if err := uploadBatch(sshc, batch); err != nil {

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -552,10 +552,6 @@ KC_DB_PASSWORD=mmpass
 KC_DB_USERNAME=keycloak
 KC_DATABASE=keycloak`
 
-const prometheusNodeExporterConfig = `
-ARGS="--collector.ethtool"
-`
-
 const netpeekServiceFile = `
 [Unit]
 Description=netpeek
@@ -577,7 +573,7 @@ Description=Node Exporter
 [Service]
 # Fallback when environment file does not exist
 EnvironmentFile=-/etc/default/prometheus-node-exporter
-ExecStart=/usr/bin/prometheus-node-exporter
+ExecStart=/usr/bin/prometheus-node-exporter --collector.ethtool
 
 [Install]
 WantedBy=multi-user.target`

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -577,7 +577,7 @@ Description=Node Exporter
 [Service]
 # Fallback when environment file does not exist
 EnvironmentFile=-/etc/default/prometheus-node-exporter
-ExecStart=/usr/local/bin/node_exporter
+ExecStart=/usr/bin/prometheus-node-exporter
 
 [Install]
 WantedBy=multi-user.target`

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -572,7 +572,6 @@ Description=Node Exporter
 
 [Service]
 # Fallback when environment file does not exist
-EnvironmentFile=-/etc/default/prometheus-node-exporter
 ExecStart=/usr/bin/prometheus-node-exporter --collector.ethtool
 
 [Install]

--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -571,7 +571,6 @@ const prometheusNodeExporterServiceFile = `[Unit]
 Description=Node Exporter
 
 [Service]
-# Fallback when environment file does not exist
 ExecStart=/usr/bin/prometheus-node-exporter --collector.ethtool
 
 [Install]


### PR DESCRIPTION
#### Summary
The path for the Prometheus node exporter binary has changed without us noticing (probably due to the dependency from `sudo apt-get install -y prometheus-node-exporter ` being updated), so we were missing node metrics like CPU and memory.

#### Ticket Link
--