### PR TITLE
Add Docker container distribution and image publishing pipeline

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,160 @@
+# Builds and publishes the mattermost-load-test-ng container on tag push.
+# Single-arch (linux/amd64); switch to multi-arch later by extending the platforms list.
+#
+# Required repo secrets:
+#   DOCKERHUB_USERNAME - account with push access to docker.io/mattermost
+#   DOCKERHUB_TOKEN    - PAT scoped to the mattermost-load-test-ng repo only
+#
+# Triggers:
+#   - push of a v* tag (e.g. v1.6.0)   -> full publish to Docker Hub + GHCR
+#   - workflow_dispatch                 -> manual run for testing the workflow itself
+#
+# Verify action versions periodically (release pages on github.com/<org>/<action>/releases):
+#   actions/checkout, docker/setup-buildx-action, docker/setup-qemu-action,
+#   docker/login-action, docker/metadata-action, docker/build-push-action,
+#   aquasecurity/trivy-action, sigstore/cosign-installer
+name: release-docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish (manual runs only, e.g. v0.0.0-test).'
+        required: true
+        default: 'v0.0.0-manual'
+      push:
+        description: 'Push to Docker Hub (true) or build-only (false).'
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+  packages: write     # publish to ghcr.io
+  id-token: write     # cosign keyless signing via GitHub OIDC
+
+env:
+  DOCKERHUB_IMAGE: mattermost/mattermost-load-test-ng
+  GHCR_IMAGE: ghcr.io/mattermost/mattermost-load-test-ng
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version + push intent
+        id: ctx
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "push=${{ inputs.push }}"    >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "push=true"                       >> "$GITHUB_OUTPUT"
+          fi
+
+      # QEMU is kept here so flipping to multi-arch later is a one-line change in the
+      # build step's `platforms:` field — no other workflow surgery needed.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: steps.ctx.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        if: steps.ctx.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
+          # Pin :v1.2.3 always; only re-tag :latest on real tag pushes (not manual runs).
+          tags: |
+            type=raw,value=${{ steps.ctx.outputs.version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.ctx.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          # When push=true, image goes to the registries. When false, image is loaded
+          # locally for the Trivy scan step (build-and-scan dry-run).
+          push: ${{ steps.ctx.outputs.push == 'true' }}
+          load: ${{ steps.ctx.outputs.push == 'false' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Buildx-native supply-chain attestations attached to the image manifest.
+          provenance: true
+          sbom: true
+
+      # Block releases when CRITICAL/HIGH CVEs with available fixes are present.
+      # ignore-unfixed: don't fail on CVEs upstream hasn't shipped fixes for yet.
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.DOCKERHUB_IMAGE }}:${{ steps.ctx.outputs.version }}
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+
+      - name: Install cosign
+        if: steps.ctx.outputs.push == 'true'
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless signing via GitHub OIDC — no key management required.
+      # Consumers verify with:
+      #   cosign verify mattermost/mattermost-load-test-ng:vX.Y.Z \
+      #     --certificate-identity-regexp 'https://github.com/mattermost/mattermost-load-test-ng/.*' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      - name: Sign images
+        if: steps.ctx.outputs.push == 'true'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS:   ${{ steps.meta.outputs.tags }}
+        run: |
+          for tag in $TAGS; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+
+      - name: Write job summary
+        if: steps.ctx.outputs.push == 'true'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Published images
+
+          \`\`\`
+          docker pull ${{ env.DOCKERHUB_IMAGE }}:${{ steps.ctx.outputs.version }}
+          docker pull ${{ env.GHCR_IMAGE }}:${{ steps.ctx.outputs.version }}
+          \`\`\`
+          EOF

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,18 @@ builds:
       - -trimpath
     env:
       - CGO_ENABLED=0
+  - main: ./cmd/ltctl
+    id: "ltctl"
+    binary: bin/ltctl
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
 archives:
   -
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,103 @@
-FROM golang:latest
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage build for mattermost-load-test-ng.
+# Produces a single image containing ltagent, ltapi, ltcoordinator, and ltctl.
+# The desired binary is selected per container via the command (e.g. `docker run ... ltapi`).
+#
+# Build (single arch, amd64):
+#   docker build -t mattermost/mattermost-load-test-ng:vX.Y.Z .
+#
+# Build (multi-arch via buildx):
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     -t mattermost/mattermost-load-test-ng:vX.Y.Z --push .
+#
+# Run a manual load test (most common usage):
+#   docker run --rm \
+#     -v $(pwd)/config.json:/mattermost-load-test/config/config.json:ro \
+#     mattermost/mattermost-load-test-ng:vX.Y.Z ltagent -n 100 -d 600
 
-ENV PATH="/mattermost-load-test/bin:${PATH}"
-ENV PATH="/mattermost/bin:${PATH}"
-ARG LOADTEST_BINARY
-ARG MM_BINARY
+# ---------- Stage 1: build ----------
+# BUILDPLATFORM runs the toolchain natively on the build host while cross-compiling
+# to TARGETOS/TARGETARCH. Single-arch builds work too — TARGETOS/TARGETARCH default
+# to the build host's values when --platform isn't supplied.
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS build
+# Verify latest 1.23.x patch before each release:
+#   curl -s 'https://go.dev/dl/?mode=json' | jq -r '.[0].version'
 
-WORKDIR /
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN apt-get update \
-    && apt-get -y install \
+WORKDIR /src
+
+# Module download as a cacheable layer so source changes don't re-download dependencies.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+ENV CGO_ENABLED=0
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -mod=readonly -trimpath -ldflags="-s -w" -o /out/ltagent       ./cmd/ltagent && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -mod=readonly -trimpath -ldflags="-s -w" -o /out/ltapi         ./cmd/ltapi && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -mod=readonly -trimpath -ldflags="-s -w" -o /out/ltcoordinator ./cmd/ltcoordinator && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -mod=readonly -trimpath -ldflags="-s -w" -o /out/ltctl         ./cmd/ltctl
+
+# ---------- Stage 2: runtime ----------
+FROM debian:12-slim
+# Verify latest patch tag before each release: docker pull debian:12-slim
+# CVE scan: trivy image debian:12-slim
+
+# Debug tooling expected when operators shell into a running container to investigate.
+# For a hardened minimal image, swap base to gcr.io/distroless/static-debian12:nonroot
+# and drop this apt-get block — at the cost of losing curl/jq/dig for troubleshooting.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
       curl \
       jq \
-      netcat \
+      netcat-openbsd \
       net-tools \
       iproute2 \
       dnsutils \
-      graphviz
+      tini \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /mattermost/data \
-    && curl $MM_BINARY | tar -xvz \
-    && rm -rf /mattermost/config/config.json
+# Non-root user so the image satisfies common admission policies out of the box.
+RUN groupadd --system --gid 65532 mmlt \
+    && useradd --system --uid 65532 --gid mmlt --home-dir /mattermost-load-test --shell /sbin/nologin mmlt
 
-RUN mkdir -p /mattermost-load-test \
-	&& curl $LOADTEST_BINARY | tar -xvz \
-	&& rm -f /mattermost-load-test/loadtestconfig.json
+# Copy all four binaries into PATH.
+COPY --from=build /out/ltagent /out/ltapi /out/ltcoordinator /out/ltctl /usr/local/bin/
 
+# Sample configs baked as a fallback baseline. Real configs come from a runtime mount:
+#   -v /path/to/config.json:/mattermost-load-test/config/config.json:ro
+RUN mkdir -p /mattermost-load-test/config /mattermost-load-test/logs
+COPY config/config.sample.json           /mattermost-load-test/config/config.json
+COPY config/coordinator.sample.json      /mattermost-load-test/config/coordinator.json
+COPY config/simulcontroller.sample.json  /mattermost-load-test/config/simulcontroller.json
+COPY config/simplecontroller.sample.json /mattermost-load-test/config/simplecontroller.json
+RUN chown -R mmlt:mmlt /mattermost-load-test
+
+USER mmlt
 WORKDIR /mattermost-load-test
-CMD ["tail", "-f", "/dev/null"]
+
+# ltapi listens here when used as the entrypoint. Override per role via the CMD arg.
+EXPOSE 4000
+
+# tini reaps zombies and forwards SIGTERM/SIGINT so `docker stop` exits cleanly for
+# whichever binary is chosen at runtime.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+# Default to ltapi; operators override per role: `docker run ... <image> ltagent ...`
+CMD ["ltapi", "--port=4000"]
+
+# OCI labels — version/revision filled in by the release workflow via build args.
+LABEL org.opencontainers.image.title="mattermost-load-test-ng"
+LABEL org.opencontainers.image.description="Load testing toolkit for Mattermost"
+LABEL org.opencontainers.image.source="https://github.com/mattermost/mattermost-load-test-ng"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="Mattermost, Inc."

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ AGENT=$(GOBIN)/ltagent
 AGENT_ARGS=-mod=readonly -trimpath ./cmd/ltagent
 API_SERVER=$(GOBIN)/ltapi
 API_SERVER_ARGS=-mod=readonly -trimpath ./cmd/ltapi
+LTCTL=$(GOBIN)/ltctl
+LTCTL_ARGS=-mod=readonly -trimpath ./cmd/ltctl
 
 # GOOS/GOARCH of the build host, used to determine whether we're cross-compiling or not
 BUILDER_GOOS_GOARCH="$(shell $(GO) env GOOS)_$(shell $(GO) env GOARCH)"
@@ -33,19 +35,23 @@ build-linux: ## Build the binary (only for Linux on AMD64).
 	@echo Build Linux amd64
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(AGENT) $(AGENT_ARGS)
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
+	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -o $(LTCTL) $(LTCTL_ARGS)
 
 build-osx: ## Build the binary (only for OSX on AMD64).
 	@echo Build OSX amd64
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(AGENT) $(AGENT_ARGS)
 	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(API_SERVER) $(API_SERVER_ARGS)
+	env GOOS=darwin GOARCH=amd64 $(GO) build -o $(LTCTL) $(LTCTL_ARGS)
 
 build-browser-api: ## Build the browser testing HTTP server.
 	cd browser && $(MAKE) build
 
 build: build-linux build-osx build-browser-api ## Build the binary for all platforms and browser API server.
 
-install: ## Build and install for the current platform.
+install: ## Build and install ltagent, ltapi, and ltctl for the current platform.
+	$(GO) install $(AGENT_ARGS)
 	$(GO) install $(API_SERVER_ARGS)
+	$(GO) install $(LTCTL_ARGS)
 
 package: ## Build and package (only available for Linux on AMD64).
 ifneq ($(STATUS), 0)
@@ -71,6 +77,7 @@ endif
 
 	mv $(AGENT) $(PLATFORM_DIST_PATH)/bin
 	mv $(API_SERVER) $(PLATFORM_DIST_PATH)/bin
+	mv $(LTCTL) $(PLATFORM_DIST_PATH)/bin
 
 	# Copy LTBrowser build directory if it exists
 	if [ -d "browser/dist" ]; then \

--- a/README.md
+++ b/README.md
@@ -1,20 +1,181 @@
 # Mattermost load-test-ng
 
-Mattermost load-test-ng provides a set of tools written in [Go](https://golang.org/) to help profiling [Mattermost](https://github.com/mattermost/mattermost) under heavy load, simulating real-world usage of a server installation at scale.
+A load-testing toolkit for [Mattermost](https://github.com/mattermost/mattermost),
+written in [Go](https://golang.org/). It simulates large numbers of concurrent
+users performing realistic actions against a target Mattermost server so you
+can answer questions like "will this deployment handle 2,000 users?" or
+"did our last release regress performance?"
 
-It's a complete rewrite of the [previous](https://github.com/mattermost/mattermost-load-test) load-test tool which served as inspiration.
+It's a rewrite of the original
+[mattermost-load-test](https://github.com/mattermost/mattermost-load-test) tool
+and is the supported way to load-test Mattermost going forward.
 
-## Goals
+> Join the [Developers: Performance](https://community.mattermost.com/core/channels/developers-performance) for questions, feedback, and ideas.
 
-- Give an estimate on the maximum number of concurrently active users the target system supports.
-- Enable more control over the load to generate through the use of [Controllers](docs/controllers.md).
-- Provide extensive documentation from lower level code details to higher level guides and walk-throughs.
+## What's in the box
 
-## Documentation
+Four binaries, all built from this repo:
 
-Documentation and implementation details can be found in the [docs](docs/) folder.
-Code specific documentation can be found on [GoDoc](https://godoc.org/github.com/mattermost/mattermost-load-test-ng).
+| Binary | Role |
+| --- | --- |
+| `ltagent` | Generates load. Simulates one or more users running actions against a Mattermost server. |
+| `ltapi` | HTTP API server wrapping the agent. Lets you create, start, scale, and stop load-test agents over the network. |
+| `ltcoordinator` | Orchestrates a cluster of agents to find the maximum number of concurrent users a Mattermost deployment supports. Drives the feedback loop using Prometheus metrics. |
+| `ltctl` | CLI for managing AWS-based load-test deployments (provision via Terraform, drive tests, collect reports). |
+
+You can use these individually or together depending on how big a test you
+need to run.
+
+## How the pieces fit together
+
+For a full coordinator-driven test, the architecture looks like:
+
+```
+                        +--------------------------------+
+                        |                                |
+                        |                                |
+              +---------v---------+                      |
+              |                   |                      |
+       +------|    coordinator    |------+               |
+       |      |                   |      |               |
+       |      +-------------------+      |               |
+       |                |                |               |
+       |                |                |               |
++------v------+  +------v------+  +------v------+        |
+|  load-test  |  |  load-test  |  |  load-test  |        |
+|    agent    |  |    agent    |  |    agent    |        |
++-------------+  +-------------+  +-------------+        |
+       |                |                |               |
+       |                |                |               |
+       |         +------v------+         |               |
+       |         |  mattermost |         |               |
+       +--------->   instance  <---------+               |
+                 +-------------+                         |
+                        |                                |
+                        |                                |
+                 +------v-------+                        |
+                 |              |                        |
+                 |  prometheus  |------------------------+
+                 |              |
+                 +--------------+
+```
+
+Agents drive load against Mattermost. Prometheus scrapes both Mattermost and
+the agents. The coordinator queries Prometheus to decide when to add or
+remove users from the test, eventually converging on the maximum number the
+target can sustain. Simpler setups skip the coordinator and Prometheus — see
+the "What do you want to do?" section below.
+
+## What do you want to do?
+
+### Try a load test against an existing Mattermost
+
+Fastest path. One container, point it at your Mattermost, watch your existing
+Grafana while you ramp up.
+
+```bash
+docker run --rm \
+  -v "$(pwd)/config.json:/mattermost-load-test/config/config.json:ro" \
+  mattermost/mattermost-load-test-ng:vX.Y.Z \
+  ltagent -n 100 -d 600
+```
+
+→ Full guide: [docs/docker_loadtest.md](docs/docker_loadtest.md)
+
+### Find the maximum supported users automatically
+
+Run the [coordinator](docs/coordinator.md) against a Prometheus that's
+scraping your target. The coordinator gradually increases active users until
+performance metrics indicate degradation, then converges on the supported
+maximum.
+
+→ Coordinator guide: [docs/coordinator.md](docs/coordinator.md)
+→ Full local walk-through: [docs/local_loadtest.md](docs/local_loadtest.md)
+
+### Stand up a full benchmarking environment on AWS
+
+Multi-VM Terraform deployment that provisions agents, a coordinator,
+Mattermost, Postgres, Prometheus, and Grafana. Driven by `ltctl`.
+
+```bash
+cp config/deployer.sample.json config/deployer.json
+$EDITOR config/deployer.json
+ltctl deployment create
+ltctl loadtest start
+```
+
+→ Full guide: [docs/terraform_loadtest.md](docs/terraform_loadtest.md)
+
+### Compare performance across two Mattermost versions
+
+Drive identical load against two builds and produce a side-by-side report.
+
+→ Full guide: [docs/comparison.md](docs/comparison.md) and [docs/compare.md](docs/compare.md)
+
+### Develop the tool itself
+
+Clone, build with the Makefile, run tests, contribute.
+
+```bash
+git clone https://github.com/mattermost/mattermost-load-test-ng
+cd mattermost-load-test-ng
+make install        # builds ltagent, ltapi, ltctl into ./bin
+make test           # runs the test suite
+make check-style    # lints + validates the sample config files
+```
+
+→ Developer notes: [docs/developing.md](docs/developing.md)
+
+## Contributing
+
+Issues and pull requests welcome. Before opening a PR:
+
+- Read [docs/developing.md](docs/developing.md) for repo conventions and how
+  to add new load-testing actions.
+- Run `make check-style` and `make test` locally.
+- For load-testing coverage of a new Mattermost feature, see
+  [docs/coverage.md](docs/coverage.md).
 
 ## Help
 
 If you need any help you can join the [Developers: Performance](https://community.mattermost.com/core/channels/developers-performance) channel and ask developers any question related to this project.
+
+Code-level documentation is also available on [GoDoc](https://godoc.org/github.com/mattermost/mattermost-load-test-ng).
+
+## Additional information
+
+More documentation on individual components and workflows can be found in
+the `docs/` directory:
+
+**Getting started**
+- [docs/docker_loadtest.md](docs/docker_loadtest.md) — Single-container load test via Docker
+- [docs/local_loadtest.md](docs/local_loadtest.md) — Running load tests locally from source
+- [docs/terraform_loadtest.md](docs/terraform_loadtest.md) — Multi-VM AWS deployment
+- [docs/load-test-how-to-use.md](docs/load-test-how-to-use.md) — End-to-end walkthrough for testing a new feature
+
+**Architecture & internals**
+- [docs/coordinator.md](docs/coordinator.md) — How the coordinator finds max supported users
+- [docs/controllers.md](docs/controllers.md) — User controllers (simple, simulative, browser)
+- [docs/loadtest_system.md](docs/loadtest_system.md) — Overall system design
+- [docs/implementation.md](docs/implementation.md) — Implementation notes
+
+**Configuration**
+- [docs/config/](docs/config/) — Reference docs for each config file (`config.json`, `coordinator.json`, `deployer.json`, etc.)
+
+**Workflows**
+- [docs/comparison.md](docs/comparison.md) — Comparing performance across Mattermost versions
+- [docs/compare.md](docs/compare.md) — Generating and reading comparison reports
+- [docs/generating_data.md](docs/generating_data.md) — Pre-populating Mattermost with test data
+- [docs/coverage.md](docs/coverage.md) and [docs/coverage-frequency.md](docs/coverage-frequency.md) — Action coverage and frequency tuning
+- [docs/plugin_browser_loadtest.md](docs/plugin_browser_loadtest.md) — Browser-based load with the LTBrowser sidecar
+- [docs/browser_simulations_registry.md](docs/browser_simulations_registry.md) — Registry of available browser simulations
+- [docs/external_auth_providers.md](docs/external_auth_providers.md) — Load-testing with SAML / OpenID Connect
+
+**Reference**
+- [docs/faq.md](docs/faq.md) — Frequently asked questions and troubleshooting
+- [docs/developing.md](docs/developing.md) — Developer setup and conventions
+- [docs/release.md](docs/release.md) — Release process
+
+## License
+
+Apache License 2.0 — see [LICENSE.txt](LICENSE.txt).

--- a/docs/docker_loadtest.md
+++ b/docs/docker_loadtest.md
@@ -1,0 +1,226 @@
+# Running a load test via the Docker container
+
+This guide covers the simplest production-style workflow: pull the published
+image to any host with Docker, point it at a Mattermost instance, and watch
+your existing Grafana while a manual load ramp finds the cliff.
+
+No coordinator, no extra Prometheus, no compose stack. Just one container and
+your eyes on a dashboard.
+
+## When to use this guide
+
+Use this when:
+
+- You want to find when a specific Mattermost instance starts to fall over.
+- Mattermost is already running and its `/metrics` endpoint is scraped by
+  some Prometheus, with Grafana on top.
+- You can run Docker on a host that has network reachability to Mattermost.
+
+If you instead want unattended, automated "find max users" runs that converge
+on a single number, you want the coordinator + Prometheus setup — see
+[`local_loadtest.md`](./local_loadtest.md) and [`coordinator.md`](./coordinator.md).
+
+## Prerequisites
+
+Verify each before starting:
+
+1. **Docker** is installed on the host. Test: `docker version`.
+2. **The image** is available to the host. Options:
+   - Pull from Docker Hub (open networks): `docker pull mattermost/mattermost-load-test-ng:vX.Y.Z`
+   - Side-load (closed networks): `docker load -i mattermost-load-test-ng.tar`
+     where the tar file came from `docker save` on a connected build machine.
+3. **Mattermost is reachable** from the host. Test:
+   `curl -v https://mattermost.example.com/api/v4/system/ping`. Expect HTTP 200.
+4. **Mattermost system admin credentials** (email + password).
+5. **A Grafana that's already viewing Mattermost metrics.** Cluster Grafana,
+   the team's existing one, anything that has at least a panel for
+   `mattermost_api_time_*` and request rate / error rate / latency.
+6. **For Enterprise:** a valid license already applied to Mattermost.
+
+## Step 1: Write a config file
+
+On the load-test host, create `config.json`. Adjust `ServerURL`,
+`WebSocketURL`, `AdminEmail`, `AdminPassword`, and `MaxActiveUsers` for your
+environment. The other defaults are a reasonable simulative-user profile.
+
+```json
+{
+  "ConnectionConfiguration": {
+    "ServerURL": "https://mattermost.example.com",
+    "WebSocketURL": "wss://mattermost.example.com",
+    "AdminEmail": "sysadmin@example.com",
+    "AdminPassword": "REPLACE-ME"
+  },
+  "UserControllerConfiguration": {
+    "Type": "simulative",
+    "RatesDistribution": [
+      { "Rate": 1.0,  "Percentage": 0.05 },
+      { "Rate": 2.0,  "Percentage": 0.10 },
+      { "Rate": 3.0,  "Percentage": 0.15 },
+      { "Rate": 6.0,  "Percentage": 0.40 },
+      { "Rate": 30.0, "Percentage": 0.30 }
+    ],
+    "ServerVersion": ""
+  },
+  "InstanceConfiguration": {
+    "NumTeams": 2,
+    "NumChannels": 10,
+    "NumPosts": 0,
+    "NumReactions": 0,
+    "NumAdmins": 0,
+    "PercentReplies": 0.5,
+    "PercentRepliesInLongThreads": 0.05,
+    "PercentUrgentPosts": 0.001,
+    "PercentPublicChannels": 0.2,
+    "PercentPrivateChannels": 0.1,
+    "PercentDirectChannels": 0.6,
+    "PercentGroupChannels": 0.1
+  },
+  "UsersConfiguration": {
+    "InitialActiveUsers": 0,
+    "UsersFilePath": "",
+    "MaxActiveUsers": 2000,
+    "MaxActiveBrowserUsers": 0,
+    "AvgSessionsPerUser": 1,
+    "PercentOfUsersAreAdmin": 0.0005
+  },
+  "LogSettings": {
+    "EnableConsole": true,
+    "ConsoleLevel": "ERROR",
+    "ConsoleJson": false,
+    "EnableFile": true,
+    "FileLevel": "INFO",
+    "FileJson": true,
+    "FileLocation": "/mattermost-load-test/logs/ltagent.log",
+    "EnableColor": false
+  }
+}
+```
+
+Note: `AdminPassword` sits in this file as plaintext. For test/dev island
+use this is fine. For production-similar runs, the operator should put the
+password in a Docker secret or an env file with restricted file permissions
+on the host, not check it into version control.
+
+## Step 2: Seed Mattermost with test data (one-time)
+
+Run `ltagent init` to create the initial teams and channels that simulated
+users will join.
+
+```bash
+mkdir -p ./logs
+docker run --rm \
+  -v "$(pwd)/config.json:/mattermost-load-test/config/config.json:ro" \
+  -v "$(pwd)/logs:/mattermost-load-test/logs" \
+  mattermost/mattermost-load-test-ng:vX.Y.Z \
+  ltagent init
+```
+
+This is safe to skip if you've already seeded the target with previous runs.
+
+## Step 3: Run the load test — manual ramp
+
+The pattern: start small, watch Grafana, double or step up until you see
+degradation.
+
+```bash
+# 100 users for 10 minutes
+docker run --rm \
+  -v "$(pwd)/config.json:/mattermost-load-test/config/config.json:ro" \
+  -v "$(pwd)/logs:/mattermost-load-test/logs" \
+  mattermost/mattermost-load-test-ng:vX.Y.Z \
+  ltagent -n 100 -d 600
+```
+
+Re-run with larger `-n` until your Grafana dashboard shows the system under
+stress:
+
+```bash
+docker run --rm ... ltagent -n 250  -d 600
+docker run --rm ... ltagent -n 500  -d 600
+docker run --rm ... ltagent -n 1000 -d 600
+```
+
+## Step 4: What to watch on Grafana
+
+The metrics that matter, in roughly the order they degrade:
+
+| Signal                                  | What "starting to crack" looks like                  |
+| --------------------------------------- | ---------------------------------------------------- |
+| Average / P99 API response time         | Climbing past your team's SLO (often P99 > 2s)       |
+| HTTP error rate (4xx and 5xx)           | Sustained > ~0.5%                                    |
+| Mattermost pod CPU                      | Sustained > 85%                                      |
+| Mattermost pod memory                   | Climbing without leveling off                        |
+| Database connection pool utilization    | Saturated; new connections waiting                   |
+| WebSocket connections established       | Diverging from active-user count                     |
+| Goroutine count (`go_goroutines`)       | Climbing linearly with no plateau — signals leak     |
+
+**Define "the cliff" up front so the number you report survives review.**
+A useful default: "P99 API response time exceeds 2 seconds for three
+consecutive minutes, OR 5xx error rate exceeds 0.5% for one minute." Whatever
+you pick, write it down with the test result.
+
+## Step 5: Stop and clean up
+
+`ltagent -d 600` exits on its own after the configured duration. To stop
+early, `Ctrl-C` the docker run or:
+
+```bash
+docker ps        # find the container ID
+docker stop <id>
+```
+
+Logs are in `./logs/ltagent.log` on the host.
+
+## Common configurations and troubleshooting
+
+### "Connection refused" or DNS failures
+The container can't reach Mattermost. From the host: `curl -v <ServerURL>/api/v4/system/ping`.
+If that fails, the issue is host-level connectivity (firewall, DNS, VPN),
+not the container.
+
+### "401 Unauthorized" during init
+`AdminEmail` / `AdminPassword` in config.json don't match a system admin
+account in Mattermost. Verify by logging into Mattermost manually with the
+same credentials.
+
+### Test starts but no users actually log in
+Check `./logs/ltagent.log`. Common cause: Mattermost rate-limiting at the
+ingress (nginx-ingress default is 5 req/s per IP). Either raise the limit
+in Mattermost's ingress config for the test window, or add the load-test
+host to a rate-limit-exempt allowlist.
+
+### "Too many open files"
+The kernel ulimit on the host is too low for the user count. On the host:
+```bash
+ulimit -n              # check current
+sudo sysctl -w fs.file-max=1000000
+ulimit -n 65536
+```
+Then re-run the container.
+
+### Closed-network registry handling
+If your host can't reach docker.io, build on a connected machine and ship
+the tarball:
+```bash
+# On the connected machine:
+docker pull mattermost/mattermost-load-test-ng:vX.Y.Z
+docker save mattermost/mattermost-load-test-ng:vX.Y.Z -o lt.tar
+scp lt.tar user@host:/tmp/
+# On the closed host:
+docker load -i /tmp/lt.tar
+```
+
+## What this guide deliberately does not cover
+
+- **Multi-agent / distributed load.** Single container generates ~500–2000
+  users worth of load depending on host VM size. For higher loads, see the
+  multi-agent terraform deployment in `terraform_loadtest.md`.
+- **Automated "find max users" runs.** That requires the coordinator and a
+  Prometheus the coordinator can query. See `coordinator.md`.
+- **Browser-based simulation.** Requires the LTBrowser sidecar. See
+  `plugin_browser_loadtest.md`.
+- **Comparing two Mattermost versions head-to-head.** See `compare.md`.
+
+The container shipped here can do all of those — this guide just covers the
+simplest single-agent manual-ramp use case.


### PR DESCRIPTION
## Summary

  - Add a multi-stage `Dockerfile` that produces a runnable container image with `ltagent`, `ltapi`, `ltcoordinator`, and `ltctl` baked in.
  - Add a tag-triggered GitHub Actions workflow that builds and publishes the image to `docker.io/mattermost` and `ghcr.io`, with Trivy scanning and cosign keyless signing.
  - Add `docs/docker_loadtest.md` — an operator guide for single-container load tests against an existing Mattermost.
  - Fix a long-standing gap: `ltctl` was not built by `make build-linux`/`build-osx`/`install` or shipped by `goreleaser`. It is now.
  - Rewrite `README.md` with a "what do you want to do?" structure, a components table, the coordinator architecture diagram, and a documentation index.

  ## What changed

  **New files**
  - `.github/workflows/release-docker.yml` — Tag-triggered (`v*`) image build. `linux/amd64` only for now (multi-arch is a one-line `platforms:` change). Pushes to Docker Hub and GHCR. Trivy gate on
  `CRITICAL,HIGH` with `ignore-unfixed: true`. Cosign keyless signing via GitHub OIDC. Buildx-native SBOM + provenance attestations. Supports `workflow_dispatch` with `push=false` for dry-run validation.
  - `docs/docker_loadtest.md` — Prerequisites, config file template, `ltagent init`, manual ramp (`-n` / `-d`), what to watch on Grafana, common troubleshooting, closed-network side-load instructions.

  **Replaced**
  - `Dockerfile` — Multi-stage build. Stage 1 cross-compiles static Go binaries (`CGO_ENABLED=0`) with module cache mounts. Stage 2 is `debian:12-slim` with debug tooling (`curl`, `jq`, `netcat`, `dnsutils`,
  `iproute2`), runs as non-root uid 65532, uses tini for signal handling. All four binaries land in `/usr/local/bin/`. Sample configs are baked as a fallback baseline; real configs come from a runtime volume
  mount. OCI labels populated by the workflow at build time.
  - `README.md` — New structure: intro paragraph + Help blockquote callout near the top, components table, architecture diagram (reused from `docs/coordinator.md`), `What do you want to do?` user-intent
  sections (Docker / coordinator / AWS terraform / comparison / develop), Contributing, Help (full section), and a categorized documentation index under "Additional information".

  **Modified**
  - `Makefile` — New `LTCTL` / `LTCTL_ARGS` variables. `ltctl` added to `build-linux`, `build-osx`, `install`, and the `package` target so it appears in `bin/` and in distribution tarballs.
  - `.goreleaser.yml` — `ltctl` added as a third build alongside `ltagent` and `ltapi`. Release tarballs now include the ltctl binary.

  ## Why

  1. **Make the load-test tool consumable as a Docker image.** The old `Dockerfile` was a "Mattermost server + load-test tool in one container for local laptop hacking" pattern — broke for air-gap (`curl` at
  build), not consumable as a release artifact, ran as root, ended in `tail -f /dev/null`. The new image is a proper multi-binary load-test container that drops onto any host with Docker and runs against a
  reachable Mattermost.
  2. **Close the ltctl build gap.** `ltctl` is the user-facing CLI for AWS deployments but was never built by `make` or shipped in `goreleaser` tarballs. Users had to run `go install ./cmd/ltctl` separately to
   get it. Now it builds, installs, and ships alongside the other binaries.
  3. **Make the README useful as a landing page.** The previous README was a 21-line stub. The new one orients a visitor by what they're trying to do, points at the right doc, and indexes the rest.

  ## Test plan

  - [ ] Configure repo secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (PAT scoped to `mattermost-load-test-ng` only).
  - [ ] Confirm `ghcr.io/mattermost/mattermost-load-test-ng` package path is permitted by the org settings.
  - [ ] Local smoke build:
    ```
    docker build -t mattermost-load-test-ng:local .
    docker run --rm mattermost-load-test-ng:local ltapi --help
    docker run --rm mattermost-load-test-ng:local ltctl --help
    docker run --rm mattermost-load-test-ng:local ltagent --help
    docker run --rm mattermost-load-test-ng:local ltcoordinator --help
    ```
  - [ ] Dry-run the workflow: `Actions → release-docker → Run workflow`, `tag=v0.0.0-test`, `push=false`. Validates the build + Trivy scan path without publishing.
  - [ ] After dry-run is green, cut a real `v0.0.1` (or similar) to exercise the publish + cosign path end-to-end.
  - [ ] Verify `make install` produces `bin/ltctl`.
  - [ ] Verify `make build-linux` produces all four binaries in `bin/`.
  - [ ] Verify `make package` includes `ltctl` in the tarball.

  ## Out of scope (deliberately)

  - Multi-arch image builds — restricted to `linux/amd64` for now. `linux/arm64` is a one-line addition to `platforms:` when needed.
  - A `docker compose` bundle including Prometheus / Grafana for closed-environment max-finding runs.
  - Kubernetes manifests / Helm chart.
  - Azure-specific Terraform.
  - Image signing with a managed key. Keyless OIDC signing is enabled; managed-key is a future hardening step.

  ## Follow-up

  - Pinned versions to verify before each release: `golang:1.23-bookworm`, `debian:12-slim`, `aquasecurity/trivy-action@0.28.0`. Lookup commands are in `Dockerfile` and workflow comments.
  - `ignore-unfixed: true` on the Trivy step avoids blocking releases on un-fixable upstream CVEs. Worth a periodic review of what's accumulating in that bucket.
  - Once images are publishing, add a one-liner to `docs/terraform_loadtest.md` and `docs/local_loadtest.md` noting that pre-built images are now available as an alternative.