### PR TITLE
Fix overridden net.core.{r,w}mem_max values

### DIFF
--- a/deployment/terraform/strings.go
+++ b/deployment/terraform/strings.go
@@ -274,15 +274,9 @@ net.ipv4.tcp_notsent_lowat = 16384
 net.ipv4.tcp_rmem = 4096 156250 2500000
 net.ipv4.tcp_wmem = 4096 156250 2500000
 
-# Bumping the theoretical maximum buffer size for receiving TCP sockets not making use of autotuning (i.e. using SO_RCVBUF).
-net.core.rmem_max = 2500000
-# Bumping the theoretical maximum buffer size for sending TCP sockets not making use of autotuning (i.e. using SO_SNDBUF).
-net.core.wmem_max = 2500000
-
-# Bumping the theoretical maximum buffer size of receiving UDP sockets.
+# Bumping the theoretical maximum buffer size of receiving/sending sockets,
+# either UDP, or TCP not using autotuning (i.e. using SO_RCVBUF)
 net.core.rmem_max = 16777216
-
-# Setting the theoretical maximum buffer size of sending UDP sockets.
 net.core.wmem_max = 16777216
 `
 


### PR DESCRIPTION
#### Summary
PR #752 modified the values for the kernel sockets to tune networking, but ended up modifying the values `net.core.{r,w}mem_max` twice, with different comments for UDP and TCP sockets.

UDP sockets are governed by net.core.{r,w}mem_max, as are TCP sockets (as are [all sockets in general](https://man7.org/linux/man-pages/man7/socket.7.html)), but the latter are further fine-tuned via `net.ipv4.tcp_{r,w}mem`, which are correctly set above. What the modified values in this PR do is setting a maximum for all sockets in the kernel, so we choose the larger value that was intended for UDP here: 16 MiB

This PR does not change the value the system ended up using, since sysctl simply overrides the value with the latter setting, which happened to be the correct one. But this was quite confusing when trying to communicate this to our customers trying to fine-tune these settings. Next, a PR to fix [the docs](https://docs.mattermost.com/administration-guide/scale/high-availability-cluster-based-deployment.html#configuration-settings).

#### Ticket Link
--